### PR TITLE
updated Analytics landing page

### DIFF
--- a/_includes/main_nav.html
+++ b/_includes/main_nav.html
@@ -57,7 +57,7 @@
             </a>
             <ul class="dropdown-menu">
               <li><a href="https://chrome.google.com/webstore/detail/headerbid-expert/cgfkddgbnfplidghapbbnngaogeldmop">Chrome Extension</a></li>
-              <li><a href="{{site.github.url}}/dev-docs/integrate-with-the-prebid-analytics-api.html">Analytics</a></li>
+              <li><a href="{{site.baseurl}}/overview/analytics.html">Analytics</a></li>
               <li><a href="{{site.github.url}}/download.html">Download</a></li>
             </ul>
           </li>

--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -21,7 +21,7 @@ There are several analytics adapter plugins available to track header bidding pe
 | PulsePoint | Contact vendor | [Website](https://www.pulsepoint.com/header-bidding.html) | |
 | ShareThrough |Contact vendor | | |
 | PrebidAnalytics by Roxot | Free, see [terms](http://panel.prebidanalytics.com/account/pages/terms-of-service). | [Website](http://prebidanalytics.com/overview-examples) | 0.22 |
-| PubWise | Free managed service. See [terms](http://admin.pubwise.io/terms) | [Website](https://pubwise.io/) | 0.24 |
+| PubWise | Free, see [terms](http://admin.pubwise.io/terms) | [Website](https://pubwise.io/) | 0.24 |
 
 None of these analytics options are endorsed or supported by Prebid.org.
 

--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -1,0 +1,67 @@
+---
+layout: page
+title: Analytics Overview
+description: Prebid.js Analytics Overview
+
+pid: 10
+
+top_nav_section: overview
+nav_section: analytics
+
+---
+<div class="bs-docs-section" markdown="1">
+# Analytics for Prebid
+
+There are several analytics adapter plugins available to track header bidding performance for your site.
+
+## Self-Serve Analytics
+
+If you've installed Prebid on your own, these are the options for plugging in reporting. Note that none of them are endorsed or supported by Prebid.org.
+
+#### [Google Analytics](/overview/ga-analytics.html)
+
+Provided by the open source team as a basic approach to get header bidding stats. It assumes you've already signed up for a Google Analytics account - either free or paid.
+
+#### [PrebidAnalytics by Roxot](http://prebidanalytics.com)
+
+Roxot offers [prebidanalytics.com](http://prebidanalytics.com) as a free analytics service.
+
+
+## Managed Services
+
+There are several other analytics adapters available to publishers who work directly with a specific service provider.
+
+For additional service and analytics options, you may contact:
+
+* AppNexus (link or contact info)
+* PulsePoint
+* [RubiconProject](http://rubiconproject.com/headerbidding/)
+* Sharethrough
+
+## How it works
+
+Each analytics provider has specific instructions for using their system, but these are the general steps:
+
+* Create an account with the analytics vendor and obtain the necessary IDs
+* Build the Prebid.js package with the vendor's analytics adapter
+* Load analytics javascript from vendor directly on the page
+* Call the pbjs.enableAnalytics() function
+* Use the vendor's UI for reporting
+
+This is an example call to pbjs.enableAnalytics():
+
+```
+pbjs.que.push(function() {
+    pbjs.enableAnalytics({
+        provider: 'NAME',
+        options: {
+            [...]
+        }
+    });
+});
+```
+
+## More Details
+
+* [Creating a new analytics adapter](/dev-docs/integrate-with-the-prebid-analytics-api.html)
+</div>

--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -20,7 +20,7 @@ There are several analytics adapter plugins available to track header bidding pe
 | AppNexus | Contact vendor | [Website](https://www.appnexus.com/en/publishers/header-bidding) | |
 | PulsePoint | Contact vendor | [Website](https://www.pulsepoint.com/header-bidding.html) | |
 | ShareThrough |Contact vendor | | |
-| PrebidAnalytics by Roxot | Free, see [terms](http://panel.prebidanalytics.com/account/pages/terms-of-service). | [Website](http://prebidanalytics.com) | 0.22 |
+| PrebidAnalytics by Roxot | Free, see [terms](http://panel.prebidanalytics.com/account/pages/terms-of-service). | [Website](http://prebidanalytics.com/overview-examples) | 0.22 |
 | PubWise | Contact vendor | [Website](https://pubwise.io/) | 0.24 |
 
 None of these analytics options are endorsed or supported by Prebid.org.

--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -21,7 +21,7 @@ There are several analytics adapter plugins available to track header bidding pe
 | PulsePoint | Contact vendor | [Website](https://www.pulsepoint.com/header-bidding.html) | |
 | ShareThrough |Contact vendor | | |
 | PrebidAnalytics by Roxot | Free, see [terms](http://panel.prebidanalytics.com/account/pages/terms-of-service). | [Website](http://prebidanalytics.com/overview-examples) | 0.22 |
-| PubWise | Contact vendor | [Website](https://pubwise.io/) | 0.24 |
+| PubWise | Free managed service. See [terms](http://admin.pubwise.io/terms) | [Website](https://pubwise.io/) | 0.24 |
 
 None of these analytics options are endorsed or supported by Prebid.org.
 

--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -16,12 +16,12 @@ There are several analytics adapter plugins available to track header bidding pe
 
 | Analytics Adapter | Cost | Contact | Version Added |
 | ------------- | ------------- | ----------- | ------------|
-| [Google Analytics](http://prebid.org/overview/ga-analytics.html) | Free up to a certain volume | [website](https://www.google.com/analytics) | |
-| AppNexus | contact vendor | [website](https://www.appnexus.com/en/publishers/header-bidding) | |
-| PulsePoint | contact vendor | [website](https://www.pulsepoint.com/header-bidding.html) | |
-| ShareThrough |contact vendor | | |
-| PrebidAnalytics by Roxot | Free, see [terms](http://panel.prebidanalytics.com/account/pages/terms-of-service) | [website](http://prebidanalytics.com) | 0.22 |
-| PubWise | contact vendor | [website](https://pubwise.io/) | 0.24 |
+| [Google Analytics](http://prebid.org/overview/ga-analytics.html) | Free up to a certain volume. See [terms](https://www.google.com/analytics/terms/). | [Website](https://www.google.com/analytics) | |
+| AppNexus | Contact vendor | [Website](https://www.appnexus.com/en/publishers/header-bidding) | |
+| PulsePoint | Contact vendor | [Website](https://www.pulsepoint.com/header-bidding.html) | |
+| ShareThrough |Contact vendor | | |
+| PrebidAnalytics by Roxot | Free, see [terms](http://panel.prebidanalytics.com/account/pages/terms-of-service). | [Website](http://prebidanalytics.com) | 0.22 |
+| PubWise | Contact vendor | [Website](https://pubwise.io/) | 0.24 |
 
 None of these analytics options are endorsed or supported by Prebid.org.
 

--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -14,36 +14,23 @@ nav_section: analytics
 
 There are several analytics adapter plugins available to track header bidding performance for your site.
 
-## Self-Serve Analytics
+| Analytics Adapter | Cost | Contact | Version Added |
+| ------------- | ------------- | ----------- | ------------|
+| [Google Analytics](http://prebid.org/overview/ga-analytics.html) | Free up to a certain volume | [website](https://www.google.com/analytics) | |
+| AppNexus | contact vendor | [website](https://www.appnexus.com/en/publishers/header-bidding) | |
+| PulsePoint | contact vendor | [website](https://www.pulsepoint.com/header-bidding.html) | |
+| ShareThrough |contact vendor | | |
+| PrebidAnalytics by Roxot | Free, see [terms](http://panel.prebidanalytics.com/account/pages/terms-of-service) | [website](http://prebidanalytics.com) | 0.22 |
+| PubWise | contact vendor | [website](https://pubwise.io/) | 0.24 |
 
-If you've installed Prebid on your own, these are the options for plugging in reporting. Note that none of them are endorsed or supported by Prebid.org.
-
-#### [Google Analytics](/overview/ga-analytics.html)
-
-Provided by the open source team as a basic approach to get header bidding stats. It assumes you've already signed up for a Google Analytics account - either free or paid.
-
-#### [PrebidAnalytics by Roxot](http://prebidanalytics.com)
-
-Roxot offers [prebidanalytics.com](http://prebidanalytics.com) as a free analytics service.
-
-
-## Managed Services
-
-There are several other analytics adapters available to publishers who work directly with a specific service provider.
-
-For additional service and analytics options, you may contact:
-
-* AppNexus (link or contact info)
-* PulsePoint
-* [RubiconProject](http://rubiconproject.com/headerbidding/)
-* Sharethrough
+None of these analytics options are endorsed or supported by Prebid.org.
 
 ## How it works
 
 Each analytics provider has specific instructions for using their system, but these are the general steps:
 
 * Create an account with the analytics vendor and obtain the necessary IDs
-* Build the Prebid.js package with the vendor's analytics adapter
+* Build Prebid.js package with the vendor's analytics adapter
 * Load analytics javascript from vendor directly on the page
 * Call the pbjs.enableAnalytics() function
 * Use the vendor's UI for reporting
@@ -60,8 +47,6 @@ pbjs.que.push(function() {
     });
 });
 ```
-
 ## More Details
-
 * [Creating a new analytics adapter](/dev-docs/integrate-with-the-prebid-analytics-api.html)
 </div>

--- a/overview/ga-analytics.md
+++ b/overview/ga-analytics.md
@@ -27,15 +27,15 @@ nav_section: analytics
 
 The day starts from making sure the bidders are not generating less revenue:
 
-![Blocking Ad Calls 1]({{ site.github.url }}/assets/images/blog/analytics/revenue-by-date.png)
+![Blocking Ad Calls 1]({{ site.baseurl }}/assets/images/blog/analytics/revenue-by-date.png)
 
 Something is not right here - total revenue from yesterday dropped quite a bit. This could be caused by certain bidders were down or experienced technical issues. Let's take a look at the bidder timeout rate:
 
-![Blocking Ad Calls 1]({{ site.github.url }}/assets/images/blog/analytics/timeout-by-date.png)
+![Blocking Ad Calls 1]({{ site.baseurl }}/assets/images/blog/analytics/timeout-by-date.png)
 
 Bidder timeout seems okay. The problem might then be caused by bidders' lower bid rate:
 
-![Blocking Ad Calls 1]({{ site.github.url }}/assets/images/blog/analytics/bidrate-by-date.png)
+![Blocking Ad Calls 1]({{ site.baseurl }}/assets/images/blog/analytics/bidrate-by-date.png)
 
 Here we go. Bidder 1 and 4 bid much less than usual. You may want to drill down even further - Prebid.js Analytics also provides:
 
@@ -54,7 +54,7 @@ To understand exactly how much time per bidder spent, the Analytics Platform all
 
 <br>
 
-![Blocking Ad Calls 1]({{ site.github.url }}/assets/images/blog/analytics/loadtime-histogram.png)
+![Blocking Ad Calls 1]({{ site.baseurl }}/assets/images/blog/analytics/loadtime-histogram.png)
 
 You might derive:
 
@@ -67,7 +67,7 @@ Similar query for bidders' bid CPM:
 
 <br>
 
-![Blocking Ad Calls 1]({{ site.github.url }}/assets/images/blog/analytics/cpm-histogram.png)
+![Blocking Ad Calls 1]({{ site.baseurl }}/assets/images/blog/analytics/cpm-histogram.png)
 
 > **Try out the product and explore the demo dashboard <a href="https://docs.google.com/spreadsheets/d/11czzvF5wczKoWGMrGgz0NFEOM7wsnAISbp_MpmGzogU/edit?usp=sharing" target="_blank">here</a>!** This will be the base of your dashboard!
 


### PR DESCRIPTION
re-wiring the Analytics menu option to point to a new landing page that lists both GA and Roxot.

It has a section for 'managed services' which is aimed at laying out the choices publishers have for other analytics and managed offerings. AppNexus may want to add an enquiry link.

