### PR TITLE
VIDNY-244. Not skippable video will be targeted on iOS.

### DIFF
--- a/examples/video/bc-demo.html
+++ b/examples/video/bc-demo.html
@@ -14,6 +14,7 @@
     <script>
      var pbjs = pbjs || {};
      pbjs.que = pbjs.que || [];
+     iosDevice = !!navigator.platform.match(/iPhone|iPod|iPad/);
 
      /* PRE-DEFINE `invokeVideoPlayer`
 
@@ -49,7 +50,7 @@
          {
            bidder: 'appnexusAst',
            params: {
-             placementId: '9333431', // Add your own placement id here
+             placementId:  iosDevice ? '12349520':'9333431', // Add your own placement id here. Note, skippable video is not supported on iOS 
              video: {
                skipppable: true,
                playback_method: ['auto_play_sound_off']

--- a/examples/video/ooyala-demo.html
+++ b/examples/video/ooyala-demo.html
@@ -37,6 +37,7 @@
     <script>
      var pbjs = pbjs || {};
      pbjs.que = pbjs.que || [];
+     iosDevice = !!navigator.platform.match(/iPhone|iPod|iPad/);
      console.log("|||| Start of prebid: " + performance.now());
 
      /* PRE-DEFINE `invokeVideoPlayer`
@@ -71,7 +72,7 @@
          {
            bidder: 'appnexusAst',
            params: {
-             placementId: '9333431', // Add your own placement id here
+             placementId: iosDevice ? '12349520':'9333431', // Add your own placement id here. Note, skippable video is not supported on iOS 
              video: {
                skippable: true,
                playback_method: ['auto_play_sound_off']


### PR DESCRIPTION
Skippable videos are not supported in IMA3 SDK on iPhone devices. A logic to play either skippabe or not skippable video added to demo html depend on the client device.