### PR TITLE
Set a ratio under 100%

### DIFF
--- a/dev-docs/examples/adjust-price.md
+++ b/dev-docs/examples/adjust-price.md
@@ -16,7 +16,7 @@ about:
 - Standard price granularity (pbMg see <a href="/dev-docs/publisher-api-reference.html#bidResponse">reference here</a>).
 
 
-jsfiddle_link: jsfiddle.net/prebid/hn06j4f4/6/embedded/html,result
+jsfiddle_link: jsfiddle.net/prebid/hn06j4f4/8/embedded/html,result
 
 code_height: 2725
 code_lines: 125


### PR DESCRIPTION
To reflect the text on the side, it should be 0.85 (85% = 100 - 15%) rather than 1.4. I can't think of a ratio over 100% in a real world case.