### PR TITLE
Rename roxot adapter

### DIFF
--- a/download.md
+++ b/download.md
@@ -704,7 +704,7 @@ To improve the speed and load time of your site, build Prebid.js for only the he
 <div class="col-md-4">
   <div class="checkbox">
     <label>
-      <input type="checkbox" analyticscode="roxot" class="analytics-check-box"> Prebid Analitics by Roxot
+      <input type="checkbox" analyticscode="roxot" class="analytics-check-box"> Prebid Analytics by Roxot
     </label>
   </div>
 </div>

--- a/download.md
+++ b/download.md
@@ -704,7 +704,7 @@ To improve the speed and load time of your site, build Prebid.js for only the he
 <div class="col-md-4">
   <div class="checkbox">
     <label>
-      <input type="checkbox" analyticscode="roxot" class="analytics-check-box"> Roxot
+      <input type="checkbox" analyticscode="roxot" class="analytics-check-box"> Prebid Analitics by Roxot
     </label>
   </div>
 </div>


### PR DESCRIPTION
Hey guys,

Please rename "Roxot" analytics adapter to "Prebid Analytics by Roxot". It's the official name for our analytics product and we want to be consistent across different platforms. Otherwise, publishers might be confused when seeing the same product under different names. 

Could you merge it to the master as soon as the 0.22.0 prebid.js is released?

Thanks in advance.