### PR TITLE
Omit s2s only adapters from the download page

### DIFF
--- a/dev-docs/bidders.md
+++ b/dev-docs/bidders.md
@@ -109,6 +109,10 @@ Demand from the bidders listed below is available via the [Prebid Server integra
 <div class="bs-docs-section" markdown="1">
 <h2><a name="{{ page.biddercode }}" />{{ page.title }}</h2>
 
+{% if page.s2s_only == true %}  
+<h3>Note:</h3> This is a S2S adapter only.
+{% endif %}
+
 <h3>Bidder Code</h3>
 
 <code>{{ page.biddercode }}</code>

--- a/dev-docs/bidders/districtm.md
+++ b/dev-docs/bidders/districtm.md
@@ -12,6 +12,7 @@ biddercode: districtm
 
 biddercode_longer_than_12: false
 
+s2s_only: true
 
 ---
 

--- a/download.md
+++ b/download.md
@@ -122,6 +122,9 @@ To improve the speed and load time of your site, build Prebid.js for only the he
 <h4>Bidder Adapters</h4>
 
 {% for page in bidder_pages %}
+  {% if page.s2s_only == true %}  
+    {% continue %}
+  {% endif %}
 <div class="col-md-4">
  <div class="checkbox">
   <label>


### PR DESCRIPTION
Hides bidders that don't have a client side JS library. 