### PR TITLE
Issue 26

### DIFF
--- a/_includes/dev-docs/build-from-source-warning.md
+++ b/_includes/dev-docs/build-from-source-warning.md
@@ -1,0 +1,2 @@
+{: .bg-warning :}
+This example uses a test version of Prebid.js hosted on our CDN that is not recommended for production use.  It includes all available adaptors.  Production implementations should build from source or customize the build using he [Download](http://prebid.org/download.html) page to make sure only the necessary bidder adaptors are included.  

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -291,6 +291,10 @@ img {
   border-radius: 5px;
 }
 
+.bg-warning {
+  padding: 10px;
+  border-radius: 5px;
+}
 
 table.jsfiddle-line-number {
     width: 100%;

--- a/dev-docs/examples/adjust-price.md
+++ b/dev-docs/examples/adjust-price.md
@@ -16,7 +16,7 @@ about:
 - Standard price granularity (pbMg see <a href="/dev-docs/publisher-api-reference.html#bidResponse">reference here</a>).
 
 
-jsfiddle_link: jsfiddle.net/prebid/hn06j4f4/2/embedded/html,result
+jsfiddle_link: jsfiddle.net/prebid/hn06j4f4/3/embedded/html,result
 
 code_height: 2536
 code_lines: 116
@@ -24,7 +24,7 @@ code_lines: 116
 pid: 80
 ---
 
-<!-- jsfiddle.net/prebid/hn06j4f4/embedded/html,result -->
+{% include dev-docs/build-from-source-warning.md %}
 
 <br>
 <br>
@@ -48,7 +48,6 @@ Same setup as in [Basic Example](/dev-docs/examples/basic-example.html). Check t
 <br><br><br><br><br><br>
 <br><br><br><br><br><br>
 <br><br><br><br><br><br>
-<br><br><br>
 
 <div markdown="1">
 #### Line 62 to 64: Adjust Bid Price

--- a/dev-docs/examples/adunit-refresh.md
+++ b/dev-docs/examples/adunit-refresh.md
@@ -15,13 +15,13 @@ about:
 - Standard keyword targeting setup (<a href="/dev-docs/publisher-api-reference.html#bidderSettingsDefault">reference</a>).
 - Standard price granularity (pbMg see <a href="/dev-docs/publisher-api-reference.html#bidResponse">reference here</a>).
 
-jsfiddle_link: jsfiddle.net/prebid/dzrs3gfL/1/embedded/html,result
+jsfiddle_link: jsfiddle.net/prebid/dzrs3gfL/5/embedded/html,result
 code_height: 2893
 code_lines: 133
 
 pid: 10
 ---
-
+{% include dev-docs/build-from-source-warning.md %}
 
 <br>
 <br>

--- a/dev-docs/examples/basic-example.md
+++ b/dev-docs/examples/basic-example.md
@@ -12,7 +12,7 @@ about:
 - Standard keyword targeting setup (<a href="/dev-docs/publisher-api-reference.html#bidderSettingsDefault">reference</a>).
 - Standard price granularity (pbMg see <a href="/dev-docs/publisher-api-reference.html#bidResponse">reference here</a>).
 
-jsfiddle_link: jsfiddle.net/prebid/9ow4k8j6/30/embedded/html,result
+jsfiddle_link: jsfiddle.net/prebid/9ow4k8j6/59/embedded/html,result
 
 code_lines: 101
 code_height: 2221
@@ -20,6 +20,7 @@ code_height: 2221
 pid: 10
 ---
 
+{% include dev-docs/build-from-source-warning.md %}
 
 <br>
 <br>

--- a/dev-docs/examples/custom-price-bucket.md
+++ b/dev-docs/examples/custom-price-bucket.md
@@ -14,13 +14,14 @@ about:
 - Integration with DFP's GPT single request asynchronous mode.
 - One set of line items for all bidders
 
-jsfiddle_link: jsfiddle.net/prebid/bp9magow/7/embedded/html,result
+jsfiddle_link: jsfiddle.net/prebid/bp9magow/11/embedded/html,result
 code_height: 2977
 code_lines: 137
 
 pid: 10
 ---
 
+{% include dev-docs/build-from-source-warning.md %}
 
 <br>
 <br>
@@ -33,7 +34,6 @@ Same setup as in [Basic Example](/dev-docs/examples/basic-example.html). Check t
 
 </div>
 
-<br><br><br><br><br><br>
 <br><br><br><br><br><br>
 <br><br><br><br><br><br>
 <br><br><br><br><br><br>

--- a/dev-docs/examples/full-page-refresh.md
+++ b/dev-docs/examples/full-page-refresh.md
@@ -15,13 +15,14 @@ about:
 - Standard keyword targeting setup (<a href="/dev-docs/publisher-api-reference.html#bidderSettingsDefault">reference</a>).
 - Standard price granularity (pbMg see <a href="/dev-docs/publisher-api-reference.html#bidResponse">reference here</a>).
 
-jsfiddle_link: jsfiddle.net/prebid/amg49spy/9/embedded/html,result
+jsfiddle_link: jsfiddle.net/prebid/amg49spy/10/embedded/html,result
 code_height: 2536
 code_lines: 116
 
 pid: 10
 ---
 
+{% include dev-docs/build-from-source-warning.md %}
 
 <br>
 <br>

--- a/dev-docs/examples/postbid.md
+++ b/dev-docs/examples/postbid.md
@@ -14,13 +14,14 @@ about:
 - There is no need for per-price-bucket-per-line-item setup, because the post-bid creative is chosen after the ad server has chosen the line item. 
 - This post-bid creative <strong>supports passback</strong>. See more info on passbacks in the below line-by-line explanation.
 
-jsfiddle_link: jsfiddle.net/prebid/akLqdj3d/5/embedded/html,result
+jsfiddle_link: jsfiddle.net/prebid/akLqdj3d/8/embedded/html,result
 code_height: 1864
 code_lines: 84
 
 pid: 10
 ---
 
+{% include dev-docs/build-from-source-warning.md %}
 
 <br><br>
 <br><br>

--- a/dev-docs/getting-started.md
+++ b/dev-docs/getting-started.md
@@ -19,14 +19,11 @@ nav_section: quick-start
 
 The easiest way to get started with Prebid.js is using the following JSFiddle example. Go to the "Result" tab to see the keyword targeting for this header auction.
 
-* **[Prebid.js JSFiddle](http://jsfiddle.net/hqhbLdxn/1/)**
+{% include dev-docs/build-from-source-warning.md %}
 
-<iframe width="100%" height="680" src="//jsfiddle.net/prebid/hqhbLdxn/8/embedded/html,result" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
+For more information on how to setup your ad server, see the [Ad Ops Guide](/adops.html).
 
-<br>
-
-{: .bg-info :}
-Note that the above JSFiddle code is not integrated with an ad server. To move to the next section, you will **need access to your ad server** for setting up line items. For more information on how to setup your ad server, go to [Adops Guide](/adops.html).
+<iframe width="100%" height="680" src="//jsfiddle.net/prebid/hqhbLdxn/61/embedded/html,result" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
 
 <div class="bs-docs-section" markdown="1">
 


### PR DESCRIPTION
Updates all CDN URLs in JSFiddle examples to use the new (testing-only, not for production use) URL.