### PR TITLE
Add docs for `pbjs.aliasBidder()`

### DIFF
--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -951,8 +951,15 @@ pbjs.aliasBidder('appnexusAst', 'newAlias');
 
 {% endhighlight %}
 
-Defining an alias can help avoid user confusion since it's possible to load an adapter with the same string name twice in different contexts (e.g., `"appnexusAst"` may be loaded once by an SSP and once by the publisher).
+Defining an alias can help avoid user confusion since it's possible to send parameters to the same adapter but in different contexts (e.g, The publisher uses `"appnexusAst"` for demand and also uses `"newAlias"` which is an SSP partner that uses the `"appnexusAst"` adapter to serve their own unique demand).
 
 It's not technically necessary to define an alias, since each copy of an adapter with the same name gets a different ID in the internal bidder registry so Prebid.js can still tell them apart.
+
+If you define an alias and are using `pbjs.sendAllBids`, you must also set up additional line items in the ad server with keyword targeting that matches the name of the alias.  For example:
+
++ `hb_pb_newalias`
++ `hb_adid_newalias`
++ `hb_size_newalias`
++ `hb_deal_newalias`
 
 </div>

--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -40,6 +40,7 @@ This page has documentation for the public API methods of Prebid.js.
   * [.setBidderSequence(order)](#module_pbjs.setBidderSequence)
   * [.onEvent(event, handler, id)](#module_pbjs.onEvent)
   * [.offEvent(event, handler, id)](#module_pbjs.onEvent)
+  * [.aliasBidder(adapterName, aliasedName)](#module_pbjs.aliasBidder)
 
 <a name="module_pbjs.getAdserverTargeting"></a>
 
@@ -937,5 +938,21 @@ The example below shows how to use these methods:
                 ...
 
 {% endhighlight %}
+
+<a name="module_pbjs.aliasBidder"></a>
+
+### pbjs.aliasBidder(adapterName, aliasedName)
+
+To define an alias for a bidder adapter, call this method at runtime:
+
+{% highlight js %}
+
+pbjs.aliasBidder('appnexusAst', 'newAlias');
+
+{% endhighlight %}
+
+Defining an alias can help avoid user confusion since it's possible to load an adapter with the same string name twice in different contexts (e.g., `"appnexusAst"` may be loaded once by an SSP and once by the publisher).
+
+It's not technically necessary to define an alias, since each copy of an adapter with the same name gets a different ID in the internal bidder registry so Prebid.js can still tell them apart.
 
 </div>


### PR DESCRIPTION
@aneuway2 mind taking a look at these docs for the `aliasBidder` method?

@mkendall07 can you verify the technical accuracy of this description W.R.T. IDs registered with Prebid.js allowing you to load two adapters with the same names?

Happy to update if there is a clearer/simpler way to think about how this works, or if something is off base technically.