### PR TITLE
Add RTK Aardvark bidder information to Prebid Documentation

### DIFF
--- a/dev-docs/bidders/aardvark.md
+++ b/dev-docs/bidders/aardvark.md
@@ -1,0 +1,5 @@
+{: .table .table-bordered .table-striped } 
+| Name | Scope | Description | Example | 
+| :--- | :---- | :---------- | :------ | 
+| ai | required | The rtk auction ID | "XBC1" |
+| sc | required | The rtk shortcode | "AF2g" |

--- a/download.md
+++ b/download.md
@@ -99,6 +99,13 @@ To improve the speed and load time of your site, build Prebid.js for only the he
   <div class="col-md-4">
     <div class="checkbox">
       <label>
+        <input type="checkbox" bidderCode="aardvark" class="bidder-check-box"> Aardvark by RTK
+      </label>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="checkbox">
+      <label>
         <input type="checkbox" bidderCode="aol" class="bidder-check-box"> AOL
       </label>
     </div>

--- a/index.md
+++ b/index.md
@@ -78,6 +78,10 @@ description: A free and open source library for publishers to quickly implement 
     <div class="row bs-docs-featured-sites bidder-logos text-center">
     
       <div class="col-xs-6 col-sm-4">
+        <h3>Aardvark by RTK</h3>
+      </div>
+      
+      <div class="col-xs-6 col-sm-4">
         <h3>AOL</h3>
       </div>
     


### PR DESCRIPTION
Update to:
- Reference to supported adapters on home page
- Reference to Bidder dev documentation 
- Add Aardvark checkbox for HB adapter option in Download section