### PR TITLE
VIDNY-261. Updated version of the videojs in html's href.

### DIFF
--- a/examples/video/videojs-demo.html
+++ b/examples/video/videojs-demo.html
@@ -14,8 +14,9 @@
      -->
 
   <!-- videojs -->
-  <link rel="stylesheet" href="http://vjs.zencdn.net/5.9.2/video-js.css">
-  <script type="text/javascript" src="http://vjs.zencdn.net/5.9.2/video.js"></script>
+  <!-- use recent version of videojs to ensure proper functioning with the iOS devices -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/video.js/6.4.0/video-js.css">
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/video.js/6.4.0/video.js"></script>
 
   <!-- videojs-vast-vpaid -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/videojs-vast-vpaid/2.0.2/videojs.vast.vpaid.min.css" rel="stylesheet">


### PR DESCRIPTION
Many fixes happened since 5.9.x in videojs in particular for iOS support:
https://github.com/wikimedia/mediawiki-extensions-TimedMediaHandler/commit/69c91c59fb4034a55d8aa6cbc41fe7c285b8ae13

Updated version of the videojs script from 5.9.2 to 6.4.0 in the html... that fixed issue.