### PR TITLE
Add SpotX to the Partners list on Prebid homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -65,6 +65,7 @@ description: Free and open source solutions for publishers to quickly implement 
     <div class="col-xs-6 col-sm-4"><h3>AOL</h3></div>
     <div class="col-xs-6 col-sm-4"><h3>Index Exchange</h3></div>
     <div class="col-xs-6 col-sm-4"><h3>Sovrn</h3></div>
+    <div class="col-xs-6 col-sm-4"><h3>SpotX</h3></div>
     <div class="col-xs-6 col-sm-4"><h3>PulsePoint</h3></div>
     <div class="col-xs-6 col-sm-4"><h3>TripleLift</h3></div>
     <div class="col-xs-6 col-sm-4"><h3>SpringServe</h3></div>


### PR DESCRIPTION
SpotX was previously added to the bidder documentation via #280, but wasn't added to the list of supported partners on the Prebid homepage. Adding here...