### PR TITLE
Add 'Simplified Price Bucket Setup' example

### DIFF
--- a/_layouts/example.html
+++ b/_layouts/example.html
@@ -62,6 +62,7 @@ Click on the JSFiddle "Result" tab to see the result. Or, edit it in JSFiddle.
       <li><a href="/dev-docs/examples/adunit-refresh.html">Individual ad unit refresh</a></li>
       <li><a href="/dev-docs/examples/postbid.html">Post-bid example</a></li>
       <!-- <li><a href="/dev-docs/examples/log-all-bids.html">Log all bids to the ad server</a></li> -->
+	  <li><a href="/dev-docs/examples/simplified-price-bucket-setup.html">Simplified price bucket setup</a></li>
     </ul>
   </div>
 </div>

--- a/dev-docs/examples/simplified-price-bucket-setup.md
+++ b/dev-docs/examples/simplified-price-bucket-setup.md
@@ -1,0 +1,52 @@
+---
+layout: example
+title: Simplified Price Bucket Setup
+description: Simplified Price Bucket Setup with Prebid.js
+
+top_nav_section: dev_docs
+nav_section: quick-start
+
+hide: true
+
+about:
+- Simplified price bucket setup with one function call to <a href="/dev-docs/publisher-api-reference.html#setPriceGranularity"><code>pbjs.setPriceGranularity()</code></a>
+
+jsfiddle_link: jsfiddle.net/prebid/bp9magow/14/embedded/html,result
+code_height: 2436
+code_lines: 112
+
+pid: 0
+---
+
+{% include dev-docs/build-from-source-warning.md %}
+
+<br>
+<br>
+<br>
+
+<div markdown="1">
+#### Line 1 to 59: Set timeout and define ad units
+
+Here we use the same setup as in the [Basic Example](/dev-docs/examples/basic-example.html).
+
+</div>
+
+<br><br><br><br><br><br>
+<br><br><br><br><br><br>
+<br><br><br><br><br><br>
+<br><br><br><br><br><br>
+<br><br><br><br><br><br>
+<br><br><br><br><br><br>
+<br><br><br><br><br><br>
+<br><br><br><br><br><br>
+<br><br><br><br><br><br>
+
+<div markdown="1">
+#### Line 62: Set price granularity
+
+The simplest way to set price granularity is to use the helper method [`pbjs.setPriceGranularity`](/dev-docs/publisher-api-reference.html#module_pbjs.setPriceGranularity).  For more information about this method, see [its documentation](/dev-docs/publisher-api-reference.html#module_pbjs.setPriceGranularity).
+
+You can see the effect of this setting if you click into the **Result** tab of the example.
+
+If you need more control over pricing granularity, see the [Custom price bucket granularity](/dev-docs/examples/custom-price-bucket-granularity.html) example.
+</div>

--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -368,7 +368,9 @@ Accepted values:
 | CPM > $10 and < $20 | 	$0.50 increments             |
 | CPM > $20           | 	Caps the price bucket at $20 |
 
-For more information, see the [`bidResponse`](#bidResponse) documentation below.
+For more information about price buckets, see the [`bidResponse`](#bidResponse) documentation below.
+
+For an example showing how to use this method, see [Simplified price bucket setup](/dev-docs/examples/simplified-price-bucket-setup.html).
 
 <hr class="full-rule">
 


### PR DESCRIPTION
Also:

- Update examples template with a link

- Update API reference so `pbjs.setPriceGranularity()` links to the
  example

Addresses https://github.com/prebid/prebid.github.io/issues/50