### PR TITLE
Added Admedia to home and download pages

### DIFF
--- a/download.md
+++ b/download.md
@@ -240,6 +240,14 @@ To improve the speed and load time of your site, build Prebid.js for only the he
     </div>
   </div>
 
+  <div class="col-md-4">
+    <div class="checkbox">
+      <label>
+        <input type="checkbox" bidderCode="admedia" class="bidder-check-box"> AdMedia
+      </label>
+    </div>
+  </div>
+
 </div>
 
 <br>
@@ -319,6 +327,7 @@ package.json:
 "adapters": [
   "adequant",
   "adform",
+  "admedia",
   "aol",
   "appnexus",
   "indexExchange",

--- a/index.md
+++ b/index.md
@@ -140,6 +140,10 @@ description: A free and open source library for publishers to quickly implement 
       <div class="col-xs-6 col-sm-4">
         <h3>NginAd</h3>
       </div>
+
+      <div class="col-xs-6 col-sm-4">
+        <h3>AdMedia</h3>
+      </div>
     
     </div>
 <!-- 


### PR DESCRIPTION
When I tested the download from localhost, I do get the email to download but the JS doesn't contain the bidder code for any of the existing bidders or the new addition for AdMedia. 

Production download works for existing bidders. Not sure if the Parse backend needs to be updated but can you guys test if AdMedia's bidder code gets downloaded and make necessary changes?

Thanks!