### PR TITLE
Remove (some/most?) vendor-specific analytics instructions

### DIFF
--- a/dev-docs/analytics-ga.md
+++ b/dev-docs/analytics-ga.md
@@ -1,12 +1,12 @@
 ---
+redirect_to: "/overview/analytics.html"
 layout: page
 title: Analytics with GA
 description: Prebid.js Analytics with GA
 pid: 30
-
 top_nav_section: dev_docs
 nav_section: reference
-
+hide: true
 ---
 
 <div class="bs-docs-section" markdown="1">

--- a/dev-docs/integrate-with-the-prebid-analytics-api.md
+++ b/dev-docs/integrate-with-the-prebid-analytics-api.md
@@ -112,7 +112,7 @@ In your PR to add the new adapter, please provide the following information:
 3. There are several types of analytics adapters. The example here focuses on the 'endpoint' type. See [AnalyticsAdapter.js](https://github.com/prebid/Prebid.js/blob/master/src/AnalyticsAdapter.js) for more info on the 'library' and 'bundle' types.
 
     * endpoint - Calls the specified URL on analytics events. Doesn't require a global context.
-    * library - The URL is considered to be a library to load. Exepects a global context.
+    * library - The URL is considered to be a library to load. Expects a global context.
     * bundle - An advanced option expecting a global context.
 
 4. In order to get access to the configuration passed in from the page, the analytics

--- a/dev-docs/integrate-with-the-prebid-analytics-api.md
+++ b/dev-docs/integrate-with-the-prebid-analytics-api.md
@@ -3,7 +3,6 @@ layout: page
 title: Integrate with the Prebid Analytics API
 description: Integrate with the Prebid Analytics API
 pid: 28
-
 top_nav_section: dev_docs
 nav_section: adapters
 hide: false
@@ -21,6 +20,9 @@ The Prebid Analytics API provides a way to get analytics data from `Prebid.js` a
 + You can selectively build the `Prebid.js` library to include only the analytics adapters for the provider(s) you want.  This keeps the library small and minimizes page load time.
 
 + Since this API separates your analytics provider's code from `Prebid.js`, the upgrade and maintenance of the two systems are separate.  If you want to upgrade your analytics library, there is no need to upgrade or test the core of `Prebid.js`.
+
+* TOC
+{:toc }
 
 ## Architecture of the Analytics API
 
@@ -161,5 +163,10 @@ To add the new analyticsAdapter into a prebid package, use a command like this:
 {% highlight js %}
 gulp bundle --modules=abcAnalyticsAdapter,xyzBidAdapter
 {% endhighlight %}
+
+## Further Reading
+
+- [Analytics for Prebid]({{site.baseurl}}/overview/analytics.html) (Overview and list of Analytics providers)
+- [Integrate with the Prebid Analytics API]({{site.baseurl}}/dev-docs/integrate-with-the-prebid-analytics-api.html) (For developers)
 
 </div>

--- a/dev-docs/integrate-with-the-prebid-analytics-api.md
+++ b/dev-docs/integrate-with-the-prebid-analytics-api.md
@@ -166,7 +166,7 @@ gulp bundle --modules=abcAnalyticsAdapter,xyzBidAdapter
 
 ## Further Reading
 
-- [Analytics for Prebid]({{site.baseurl}}/overview/analytics.html) (Overview and list of Analytics providers)
+- [Analytics for Prebid]({{site.baseurl}}/overview/analytics.html) (Overview and list of analytics providers)
 - [Integrate with the Prebid Analytics API]({{site.baseurl}}/dev-docs/integrate-with-the-prebid-analytics-api.html) (For developers)
 
 </div>

--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -1,28 +1,27 @@
 ---
 layout: page
-title: Analytics Overview
+title: Analytics for Prebid
 description: Prebid.js Analytics Overview
-
 pid: 10
-
 top_nav_section: overview
 nav_section: analytics
-
 ---
+
 <div class="bs-docs-section" markdown="1">
+
 # Analytics for Prebid
 
 There are several analytics adapter plugins available to track header bidding performance for your site.
 
 {: .table .table-bordered .table-striped }
-| Analytics Adapter | Cost | Contact | Version Added |
-| ------------- | ------------- | ----------- | ------------|
-| [Google Analytics](http://prebid.org/overview/ga-analytics.html) | Free up to a certain volume. See [terms](https://www.google.com/analytics/terms/). | [Website](https://www.google.com/analytics) | |
-| AppNexus | Contact vendor | [Website](https://www.appnexus.com/en/publishers/header-bidding) | |
-| PulsePoint | Contact vendor | [Website](https://www.pulsepoint.com/header-bidding.html) | |
-| ShareThrough |Contact vendor | | |
-| PrebidAnalytics by Roxot | Free, see [terms](http://panel.prebidanalytics.com/account/pages/terms-of-service). | [Website](http://prebidanalytics.com/overview-examples) | 0.22 |
-| PubWise | Free, see [terms](http://admin.pubwise.io/terms) | [Website](https://pubwise.io/) | 0.24 |
+| Analytics Adapter                                                | Cost                                                                                | Contact                                                          | Version Added |
+| -------------                                                    | -------------                                                                       | -----------                                                      |  ------------ |
+| [Google Analytics](http://prebid.org/overview/ga-analytics.html) | Free up to a certain volume. See [terms](https://www.google.com/analytics/terms/).  | [Website](https://www.google.com/analytics)                      |               |
+| AppNexus                                                         | Contact vendor                                                                      | [Website](https://www.appnexus.com/en/publishers/header-bidding) |               |
+| PulsePoint                                                       | Contact vendor                                                                      | [Website](https://www.pulsepoint.com/header-bidding.html)        |               |
+| ShareThrough                                                     | Contact vendor                                                                      |                                                                  |               |
+| PrebidAnalytics by Roxot                                         | Free, see [terms](http://panel.prebidanalytics.com/account/pages/terms-of-service). | [Website](http://prebidanalytics.com/overview-examples)          |          0.22 |
+| PubWise                                                          | Free, see [terms](http://admin.pubwise.io/terms)                                    | [Website](https://pubwise.io/)                                   |          0.24 |
 
 None of these analytics options are endorsed or supported by Prebid.org.
 
@@ -32,13 +31,14 @@ Each analytics provider has specific instructions for using their system, but th
 
 * Create an account with the analytics vendor and obtain the necessary IDs
 * Build Prebid.js package with the vendor's analytics adapter
-* Load analytics javascript from vendor directly on the page
-* Call the pbjs.enableAnalytics() function
+* Load analytics JavaScript from vendor directly on the page
+* Call the `pbjs.enableAnalytics()` function
 * Use the vendor's UI for reporting
 
-This is an example call to pbjs.enableAnalytics():
+This is an example call to `pbjs.enableAnalytics()`:
 
-```
+{% highlight js %}
+
 pbjs.que.push(function() {
     pbjs.enableAnalytics({
         provider: 'NAME',
@@ -47,8 +47,11 @@ pbjs.que.push(function() {
         }
     });
 });
-```
 
-## More Details
-* [Creating a new analytics adapter](/dev-docs/integrate-with-the-prebid-analytics-api.html)
+{% endhighlight %}
+
+## Further Reading
+
+- [Integrate with the Prebid Analytics API]({{site.baseurl}}/dev-docs/integrate-with-the-prebid-analytics-api.html) (For developers)
+
 </div>

--- a/overview/ga-analytics.md
+++ b/overview/ga-analytics.md
@@ -88,7 +88,7 @@ Prebid.js has a seamless integration with Google Analytics and Google Spreadshee
 
 ## Further Reading
 
-- [Analytics for Prebid]({{site.baseurl}}/overview/analytics.html) (Overview and list of Analytics providers)
+- [Analytics for Prebid]({{site.baseurl}}/overview/analytics.html) (Overview and list of analytics providers)
 - [Integrate with the Prebid Analytics API]({{site.baseurl}}/dev-docs/integrate-with-the-prebid-analytics-api.html) (For developers)
 
 </div>

--- a/overview/ga-analytics.md
+++ b/overview/ga-analytics.md
@@ -1,29 +1,33 @@
 ---
 layout: page
-title: Prebid Analytics GA
+title: Prebid Analytics with GA
 description: Prebid.js Analytics with GA for Header Bidding
-
 pid: 10
-
 top_nav_section: overview
 nav_section: analytics
-
 ---
+
 <div class="bs-docs-section" markdown="1">
 
 # Prebid Analytics with GA
+{:.no_toc}
 
-> Are my header bidding demand partners generating more revenue for me? If not, is it because of latency or is it due to low bid CPM? How about discrepancy?
+> Are my header bidding demand partners generating more revenue for me? If not, is it because of latency or is it due to low bid CPM? How about discrepancies?
 
-##### Prebid Analytics help you better manage your header bidding partners. It includes:
+* TOC
+{:toc}
+
+## Prebid Analytics helps you better manage your header bidding partners
+
+It includes:
 
 - Bidder bid/win price analysis by geo, domain, with price range distribution.
 - Bid latency by bidder, geo, and domain.
 - Seamless integration with your Google Analytics account and scheduled reports delivered to your mailbox. 
 
-<br>
+<br />
 
-#### Example reports by Prebid.js Analytics:
+## Example reports by Prebid Analytics
 
 The day starts from making sure the bidders are not generating less revenue:
 
@@ -40,19 +44,19 @@ Bidder timeout seems okay. The problem might then be caused by bidders' lower bi
 Here we go. Bidder 1 and 4 bid much less than usual. You may want to drill down even further - Prebid.js Analytics also provides:
 
 - More metrics such as: bid load time, avg bid CPM, bid rate, avg win CPM, win rate.
-- Filter the above metrics further by geo, domain, and OS
+- Ability to filter the above metrics further by geo, domain, and OS
 
-> **Try out the product and explore the demo dashboard <a href="https://docs.google.com/spreadsheets/d/11czzvF5wczKoWGMrGgz0NFEOM7wsnAISbp_MpmGzogU/edit?usp=sharing" target="_blank">here</a>!** This will be the base of your dashboard!
+> **Explore an example dashboard <a href="https://docs.google.com/spreadsheets/d/11czzvF5wczKoWGMrGgz0NFEOM7wsnAISbp_MpmGzogU/edit?usp=sharing" target="_blank">here</a>**
 
-<br>
+<br />
 
-#### Histogram analysis of latency and CPM distribution:
+## Histogram analysis of latency and CPM distribution
 
 To understand exactly how much time per bidder spent, the Analytics Platform allows you to make the below query:
 
 - For country X, what are bidders' bid load time, for mobile traffic on Android only?
 
-<br>
+<br />
 
 ![Blocking Ad Calls 1]({{ site.baseurl }}/assets/images/blog/analytics/loadtime-histogram.png)
 
@@ -61,29 +65,30 @@ You might derive:
 - Bidder 1 is really fast, because 1/3 of its bids are in red, which is in the 200 - 300ms response time range.
 - Bidder 5 is really slow, as 1/3 of its bids are in 800 - 1000ms.
 
-<br>
+<br />
 
 Similar query for bidders' bid CPM:
 
-<br>
+<br />
 
 ![Blocking Ad Calls 1]({{ site.baseurl }}/assets/images/blog/analytics/cpm-histogram.png)
 
 > **Try out the product and explore the demo dashboard <a href="https://docs.google.com/spreadsheets/d/11czzvF5wczKoWGMrGgz0NFEOM7wsnAISbp_MpmGzogU/edit?usp=sharing" target="_blank">here</a>!** This will be the base of your dashboard!
 
-<br>
+<br />
 
-### How does it work?
+## How does it work?
 
-Prebid.js has a seamless integration with Google Analytics (other analytics software support coming) and Google Spreadsheet.
+Prebid.js has a seamless integration with Google Analytics and Google Spreadsheet, as well as [several other Analytics providers]({{site.baseurl}}/overview/analytics.html).
 
 1. Prebid.js has a built-in plugin for Google Analytics, i.e. zero development work if your site uses Prebid.js.
 2. All data are sent as Events to Google Analytics. You can build reports and dashboards there just as you do today with web traffic data.
-3. We've also built dashboards and data visulization in Spreadsheet (where all the above diagrams come from). You can copy our demo dashboard and link it to your Google Analytics account in a few minutes!
+3. We've also built dashboards and data visualization in Spreadsheet (where all the above diagrams come from). You can copy our demo dashboard and link it to your Google Analytics account in a few minutes!
 4. The Spreadsheet dashboard can be scheduled to run every morning (or in other intervals). You can get 7 day revenue lookback, latency/CPM distribution analysis and more every morning!
 
-### How to get started?
+## Further Reading
 
-Go to our [Analytics Dev Docs](/dev-docs/analytics-ga.html) to get started!
+- [Analytics for Prebid]({{site.baseurl}}/overview/analytics.html) (Overview and list of Analytics providers)
+- [Integrate with the Prebid Analytics API]({{site.baseurl}}/dev-docs/integrate-with-the-prebid-analytics-api.html) (For developers)
 
 </div>


### PR DESCRIPTION
Specifically:

- Remove the dev instructions for integrating with GA, move towards neutrality
- Leave the GA overview because it's somewhat instructive and ripping it out would be more work
- Bring formatting/layout of analytics pages in line with newer/standard pages (TOC, general structure, 'Further Reading' links, etc.)
- Caught a few typos, etc.