### PR TITLE
Doc native params on `mediaTypes` (incl. `cta`)

### DIFF
--- a/dev-docs/show-native-ads.md
+++ b/dev-docs/show-native-ads.md
@@ -145,7 +145,7 @@ pbjs.addAdUnits({
 {% endhighlight %}
 
 {: .alert.alert-danger :}
-For each native ad unit, all of the bidders within that ad unit must have declared native support in their adapter.  If there are any bidders without native support in a native ad unit, the request won't be made.  For a list of bidders with native support, see [Bidders with Video and Native Demand]({{site.baseurl}}/bidders.html#bidders-with-video-and-native-demand).
+For each native ad unit, all of the bidders within that ad unit must have declared native support in their adapter if you want ads to appear.  If there are any bidders without native support in a native ad unit, requests will not be made to those bidders.  For a list of bidders with native support, see [Bidders with Video and Native Demand]({{site.baseurl}}/bidders.html#bidders-with-video-and-native-demand).
 
 #### Pre-defined native types
 

--- a/dev-docs/show-native-ads.md
+++ b/dev-docs/show-native-ads.md
@@ -44,7 +44,7 @@ The native ad responses get placed on specific keys that are sent into your ad s
 + `hb_native_linkurl`
 + `hb_native_cta`
 
-Note that these keys correspond directly to the native object you define in your ad unit (which is [described in more detail below](#native-ad-keys)).
+Note that these keys correspond directly to the `mediaTypes.native` object you define in your ad unit (which is [described in more detail below](#native-ad-keys)).
 
 The ad ops team will then reference these keys in the ad server to set up the title, body, etc.  For ad ops setup instructions, see [Set up Native Ads in your Ad Server]({{site.github.url}}/adops/setting-up-prebid-native-in-dfp.html).
 

--- a/dev-docs/show-native-ads.md
+++ b/dev-docs/show-native-ads.md
@@ -42,8 +42,9 @@ The native ad responses get placed on specific keys that are sent into your ad s
 + `hb_native_image`
 + `hb_native_icon`
 + `hb_native_linkurl`
++ `hb_native_cta`
 
-Note that these keys correspond directly to the `nativeParams` object you define in your ad unit (which is described in more detail below).
+Note that these keys correspond directly to the native object you define in your ad unit (which is [described in more detail below](#native-ad-keys)).
 
 The ad ops team will then reference these keys in the ad server to set up the title, body, etc.  For ad ops setup instructions, see [Set up Native Ads in your Ad Server]({{site.github.url}}/adops/setting-up-prebid-native-in-dfp.html).
 
@@ -51,7 +52,7 @@ The ad ops team will then reference these keys in the ad server to set up the ti
 
 Keep the following prerequisites in mind during the implementation:
 
-+ Make sure to work with native-enabled bidders. In the adapter's registerBidAdapter call, the bidder will have `"native"` in their list of supportedMediaTypes.
++ Make sure to work with native-enabled bidders. To see which bidders have native demand, see [Bidders with Video and Native Demand]({{site.baseurl}}/bidders.html#bidders-with-video-and-native-demand).
 
 ## Implementation
 
@@ -69,9 +70,11 @@ const slot = {
 };
 {% endhighlight %}
 
+<a name="native-ad-keys" />
+
 ### 2. Add native ad units
 
-Native ad units require a `nativeParams` object, with the following keys that correspond to the assets of the native ad:
+The native object (shown [below](#native-object)) contains the following keys that correspond to the assets of the native ad:
 
 {: .table .table-bordered .table-striped }
 | Key           | Description                                                                 |
@@ -82,6 +85,7 @@ Native ad units require a `nativeParams` object, with the following keys that co
 | `icon`        | The brand icon that will appear with the ad.                                |
 | `image`       | A picture that is associated with the brand, or grabs the user's attention. |
 | `clickUrl`    | Where the user will end up if they click the ad.                            |
+| `cta`         | *Call to Action* text, e.g., "Click here for more information".               |
 
 Each key's value is an object with several fields.  Most important is the `required` field, which says whether that asset should be filled in by the bid response.  Specifically, bids that do not have all of the native assets marked as required will be dropped from the auction and will not be sent to the ad server.
 
@@ -100,42 +104,48 @@ Each key's value is an object with several fields.  Most important is the `requi
   </p>
 </div>
 
+<a name="native-object" />
+
 {% highlight js %}
+
 pbjs.addAdUnits({
-  code: slot.code,
-  sizes: slot.size,
-  mediaType: "native",
-  nativeParams: {
-    title: {
-      required: true,
-      len: 80
-    },
-    body: {
-      required: true
-    },
-    brand: {
-      required: true
-    },
-    image: {
-      required: true
-    },
-    clickUrl: {
-      required: true
-    },
-  },
-  bids: [
-    {
-      bidder: 'appnexusAst',
-      params: {
-        placementId: '9880618'
-      }
-    },
-  ]
+    code: slot.code,
+    sizes: slot.size,
+    mediaTypes: {
+        native: {
+            image: {
+                required: true
+            },
+            title: {
+                required: true,
+                len: 80
+            },
+            sponsoredBy: {
+                required: true
+            },
+            clickUrl: {
+                required: true
+            },
+            body: {
+                required: true
+            },
+            icon: {
+                required: true
+            },
+        },
+        bids: [{
+            bidder: 'appnexusAst',
+            params: {
+                placementId: '9880618'
+            }
+        }, ]
+    }
 });
+
 {% endhighlight %}
 
 {: .alert.alert-danger :}
-For each native ad unit, all of the bidders within that ad unit must have declared native support in supportedMediaTypes as defined in the adapter's call to registerBidAdapter().  If there are any bidders without native support in a native ad unit, the request won't be made.
+For each native ad unit, all of the bidders within that ad unit must have declared native support in their adapter.  If there are any bidders without native support in a native ad unit, the request won't be made.  For a list of bidders with native support, see [Bidders with Video and Native Demand]({{site.baseurl}}/bidders.html#bidders-with-video-and-native-demand).
 
 #### Pre-defined native types
 
@@ -154,6 +164,7 @@ And the following optional fields:
 
 + body
 + icon
++ cta
 
 A native `image` ad unit can be set up in the manner below:
 
@@ -161,9 +172,9 @@ A native `image` ad unit can be set up in the manner below:
 
       const adUnits = [{
         code: 'adUnit-code',
-        nativeParams: {type: 'image'},
+        mediaTypes: { native: { type: 'image' } }
         bids: [
-          { bidder: 'appnexusAst', params: { placementId: 'id' } }
+          { bidder: 'appnexusAst', params: { placementId: '123456' } }
         ]
       }];
 


### PR DESCRIPTION
Scope of work here is:

- add info on `cta` field
- update example code to use `mediaTypes: { native ...` API
- add some links to our list of bidders with native support

Let me know what you think - thanks!