### PR TITLE
Updated AOL docs to correct bidFloor parameter capitalization

### DIFF
--- a/dev-docs/bidders.md
+++ b/dev-docs/bidders.md
@@ -82,7 +82,7 @@ These parameters in the bidReponse object are common across all bidders.
 | `alias` | optional | The placement alias from AOL. Must be unique per page. | `"desktop_articlepage_something_box_300_250"` |
 | `server` | optional | The server domain name. Default is adserver.adtechus.com. EU customers must use adserver.adtech.de. | `"adserver.adtech.de"` |
 | `sizeId` | optional | The size ID from AOL. | `"170"` |
-| `bidfloor` | optional | Dynamic bid floor | `0.80` |
+| `bidFloor` | optional | Dynamic bid floor (added in Prebid 0.8.1) | `"0.80"` |
 
 (The first of the `sizes` set in `adUnit` object will also apply to the AOL bid requests.)
 


### PR DESCRIPTION
Also updated example to string to be consistent with Prebid release notes (although bidFloor param can accept both string or decimal), and to acknowledge that it was added in 0.8.1.