### PR TITLE
Update 'How to Add a New Bidder' with video info

### DIFF
--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -186,6 +186,5 @@ For usage examples, see [the working adapters in the repo](https://github.com/pr
 ## Further Reading
 
 + [The bidder adapter sources in the repo](https://github.com/prebid/Prebid.js/tree/master/src/adapters)
-+ 
 
 </div>

--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -123,8 +123,11 @@ When the bid response(s) are available, notify Prebid.js immediately, so that yo
 
 To register the bid, call the `bidmanager.addBidResponse(adUnitCode, bidObject)` function. To register multiple bids, call the function multiple times.
 
-* If the bid is valid, use `bidfactory.createBid(1)` to create the `bidObject`
-* If the bid is invalid (no fill or error), use `bidfactory.createBid(2)` to create the `bidObject`
+* If the bid is valid, use `bidfactory.createBid(1)` to create the `bidObject`.  A status of `1` means the bid is valid.  For details about the status codes, see [constants.json](https://github.com/prebid/Prebid.js/blob/master/src/constants.json).
+* If the bid is invalid (no fill or error), use `bidfactory.createBid(2)` to create the `bidObject`.  A status of `2` means "no bid".
+
+{: .alert.alert-info :}
+If your bidder supports serving video ads, it needs to provide a VAST video URL in its response.  On the adapter side, your implementation of `createBid` needs to add the VAST URL to the bid.  For an example implementation, see the implementation in the [AST adapter](https://github.com/prebid/Prebid.js/blob/master/src/adapters/appnexusAst.js).
 
 Example:
 

--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -1,43 +1,43 @@
 ---
 layout: page
-title: New Bidder Adaptor
+title: How to Add a New Bidder Adaptor
 description: Documentation on how to add a new bidder adaptor
 pid: 25
-
 top_nav_section: dev_docs
 nav_section: adaptors
 ---
 
 <div class="bs-docs-section" markdown="1">
 
-# How to add a new bidder adaptor
+# How to Add a New Bidder Adaptor
 {:.no_toc}
 
-A bidder adapter is responsible for:
+At a high level, a bidder adapter is responsible for:
 
-1. Given the list of all ad unit tag IDs, sending out the bid requests in the most efficient way.
-2. Whenever a bid is back, registering the bid with Prebid.js. 
+1. Sending out bid requests to the ad server
+2. Registering the bids that are returned with Prebid.js
+
+This page has instructions for writing your own bidder adapter.  The instructions here try to walk you through some of the code you'll need to write for your adapter.  When in doubt, use [the working adapters in the Github repo](https://github.com/prebid/Prebid.js/tree/master/src/adapters) for reference.
 
 * TOC
 {:toc}
 
 
-### Step 1: Prepare prerequisites for a Github PR
+## Step 1: Prepare prerequisites for a pull request
 
 In your PR to add the new adapter, please provide the following information:
 
 - The contact email of the adapter's maintainer.
-- A test ad unit that will consistently return test creatives. This is to ensure future Prebid.js updates do not break your adapter.
+- A test ad unit that will consistently return test creatives. This helps us to ensure future Prebid.js updates do not break your adapter.
 
 
-### Step 2: Add a new bidder JS file
+## Step 2: Add a new bidder JS file
 
 1. Create a JS file under `src/adapters` with the name of the bidder, e.g., `rubicon.js`
 
 2. Create an adapter factory function with the signature shown below:
 
 {% highlight js %}
-
 var bidfactory = require('../bidfactory.js');
 var bidmanager = require('../bidmanager.js');
 
@@ -45,7 +45,7 @@ var BidderNameAdapter = function BidderNameAdapter() {
 
     function _callBids(params){}
 
-    // Export the callBids function, so that prebid.js can execute
+    // Export the `callBids` function, so that Prebid.js can execute
     // this function when the page asks to send out bid requests.
     return {
         callBids: _callBids
@@ -53,18 +53,23 @@ var BidderNameAdapter = function BidderNameAdapter() {
 };
 
 module.exports = BidderNameAdapter;
-
 {% endhighlight %}
 
-
-### Step 3: Design your bid params
-
-Use the `bids.params` object for defining the parameters of your ad requests. The parameters are usually the tag ID and/or the site ID, etc. 
-
-Note that the placement size can be read from the `adUnit` object, so there is no need to put your own here.
+A good example of an adapter that uses this pattern for its implementation is [OpenX](https://github.com/prebid/Prebid.js/blob/master/src/adapters/openx.js).
 
 
-### Step 4: Send out bid requests
+## Step 3: Design your bid params
+
+Use the `bid.params` object for defining the parameters of your ad request. At a minimum, you should include the tag ID and the  site ID.  You can also include ad sizes, keywords, and other data, such as video bidding information.
+
+For more information about the kinds of information that can be passed using these parameters, see [the list of bidder parameters]({{site.github.url}}/dev-docs/bidders.html).
+
+For example, if your bidder supports serving video ads, you could add a `video` object to your adapter's bid parameters like the [AppNexus AST adapter]({{site.github.url}}/dev-docs/bidders.html#appnexusAst).  To see how those video params are processed and added to the ad tag, see [the AST adapter's implementation of the `callBids` function](https://github.com/prebid/Prebid.js/blob/master/src/adapters/appnexusAst.js).
+
+For more information about how the implementation of `callBids` should work generally, see the next section.
+
+
+## Step 4: Send out bid requests
 
 When the page asks Prebid.js to send out bid requests, your bidder's `_callBids(params)` function will be executed. This is a good place for you to send out bid requests to your bidder.
 
@@ -97,7 +102,7 @@ The `params` object contains information about the bids configured in the reques
             // passed through from the configuration as is.
             params: { 
             	unit: '3242432',
-                pagid: '123124',
+                pgid: '123124',
                 jstag_url: 'http://...'
             },
         }, {
@@ -112,14 +117,14 @@ The `params` object contains information about the bids configured in the reques
 Note that you should keep track of the `adUnitCode` in bid requests. In the next section this will come in handy.
 
 
-### Step 5: Register bid responses
+## Step 5: Register bid responses
 
-When the bid response(s) are available, notify Prebid.js immediately, so that your bid can get in the auction as soon as possible. The bidder's API typically has an event listener that notifies you when the bid responses are back.
+When the bid response(s) are available, notify Prebid.js immediately, so that your bid can get into the auction as soon as possible. A bidder's API will usually have an event listener that notifies you when the bid responses are back.
 
 To register the bid, call the `bidmanager.addBidResponse(adUnitCode, bidObject)` function. To register multiple bids, call the function multiple times.
 
-* If the bid is valid: Use `bidfactory.createBid(1)` to create the `bidObject`.
-* If the bid is invalid (no fill or error): Use `bidfactory.createBid(2)` to create the `bidObject`.
+* If the bid is valid, use `bidfactory.createBid(1)` to create the `bidObject`
+* If the bid is invalid (no fill or error), use `bidfactory.createBid(2)` to create the `bidObject`
 
 Example:
 
@@ -165,7 +170,7 @@ The required parameters to add into `bidObject` are:
 | `ad`         | Required  | The creative payload of the returned bid                                 | `"<html><h3>I am an ad</h3></html>"` |
 
 
-### Helper functions
+## Helper functions
 
 **`adloader.loadScript(scriptURL, callback, cacheRequest)`**
 
@@ -173,8 +178,11 @@ Load a script asynchronously. The callback function will be executed when the sc
 
 Use this with the `cacheRequest` argument set to `true` if the script you're loading is a library or something else that doesn't change between requests.  It will cache the script so you don't have to wait for it to load before firing the supplied callback.
 
-**Examples**
+For usage examples, see [the working adapters in the repo](https://github.com/prebid/Prebid.js/tree/master/src/adapters).
 
-Check out the bidder adapter examples in the [Github repo](https://github.com/prebid/Prebid.js/tree/master/src/adapters).
+## Further Reading
+
++ [The bidder adapter sources in the repo](https://github.com/prebid/Prebid.js/tree/master/src/adapters)
++ 
 
 </div>


### PR DESCRIPTION
Changes:

- Updated intro

- Added info about adding video info to your bid params, with links to
  AST adaptor docs and implemntation for reference

- Light copy-edits throughout the page, added some more reference links