### PR TITLE
Add video demo pages

### DIFF
--- a/dev-docs/show-video-with-a-dfp-video-tag.md
+++ b/dev-docs/show-video-with-a-dfp-video-tag.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Show Video Ads with a DFP Video Tag
-description: 
+description:
 pid: 0
 is_top_nav: yeah
 top_nav_section: dev_docs
@@ -151,7 +151,7 @@ the ad -- this is where `invokeVideoPlayer` is defined:
 
 ```html
 <div class="example-video-container">
-  <video id="vid1" class="video-js vjs-default-skin vjs-big-play-centered" controls 
+  <video id="vid1" class="video-js vjs-default-skin vjs-big-play-centered" controls
     data-setup='{}'
     width='640'
     height='480'
@@ -192,10 +192,10 @@ an instream pre-roll video ad followed by the oceans video from the [video.js ho
 
 Below, find links to end-to-end "working examples" integrating Prebid.js demand with various video players:
 
-+ [video.js](http://video-demo.appnexus.com/pbjs/mjacobson/video_testing/prebid_video_videojs_new.html)
-+ [JWPlayer](http://video-demo.appnexus.com/pbjs/JWPlayerDemo/jwPlayerPrebid.html)
-+ [Brightcove](http://video-demo.appnexus.com/pbjs/brightcove-prebid/bc-demo.html)
-+ [Kaltura](http://video-demo.appnexus.com/pbjs/kaltura-prebid/klt-demo.html)
-+ [Ooyala](http://video-demo.appnexus.com/pbjs/ooyala-prebid/ooyala-demo.html)
++ [video.js]({{site.github.url}}/examples/video/prebid_video_videojs_new.html)
++ [JWPlayer]({{site.github.url}}/examples/video/jwPlayerPrebid.html)
++ [Brightcove]({{site.github.url}}/examples/video/bc-demo.html)
++ [Kaltura]({{site.github.url}}/examples/video/klt-demo.html)
++ [Ooyala]({{site.github.url}}/examples/video/ooyala-demo.html)
 
 </div>

--- a/examples/video/bc-demo.html
+++ b/examples/video/bc-demo.html
@@ -1,0 +1,156 @@
+
+
+<!DOCTYPE html>
+<html>
+<head>
+  <link href="//players.brightcove.net/videojs-ima3/2/videojs.ima3.min.css" rel="stylesheet">
+
+  <title>Prebid.js Brightcove Example</title>
+  <script type="text/javascript" src="https://acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
+  <script>
+      var pbjs = pbjs || {};
+      pbjs.que = pbjs.que || [];
+      /*
+      Prebid Video adUnit
+      */
+
+      var tempTag = false;
+      var invokeVideoPlayer = function(url){
+        tempTag = url;
+      }
+
+      var videoAdUnit = {
+        code: 'video1',
+        sizes: [640,480],
+        mediaType: 'video',
+        bids: [
+          {
+            bidder: 'appnexusAst',
+            params: {
+              placementId: '9333431', // Add your own placement id here
+              video: {
+                skipppable: true,
+                playback_method: ['auto_play_sound_off']
+              }
+            }
+          }
+        ]
+      };
+
+      var logBids = function(bids) {
+        console.log('MESSAGE: got bids back: ');
+        console.log(bids);
+        if (!bids.video1) {
+          console.log('MESSAGE: no video demand');
+        } else {
+          console.log('MESSAGE: we got video demand!');
+        }
+
+        try {
+          url = bids.video1.bids[0].vastUrl;
+          console.log('MESSAGE: VAST URL: ');
+          console.log('MESSAGE: ' + url);
+        } catch (e) {
+          console.log("MESSAGE: There was an error logging the vast url: " + e);
+        }
+      }
+
+      pbjs.que.push(function(){
+        pbjs.addAdUnits(videoAdUnit); // add your ad units to the bid request
+        pbjs.requestBids({
+          timeout : 4000,
+          bidsBackHandler : function(bids) { // this function will be called once bids are returned
+            logBids(bids);
+            var adserverTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/19968336/prebid_video_adunit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=www.test.com';
+            adserverTag = adserverTag + '&correlator=' + Date.now()
+            var options = {
+              'adserver': 'dfp',
+              'code': 'video1' //this code name must match the code name defined in the videoAdUnit json above
+             };
+            //generate the URL to pass into the video player
+            var masterTagUrl = pbjs.buildMasterVideoTagFromAdserverTag(adserverTag, options);
+            // send masterTagUrl to the video player
+            invokeVideoPlayer(masterTagUrl);
+
+          }
+        });
+      });
+
+      pbjs.bidderSettings =
+      {
+        standard: {
+          adserverTargeting: [
+            {
+              key: "hb_bidder",
+              val: function (bidResponse) {
+                return bidResponse.bidderCode;
+              }
+          }, {
+              key: "hb_adid",
+              val: function (bidResponse) {
+                return bidResponse.adId;
+              }
+          }, {
+              key: "hb_pb",
+              val: function (bidResponse) {
+                return "10.00";
+              }
+          }, {
+              key: "hb_size",
+              val: function (bidResponse) {
+                  return bidResponse.size;
+              }
+            }
+          ]
+        }
+      };
+  </script>
+</head>
+<body>
+<h1> Brightcove Prebid Example </h1>
+<!--
+By use of this code snippet, I agree to the Brightcove Publisher T and C
+found at https://accounts.brightcove.com/en/terms-and-conditions/.
+-->
+<video id="myVideo"
+        data-video-id="5276850149001"
+        data-account="5229431809001"
+        data-player="rJVmLwTBx"
+        data-embed="default"
+        data-application-id
+        class="video-js"
+        controls
+        width="300"
+        height="150"></video>
+
+
+<script src="//players.brightcove.net/5229431809001/rJVmLwTBx_default/index.min.js"></script>
+<script src="//players.brightcove.net/videojs-ima3/2/videojs.ima3.min.js"></script>
+
+<script type="text/JavaScript">
+  function invokeVideoPlayer(url){
+    bc("myVideo").ima3({
+      serverUrl: url,
+      debug: true,
+      adTechOrder: [
+        "html5",
+        "flash"
+      ],
+    });
+
+    videojs("myVideo").ready(function(){
+      var myPlayer = this;
+
+      myPlayer.on("ima3error", function(){
+        console.log("There was an ima3 error.");
+      });
+    });
+  }
+
+  if (tempTag) {
+    invokeVideoPlayer(tempTag);
+    tempTag = false;
+  }
+</script>
+</body>
+</html>

--- a/examples/video/jwPlatformPrebidDemo.html
+++ b/examples/video/jwPlatformPrebidDemo.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <!-- This page is an example of prebid and JW Platform integration -->
+  <meta charset="utf-8" />
+  <title>Prebid.js JW Platform Example</title>
+  <!-- prebid.js -->
+  <script src="https://acdn.adnxs.com/prebid/not-for-prod/prebid.js" async=true></script> 
+  <script>
+
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
+
+    // define invokeVideoPlayer in advance in case we get the bids back from prebid before the entire page loads
+    var dynamicTag = false;
+    var invokeVideoPlayer = function(url){
+      dynamicTag = url;
+    }
+
+    /*
+    Prebid Video adUnit
+    */
+
+    var videoAdUnit = {
+      code: 'video1',
+      sizes: [640,480],
+      mediaType: 'video',
+      bids: [
+        {
+          bidder: 'appnexusAst',
+          params: {
+            placementId: '9333431', // Add your own placement id here
+            video: {
+              skipppable: true,
+              playback_method: ['auto_play_sound_off']
+            }
+          }
+        }
+      ]
+    };
+
+    pbjs.que.push(function(){
+      pbjs.addAdUnits(videoAdUnit); // add your ad units to the bid request
+      pbjs.requestBids({
+        timeout : 700,
+        // this function will be called once bids are returned from pbjs.requestBids()
+        bidsBackHandler : function(bids) {
+          // add some console logs for debugging
+          console.log('MESSAGE: got bids back: ');
+          console.log(bids);
+          if (!bids.video1) {
+            console.log('MESSAGE: no video demand');
+          }
+          else {
+            console.log('MESSAGE: we got video demand!');
+          }
+
+          // Log the VAST URL, if there is one
+          try {
+            url = bids.video1.bids[0].vastUrl;
+            console.log('MESSAGE: VAST URL: ');
+            console.log('MESSAGE: ' + url);
+          } catch (e) {} // ignore if there is no vastUrl
+
+          // this is the example adserver tag
+          var adserverTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/19968336/prebid_video_adunit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=www.test.com';
+          adserverTag = adserverTag + '&correlator=' + Date.now()
+          var options = {
+            'adserver': 'dfp',
+            'code': 'video1' //this code name must match the code name defined in the videoAdUnit json above
+           };
+
+          //generate the URL to pass into the video player
+          var masterTagUrl = pbjs.buildMasterVideoTagFromAdserverTag(adserverTag, options);
+          // send masterTagUrl to the video player
+          invokeVideoPlayer(masterTagUrl);
+        }
+      });
+    });
+
+    pbjs.bidderSettings =
+    {
+        standard: {
+            adserverTargeting: [
+                {
+                    key: "hb_bidder",
+                    val: function (bidResponse) {
+                        return bidResponse.bidderCode;
+                    }
+                }, {
+                    key: "hb_adid",
+                    val: function (bidResponse) {
+                        return bidResponse.adId;
+                    }
+                }, {
+                    key: "hb_pb",
+                    val: function (bidResponse) {
+                        return "10.00";
+                    }
+                }, {
+                    key: "hb_size",
+                    val: function (bidResponse) {
+                        return bidResponse.size;
+
+                    }
+                }
+            ]
+        }
+    };
+
+
+  </script>
+</head>
+
+<body>
+
+  <h2>Prebid Video - JW Platform</h2>
+  <br>
+  <br>
+  <div id="myElement1"></div>
+  <!-- This line loads a player without loading any video content -->
+  <!-- Replace this with the correct url for your player -->
+  <script src="https://content.jwplatform.com/libraries/72xIKEe6.js"></script>
+  <script>
+    // we initialize our player instance, specifying the div to load it into
+    var playerInstance = jwplayer('myElement1');
+
+    function invokeVideoPlayer(url) {
+      // this calls setup on the player we initialized
+      // this will use the settings defined in the player we loaded above unless you override them here
+      playerInstance.setup({
+        // this line loads a playlist from your jwplatform account (in either json or rss format)
+        // this can also be a single media file by specifying "file" : "content.jwplatform.com/videos/VIDEOKEY.mp4"
+        // Replace this with the correct url for your playlist
+        "playlist": "https://content.jwplatform.com/feeds/ae4tmw2D.json",
+        // we enable vast advertising for this player
+        "advertising": {
+          "client": "vast",
+          // url is the vast tag url that we passed in when we called invokeVideoPlayer in the header
+          "tag": url,
+        },
+      });
+    }
+
+    if (dynamicTag) {
+        invokeVideoPlayer(dynamicTag);
+        dynamicTag = false;
+    }
+  </script>
+</body>
+</html>

--- a/examples/video/jwPlayerPrebid.html
+++ b/examples/video/jwPlayerPrebid.html
@@ -1,0 +1,166 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+  <!-- This page is an example of prebid and JWPlayer integration with
+       a JWPlayer playAd call once the player is ready for playback -->
+  <meta charset="utf-8" />
+  <title>Prebid.js JW Player Example</title>
+
+  <!-- prebid.js -->
+  <script src="https://acdn.adnxs.com/prebid/not-for-prod/prebid.js" async=true></script>
+
+  <!-- JWPlayer -->
+    <script type="text/javascript" src="http://ssl.p.jwpcdn.com/player/v/7.2.4/jwplayer.js"></script>
+    <script type="text/javascript">
+       jwplayer.key="YEUwUA9wRFeDcydr"; //Test Key - replace this with your own valid JWPlayer license key
+    </script>
+  <script>
+
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
+
+    // define invokeVideoPlayer in advance in case we get the bids back from prebid before the entire page loads
+    var tempTag = false;
+    var invokeVideoPlayer = function(url){
+      tempTag = url;
+    }
+
+    /*
+    Prebid Video adUnit
+    */
+
+    var videoAdUnit = {
+      code: 'video1',
+      sizes: [640,480],
+      mediaType: 'video',
+      bids: [
+        {
+          bidder: 'appnexusAst',
+          params: {
+            placementId: '9333431', // Add your own placement id here
+            video: {
+              skipppable: true,
+              playback_method: ['auto_play_sound_off']
+            }
+          }
+        }
+      ]
+    };
+
+    var logBids = function(bids){
+      console.log('MESSAGE: got bids back: ');
+      console.log(bids);
+      if (!bids.video1) {
+        console.log('MESSAGE: no video demand');
+      }
+      else {
+        console.log('MESSAGE: we got video demand!');
+      }
+
+      // Log the VAST URL, if there is one
+      try {
+        url = bids.video1.bids[0].vastUrl;
+        console.log('MESSAGE: VAST URL: ');
+        console.log('MESSAGE: ' + url);
+      } catch (e) {
+        console.log("MESSAGE: There was an error logging the vast url: " + e);
+      } // ignore if there is no vastUrl
+    }
+
+    pbjs.que.push(function(){
+      pbjs.addAdUnits(videoAdUnit); // add your ad units to the bid request
+      pbjs.requestBids({
+        timeout : 700,
+        bidsBackHandler : function(bids) { // this function will be called once bids are returned from prebid
+          // log the bids for debugging purposes
+          logBids(bids);
+          // this is the example adserver tag from https://support.google.com/dfp_premium/answer/1068325?hl=en&ref_topic=2480647
+          var adserverTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/19968336/prebid_video_adunit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=www.test.com';
+          adserverTag = adserverTag + '&correlator=' + Date.now()
+          var options = {
+            'adserver': 'dfp',
+            'code': 'video1' //this code name must match the code name defined in the videoAdUnit json above
+           };
+
+          //generate the URL to pass into the video player
+          var masterTagUrl = pbjs.buildMasterVideoTagFromAdserverTag(adserverTag, options);
+          // send masterTagUrl to the video player
+          invokeVideoPlayer(masterTagUrl);
+        }
+      });
+    });
+
+    pbjs.bidderSettings =
+    {
+        standard: {
+            adserverTargeting: [
+                {
+                    key: "hb_bidder",
+                    val: function (bidResponse) {
+                        return bidResponse.bidderCode;
+                    }
+                }, {
+                    key: "hb_adid",
+                    val: function (bidResponse) {
+                        return bidResponse.adId;
+                    }
+                }, {
+                    key: "hb_pb",
+                    val: function (bidResponse) {
+                        return "10.00";
+                    }
+                }, {
+                    key: "hb_size",
+                    val: function (bidResponse) {
+                        return bidResponse.size;
+
+                    }
+                }
+            ]
+        }
+    };
+
+  </script>
+</head>
+
+<body>
+
+  <h2>Prebid Video - JWPlayer</h2>
+  <br>
+  <br>
+  <div id="playerContainerJW" style='width:552px; height:310px; border:1px solid black;'>
+  </div>
+
+  <script>
+    var jwPlayerInstance = jwplayer("playerContainerJW");
+
+    invokeVideoPlayer = function(url) {
+        jwPlayerInstance.setup({
+            "file": "http://video-demo.appnexus.com/pbjs/JWPlayerDemo/AppNexus_Summit_Video_HighRes.mp4",
+            "autostart": true,
+            "mute": true,
+            "advertising": {
+                client: "vast",
+            }
+        });
+
+        jwPlayerInstance.on('beforePlay', function(){
+            jwPlayerInstance.playAd(url);
+        })
+    }
+
+    if (tempTag) {
+        invokeVideoPlayer(tempTag);
+        tempTag = false;
+    }
+  </script>
+  <br>
+  <br>
+  <p>
+    <a href="jwPlatformPrebidDemo.html">Click here to see an example of integrating Prebid with a JW Platform account.</a></p>
+  <p>
+    <a href="jwPlaylistUniqueAds.html">Click here to see an example of using Prebid to show a new ad between JW Player playlist items.</a>
+  </p>
+</body>
+</html>

--- a/examples/video/jwPlaylistUniqueAds.html
+++ b/examples/video/jwPlaylistUniqueAds.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <!-- This page is an example of prebid and JWPlatform integration -->
+  <meta charset="utf-8" />
+  <title>Prebid.js JWPlayer Example</title>
+  <!-- prebid.js -->
+  <script src="https://acdn.adnxs.com/prebid/not-for-prod/prebid.js" async=true></script> 
+  <script>
+
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
+
+    var PREBID_TIMEOUT = 700;
+
+    var firstPlay = true;
+
+    var tempTag = false;
+    var invokeVideoPlayer = function(url){
+      tempTag = url;
+    }
+
+    /*
+    Prebid Video adUnit
+    */
+
+    var videoAdUnit = {
+      code: 'video1',
+      sizes: [640,480],
+      mediaType: 'video',
+      bids: [
+        {
+          bidder: 'appnexusAst',
+          params: {
+            placementId: '10107530', // Add your own placement id here
+            video: {
+              skipppable: true,
+              playback_method: ['auto_play_sound_off']
+            }
+          }
+        }
+      ]
+    };
+
+    var logBids = function(bids){
+      console.log('MESSAGE: got bids back: ');
+      console.log(bids);
+      if (!bids.video1) {
+        console.log('MESSAGE: no video demand');
+      }
+      else {
+        console.log('MESSAGE: we got video demand!');
+      }
+
+      // Log the VAST URL, if there is one
+      try {
+        url = bids.video1.bids[0].vastUrl;
+        console.log('MESSAGE: VAST URL: ');
+        console.log('MESSAGE: ' + url);
+      } catch (e) {
+        console.log("MESSAGE: There was an error logging the vast url: " + e);
+      } // ignore if there is no vastUrl
+    }
+
+    var requestVideoAd = function(){
+      pbjs.requestBids({
+        timeout : PREBID_TIMEOUT,
+        // this function will be called once bids are returned from pbjs.requestBids()
+        bidsBackHandler : function(bids){
+          logBids(bids);
+          var adserverTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/19968336/prebid_video_adunit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=www.test.com';
+          adserverTag = adserverTag + '&correlator=' + Date.now()
+          var options = {
+            'adserver': 'dfp',
+            'code': 'video1' //this code name must match the code name defined in the videoAdUnit json above
+          };
+          //generate the URL to pass into the video player
+          var masterTagUrl = pbjs.buildMasterVideoTagFromAdserverTag(adserverTag, options);
+
+          invokeVideoPlayer(masterTagUrl);
+        }
+      });
+    }
+
+    pbjs.que.push(function(){
+      pbjs.addAdUnits(videoAdUnit); // add your ad units to the bid request
+      requestVideoAd();
+    });
+
+    pbjs.bidderSettings =
+    {
+      standard: {
+        adserverTargeting: [
+        {
+            key: "hb_bidder",
+            val: function (bidResponse) {
+              return bidResponse.bidderCode;
+            }
+        }, {
+            key: "hb_adid",
+            val: function (bidResponse) {
+              return bidResponse.adId;
+            }
+        }, {
+            key: "hb_pb",
+            val: function (bidResponse) {
+              return "10.00";
+            }
+        }, {
+            key: "hb_size",
+            val: function (bidResponse) {
+              return bidResponse.size;
+            }
+          }
+        ]
+      }
+    };
+
+
+  </script>
+</head>
+
+<body>
+
+  <h2>Prebid Video - JW Player Playlist</h2>
+  <br>
+  <br>
+  <div id="myElement1"></div>
+  <!-- replace this script with the libraries script of your player -->
+  <script src="https://content.jwplatform.com/libraries/72xIKEe6.js"></script>
+  <script>
+    var adTag = "";
+    var playerInstance = jwplayer('myElement1');
+
+    invokeVideoPlayer = function(url) {
+      adTag = url;
+      console.log("MESSAGE: invoking the video player");
+
+      // if this is our first time invoking the player, we also need to create the player
+      // and the event listeners
+      if(firstPlay){
+        playerInstance.setup({
+          "playlist": "https://content.jwplatform.com/feeds/ae4tmw2D.json",
+          "advertising": {
+            "client": "vast",
+          },
+        });
+
+        // set firstPlay to false to make sure we don't call setup() on our player a second time
+        firstPlay = false;
+
+        // beforePlay gets triggered before each content video plays
+        // we play the ad tag being stored in the variable adTag, which we refresh
+        // each time a content video plays by calling requestVideoAd
+        playerInstance.on("beforePlay", function(){
+          playerInstance.playAd(adTag);
+          console.log("MESSAGE: refreshing the ad slot");
+          pbjs.que.push(function() {
+            requestVideoAd();
+          });
+        });
+
+        // if our playlist ends and does not repeat, we want to play the last ad we got
+        playerInstance.on("beforeComplete", function(){
+          if(playerInstance.getPlaylistIndex() === playerInstance.getPlaylist().length - 1){
+            playerInstance.playAd(adTag);
+          }
+        });
+      }
+    }
+
+    // if prebid returned an ad before the browser reached the end of the page,
+    // the version of invokeVideoPlayer we defined in the header has stored the url in tempTag,
+    // so we call invokeVideoPlayer with the stored url we stored
+    if (tempTag) {
+      invokeVideoPlayer(tempTag);
+      tempTag = false;
+    }
+  </script>
+</body>
+</html>

--- a/examples/video/klt-demo.html
+++ b/examples/video/klt-demo.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+	<title>Kaltura Prebid Demo</title>
+	<script type="text/javascript" src="https://acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
+
+	<script>
+	    var pbjs = pbjs || {};
+	    pbjs.que = pbjs.que || [];
+
+	    /*
+	    Prebid Video adUnit
+	    */
+
+	    var dynamicTag = false;
+	    var invokeVideoPlayer = function(url){
+	      dynamicTag = url;
+	    }
+
+	    var videoAdUnit = {
+	      code: 'video1',
+	      sizes: [640,480],
+	      mediaType: 'video',
+	      bids: [
+	        {
+	          bidder: 'appnexusAst',
+	          params: {
+	            placementId: '9333431', // Add your own placement id here
+	            video: {
+	              skipppable: true,
+	              playback_method: ['auto_play_sound_off']
+	            }
+	          }
+	        }
+	      ]
+	    };
+
+	    pbjs.que.push(function(){
+	      pbjs.addAdUnits(videoAdUnit); // add your ad units to the bid request
+	      pbjs.requestBids({
+	        timeout : 4000,
+	        bidsBackHandler : function(bids) { // this function will be called once bids are returned
+	          var adserverTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/19968336/prebid_video_adunit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=www.test.com';
+	          adserverTag = adserverTag + '&correlator=' + Date.now()
+	          var options = {
+	            'adserver': 'dfp',
+	            'code': 'video1' //this code name must match the code name defined in the videoAdUnit json above
+	           };
+	          //generate the URL to pass into the video player
+	          var masterTagUrl = pbjs.buildMasterVideoTagFromAdserverTag(adserverTag, options);
+	          // send masterTagUrl to the video player
+	          invokeVideoPlayer(masterTagUrl);
+
+	        }
+	      });
+	    });
+
+	    pbjs.bidderSettings =
+	    {
+	        standard: {
+	            adserverTargeting: [
+	                {
+	                    key: "hb_bidder",
+	                    val: function (bidResponse) {
+	                        return bidResponse.bidderCode;
+	                    }
+	                }, {
+	                    key: "hb_adid",
+	                    val: function (bidResponse) {
+	                        return bidResponse.adId;
+	                    }
+	                }, {
+	                    key: "hb_pb",
+	                    val: function (bidResponse) {
+	                        return "10.00";
+	                    }
+	                }, {
+	                    key: "hb_size",
+	                    val: function (bidResponse) {
+	                        return bidResponse.size;
+
+	                    }
+	                }
+	            ]
+	        }
+	    };
+	</script>
+</head>
+<body>
+	<div id="myPlayer" style="width:320px; height:250px;"></div>
+	<script src="http://cdnapi.kaltura.com/p/2222001/sp/222200100/embedIframeJs/uiconf_id/37440401/partner_id/2222001"></script>
+	<script>
+		invokeVideoPlayer = function(url){
+			// Documentation for kWidget available here: http://player.kaltura.com/docs/kwidget
+			kWidget.embed({
+			  	"targetId": "myPlayer",
+			  	"wid": "_2222001",
+			  	"uiconf_id": 37440401,
+			  	"flashvars": {
+			    	"streamerType": "auto",
+			    	"vast": {
+			    		"plugin": true,
+    					"prerollUrl": url,
+			    	}
+			  	},
+			  	"entry_id": "1_k4eka7er",
+			  	readyCallback: function(playerId){
+			  		console.log("Kaltura player " + playerId + " is ready.");
+			  	}
+			});
+		}
+
+		if (dynamicTag) {
+	      invokeVideoPlayer(dynamicTag);
+	      dynamicTag = false;
+	    }
+	</script>
+</body>
+</html>

--- a/examples/video/ooyala-demo.html
+++ b/examples/video/ooyala-demo.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script type="text/javascript" src="https://acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
+<title>Ooyala Prebid Demo</title>
+<!-- OOYALA PLUGINS -->
+<!-- CORE PLAYER REQUIRED -->
+<script src="//player.ooyala.com/static/v4/stable/latest/core.min.js"></script>
+<!-- VIDEO PLUGINS -->
+<script src="//player.ooyala.com/static/v4/stable/latest/video-plugin/main_html5.min.js"></script>
+<script src="//player.ooyala.com/static/v4/stable/latest/video-plugin/bit_wrapper.min.js"></script>
+<script src="//player.ooyala.com/static/v4/stable/latest/video-plugin/osmf_flash.min.js"></script>
+<!-- HTML5 SKIN -->
+<script src="//player.ooyala.com/static/v4/stable/latest/skin-plugin/html5-skin.min.js"></script>
+<!-- SKIN ASSET -->
+<link rel="stylesheet" href="//player.ooyala.com/static/v4/stable/latest/skin-plugin/html5-skin.min.css"/>
+<!-- AD PLUGIN  -->
+<!-- <script src="//player.ooyala.com/static/v4/stable/latest/ad-plugin/ad_manager_vast.min.js"></script> -->
+
+<!-- IMA PLUGIN -->
+<script src="//player.ooyala.com/static/v4/stable/latest/ad-plugin/google_ima.js"></script>
+<script>
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
+    console.log("|||| Start of prebid: " + performance.now());
+    /*
+    Prebid Video adUnit
+    */
+
+    var dynamicTag = false;
+    var invokeVideoPlayer = function(url){
+      dynamicTag = url;
+    }
+
+    var videoAdUnit = {
+      code: 'video1',
+      sizes: [640,480],
+      mediaType: 'video',
+      bids: [
+        {
+          bidder: 'appnexusAst',
+          params: {
+            placementId: '9333431', // Add your own placement id here
+            video: {
+              skipppable: true,
+              playback_method: ['auto_play_sound_off']
+            }
+          }
+        }
+      ]
+    };
+
+    pbjs.que.push(function(){
+      pbjs.addAdUnits(videoAdUnit); // add your ad units to the bid request
+      pbjs.requestBids({
+        timeout : 4000,
+        bidsBackHandler : function(bids) { // this function will be called once bids are returned
+          var adserverTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/19968336/prebid_video_adunit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=www.test.com';
+          adserverTag = adserverTag + '&correlator=' + Date.now()
+          var options = {
+            'adserver': 'dfp',
+            'code': 'video1' //this code name must match the code name defined in the videoAdUnit json above
+           };
+          //generate the URL to pass into the video player
+          var masterTagUrl = pbjs.buildMasterVideoTagFromAdserverTag(adserverTag, options);
+          // debugger;
+          // send masterTagUrl to the video player
+          invokeVideoPlayer(masterTagUrl);
+
+        }
+      });
+    });
+
+    pbjs.bidderSettings =
+    {
+        standard: {
+            adserverTargeting: [
+                {
+                    key: "hb_bidder",
+                    val: function (bidResponse) {
+                        return bidResponse.bidderCode;
+                    }
+                }, {
+                    key: "hb_adid",
+                    val: function (bidResponse) {
+                        return bidResponse.adId;
+                    }
+                }, {
+                    key: "hb_pb",
+                    val: function (bidResponse) {
+                        return "10.00";
+                    }
+                }, {
+                    key: "hb_size",
+                    val: function (bidResponse) {
+                        return bidResponse.size;
+
+                    }
+                }
+            ]
+        }
+    };
+</script>
+</head>
+<body>
+<div id='container' style='width:640px;height:266px;'></div>
+<script>
+	var invokeVideoPlayer = function(url){
+		// url = "//video-demo.appnexus.com/pbjs/prebidVideoVast3.xml"
+		console.log("invoking video player with url " + url);
+		var playerParam = {
+			'pcode':'lsbWkyOjtI6LOjmlqk2o5I-TsWRA',
+			'playerBrandingId':'45b8294c6ad14265b2b47586c911cb07',
+			'debug': true,
+			'autoplay': true,
+      'initialVolume': 0.0,
+			'skin': {
+				'config': '//player.ooyala.com/static/v4/stable/4.6.9/skin-plugin/skin.json',
+				'inline': {
+					'adScreen': {
+						'showAdMarquee': true,
+						'showAdCountDown': true,
+						'showControlBar': true,
+						'useGoogleAdUI': true
+					}
+				}
+			},
+			"google-ima-ads-manager":{
+				"all_ads": [
+					{
+						"position":"0",
+						"position_type": "t",
+						"tag_url": url
+					}
+				],
+				'showAdControls': true
+			}
+		};
+		OO.ready(function() {
+			console.log("OO is ready, invoking");
+			console.dir(playerParam);
+			window.pp = OO.Player.create('container', 'ltcG54NzE6Bxk08Mqs1_KMcQZDN7lH8N', playerParam);
+		});
+	}
+  if (dynamicTag) {
+      invokeVideoPlayer(dynamicTag);
+      dynamicTag = false;
+  }
+</script>
+</body>
+</html>

--- a/examples/video/prebid_video_videojs_new.html
+++ b/examples/video/prebid_video_videojs_new.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Prebid.js video adUnit example</title>
+
+  <!-- videojs -->
+  <link rel="stylesheet" href="http://vjs.zencdn.net/5.9.2/video-js.css">
+  <script type="text/javascript" src="http://vjs.zencdn.net/5.9.2/video.js"></script>
+
+  <!-- videojs-vast-vpaid -->
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/videojs-vast-vpaid/2.0.2/videojs.vast.vpaid.min.css" rel="stylesheet">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/videojs-vast-vpaid/2.0.2/videojs_5.vast.vpaid.min.js"></script>
+
+  <!-- prebid.js -->
+  <script src="https://acdn.adnxs.com/prebid/not-for-prod/prebid.js" async=true></script>
+
+
+  <script>
+
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
+
+    /*
+    Prebid Video adUnit
+    */
+
+    var videoAdUnit = {
+      code: 'video1',
+      sizes: [640,480],
+      mediaType: 'video',
+      bids: [
+        {
+          bidder: 'appnexusAst',
+          params: {
+            placementId: '9333431',
+            video: {
+              skipppable: true,
+              playback_method: ['auto_play_sound_off']
+            }
+          }
+        }
+      ]
+    };
+
+    pbjs.que.push(function(){
+      pbjs.addAdUnits(videoAdUnit);
+      pbjs.requestBids({
+        timeout : 700,
+        bidsBackHandler : function(bids) {
+
+          var adserverTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/19968336/prebid_video_adunit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=www.test.com';
+          adserverTag = adserverTag + '&correlator=' + Date.now();
+
+          var options = {
+            'adserver': 'dfp',
+            'code': 'video1' //code that matches the video adUnit declared above
+           };
+
+          //generate URL
+          var masterTagUrl = pbjs.buildMasterVideoTagFromAdserverTag(adserverTag, options);
+
+          //send masterTagUrl to the video player
+          invokeVideoPlayer(masterTagUrl);
+        }
+      });
+    });
+
+    pbjs.bidderSettings =
+    {
+        standard: {
+            adserverTargeting: [
+                {
+                    key: "hb_bidder",
+                    val: function (bidResponse) {
+                        return bidResponse.bidderCode;
+                    }
+                }, {
+                    key: "hb_adid",
+                    val: function (bidResponse) {
+                        return bidResponse.adId;
+                    }
+                }, {
+                    key: "hb_pb",
+                    val: function (bidResponse) {
+                        return "10.00";
+                    }
+                }, {
+                    key: "hb_size",
+                    val: function (bidResponse) {
+                        return bidResponse.size;
+
+                    }
+                }
+            ]
+        }
+    };
+
+  </script>
+</head>
+
+<body>
+
+  <h2>Prebid Video -- video.js</h2>
+
+  <div class="example-video-container">
+
+    <video id="vid1" class="video-js vjs-default-skin vjs-big-play-centered" controls
+      data-setup='{}'
+      width='640'
+      height='480'
+    >
+    <source src="http://vjs.zencdn.net/v/oceans.mp4" type='video/mp4'/>
+    <source src="http://vjs.zencdn.net/v/oceans.webm" type='video/webm'/>
+    <source src="http://vjs.zencdn.net/v/oceans.ogv" type='video/ogg'/>
+
+    </video>
+  </div>
+
+  <script>
+
+    var page_load_time;
+
+    page_load_time = new Date().getTime() - performance.timing.navigationStart;
+    console.log(page_load_time + "ms -- Player loading!");
+
+    var vid1 = videojs('vid1');
+
+    page_load_time = new Date().getTime() - performance.timing.navigationStart;
+    console.log(page_load_time + "ms -- Player loaded!");
+
+    function invokeVideoPlayer(url) {
+
+      page_load_time = new Date().getTime() - performance.timing.navigationStart;
+      console.log(page_load_time + "ms -- Prebid VAST url = " + url);
+
+      videojs("vid1").ready(function() {
+
+        page_load_time = new Date().getTime() - performance.timing.navigationStart;
+        console.log(page_load_time + "ms -- Player is ready!");
+
+        var player = this;
+        var vastAd = player.vastClient({
+          adTagUrl: url,
+          playAdAlways: true,
+          verbosity: 4,
+          vpaidFlashLoaderPath: "https://github.com/MailOnline/videojs-vast-vpaid/blob/RELEASE/bin/VPAIDFlash.swf?raw=true",
+          autoplay: true
+        });
+
+        page_load_time = new Date().getTime() - performance.timing.navigationStart;
+        console.log(page_load_time + "ms -- Prebid VAST tag inserted!");
+
+        player.muted(true);
+        player.play();
+
+        page_load_time = new Date().getTime() - performance.timing.navigationStart;
+        console.log(page_load_time + "ms -- invokeVideoPlayer complete!");
+
+      });
+  }
+
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Adds video demo pages to `examples/video` directory, and updates links on `show-video-with-a-dfp-video-tag` page to point to them