### PR TITLE
Better getUserSync docs

### DIFF
--- a/dev-docs/bidder-adapter-1.md
+++ b/dev-docs/bidder-adapter-1.md
@@ -162,7 +162,7 @@ export const spec = {
     isBidRequestValid: function(bid) {},
     buildRequests: function(validBidRequests[]) {},
     interpretResponse: function(serverResponse, request) {},
-    getUserSyncs: function(syncOptions) {}
+    getUserSyncs: function(syncOptions, serverResponses) {}
 }
 registerBidder(spec);
 
@@ -287,11 +287,15 @@ All user ID sync activity must be done in one of two ways:
 {% highlight js %}
 
 {
-    getUserSyncs: function(syncOptions) {
-        if (syncOptions.iframeEnabled) {
+    getUserSyncs: function(syncOptions, serverResponses) {
+        if (syncOptions.iframeEnabled && serverResponses.length > 0) {
+            const syncFromServer = serverResponses[0].body.userSync
             return [{
                 type: 'iframe',
                 url: '//acdn.adnxs.com/ib/static/usersync/v3/async_usersync.html'
+            }, {
+                type: 'url',
+                url: syncFromServer.url
             }];
         }
     }
@@ -465,7 +469,7 @@ export const spec = {
         };
         return bidResponses;
     },
-    getUserSyncs: function(syncOptions) {
+    getUserSyncs: function(syncOptions, serverResponses) {
         if (syncOptions.iframeEnabled) {
             return [{
                 type: 'iframe',

--- a/dev-docs/bidder-adapter-1.md
+++ b/dev-docs/bidder-adapter-1.md
@@ -472,9 +472,9 @@ export const spec = {
     /**
      * Register the user sync pixels which should be dropped after the auction.
      *
-     * @param {SyncOptions} syncOptions An object describing which user sync types are allowed.
-     * @param {ServerResponse[]} serverResponses An array of all the responses from the server.
-     * @return {UserSync[]} An array of user syncs which prebid should add to the page.
+     * @param {SyncOptions} syncOptions Which user syncs are allowed?
+     * @param {ServerResponse[]} serverResponses List of server's responses.
+     * @return {UserSync[]} The user syncs which should be dropped.
      */
     getUserSyncs: function(syncOptions, serverResponses) {
         if (syncOptions.iframeEnabled && serverResponses.length > 0) {

--- a/dev-docs/bidder-adapter-1.md
+++ b/dev-docs/bidder-adapter-1.md
@@ -288,15 +288,20 @@ All user ID sync activity must be done in one of two ways:
 
 {
     getUserSyncs: function(syncOptions, serverResponses) {
-        if (syncOptions.iframeEnabled && serverResponses.length > 0) {
-            return [{
+        const syncs = []
+        if (syncOptions.iframeEnabled) {
+            syncs.push({
                 type: 'iframe',
                 url: '//acdn.adnxs.com/ib/static/usersync/v3/async_usersync.html'
-            }, {
-                type: 'iframe',
-                url: serverResponses[0].body.userSync.url
-            }];
+            });
         }
+        if (syncOptions.pixelEnabled && serverResponses.length > 0) {
+            syncs.push({
+                type: 'image',
+                url: serverResponses[0].body.userSync.url
+            });
+        }
+        return syncs;
     }
 }
 
@@ -477,15 +482,20 @@ export const spec = {
      * @return {UserSync[]} The user syncs which should be dropped.
      */
     getUserSyncs: function(syncOptions, serverResponses) {
-        if (syncOptions.iframeEnabled && serverResponses.length > 0) {
-            return [{
+        const syncs = []
+        if (syncOptions.iframeEnabled) {
+            syncs.push({
                 type: 'iframe',
-                url: 'ADAPTER_SYNC_URL'
-            }, {
-                type: 'iframe',
-                url: serverResponses[0].body.userSync.url
-            }];
+                url: '//acdn.adnxs.com/ib/static/usersync/v3/async_usersync.html'
+            });
         }
+        if (syncOptions.pixelEnabled && serverResponses.length > 0) {
+            syncs.push({
+                type: 'image',
+                url: serverResponses[0].body.userSync.url
+            });
+        }
+        return syncs;
     }
 }
 registerBidder(spec);

--- a/dev-docs/bidder-adapter-1.md
+++ b/dev-docs/bidder-adapter-1.md
@@ -233,6 +233,10 @@ The `interpretResponse` function will be called when the browser has received th
     // if the bid response was empty or an error, return []
     // otherwise parse the response and return a bidReponses array
 
+    // The response body and headers can be retrieved like this:
+    //
+    // const serverBody = serverResponse.body;
+    // const headerValue = serverResponse.headers.get('some-response-header')
     const bidResponses = [];
     const bidResponse = {
         requestId: bidRequest.bidId,
@@ -437,12 +441,13 @@ export const spec = {
         /**
          * Unpack the response from the server into a list of bids.
          *
-         * @param {*} serverResponse A successful response from the server.
+         * @param {ServerResponse} serverResponse A successful response from the server.
          * @return {Bid[]} An array of bids which were nested inside the server.
          */
         interpretResponse: function(serverResponse, bidRequest) {
+            // const serverBody = serverResponse.body;
+            // const headerValue = serverResponse.headers.get('some-response-header')
             const bidResponses = [];
-            // loop through serverResponses {
             const bidResponse = {
                 requestId: bidRequest.bidId,
                 cpm: CPM,

--- a/dev-docs/bidder-adapter-1.md
+++ b/dev-docs/bidder-adapter-1.md
@@ -468,6 +468,14 @@ export const spec = {
         };
         return bidResponses;
     },
+    
+    /**
+     * Register the user sync pixels which should be dropped after the auction.
+     *
+     * @param {SyncOptions} syncOptions An object describing which user sync types are allowed.
+     * @param {ServerResponse[]} serverResponses An array of all the responses from the server.
+     * @return {UserSync[]} An array of user syncs which prebid should add to the page.
+     */
     getUserSyncs: function(syncOptions, serverResponses) {
         if (syncOptions.iframeEnabled && serverResponses.length > 0) {
             return [{

--- a/dev-docs/bidder-adapter-1.md
+++ b/dev-docs/bidder-adapter-1.md
@@ -293,7 +293,7 @@ All user ID sync activity must be done in one of two ways:
                 type: 'iframe',
                 url: '//acdn.adnxs.com/ib/static/usersync/v3/async_usersync.html'
             }, {
-                type: 'image',
+                type: 'iframe',
                 url: serverResponses[0].body.userSync.url
             }];
         }
@@ -469,10 +469,13 @@ export const spec = {
         return bidResponses;
     },
     getUserSyncs: function(syncOptions, serverResponses) {
-        if (syncOptions.iframeEnabled) {
+        if (syncOptions.iframeEnabled && serverResponses.length > 0) {
             return [{
                 type: 'iframe',
                 url: 'ADAPTER_SYNC_URL'
+            }, {
+                type: 'iframe',
+                url: serverResponses[0].body.userSync.url
             }];
         }
     }

--- a/dev-docs/bidder-adapter-1.md
+++ b/dev-docs/bidder-adapter-1.md
@@ -231,7 +231,7 @@ The `interpretResponse` function will be called when the browser has received th
 {% highlight js %}
 
     // if the bid response was empty or an error, return []
-    // otherwise parse the response and return a bidReponses array
+    // otherwise parse the response and return a bidResponses array
 
     // The response body and headers can be retrieved like this:
     //

--- a/dev-docs/bidder-adapter-1.md
+++ b/dev-docs/bidder-adapter-1.md
@@ -289,13 +289,12 @@ All user ID sync activity must be done in one of two ways:
 {
     getUserSyncs: function(syncOptions, serverResponses) {
         if (syncOptions.iframeEnabled && serverResponses.length > 0) {
-            const syncFromServer = serverResponses[0].body.userSync
             return [{
                 type: 'iframe',
                 url: '//acdn.adnxs.com/ib/static/usersync/v3/async_usersync.html'
             }, {
-                type: 'url',
-                url: syncFromServer.url
+                type: 'image',
+                url: serverResponses[0].body.userSync.url
             }];
         }
     }


### PR DESCRIPTION
When looking over https://github.com/prebid/Prebid.js/pull/1722, I realized that https://github.com/prebid/Prebid.js/pull/1748 also changed the `getUserSyncs` format.

When I went to update them in the docs here, I found that we never actually mentioned that param at all. This addresses that.
