### PR TITLE
Update Links for Analytics Page

### DIFF
--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -21,7 +21,7 @@ There are several analytics adapter plugins available to track header bidding pe
 | PulsePoint                                                       | Contact vendor                                                                      | [Website](https://www.pulsepoint.com/header-bidding.html)        |               |
 | ShareThrough                                                     | Contact vendor                                                                      |                                                                  |               |
 | PrebidAnalytics by Roxot                                         | Paid, see [pricing](http://prebidanalytics.com/#pricing). | [Website](http://prebidanalytics.com/overview-examples)          |          0.22 |
-| PubWise                                                          | Free & Paid, see [terms](http://admin.pubwise.io/terms)                                    | [Website](https://pubwise.io/)                                   |          0.24 |
+| PubWise                                                          | Free & Paid, see [pricing](https://pubwise.io/pricing/)                                    | [Website](https://pubwise.io/pubwise/)                                   |          0.24 |
 
 None of these analytics options are endorsed or supported by Prebid.org.
 

--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -21,7 +21,7 @@ There are several analytics adapter plugins available to track header bidding pe
 | PulsePoint                                                       | Contact vendor                                                                      | [Website](https://www.pulsepoint.com/header-bidding.html)        |               |
 | ShareThrough                                                     | Contact vendor                                                                      |                                                                  |               |
 | PrebidAnalytics by Roxot                                         | Paid, see [pricing](http://prebidanalytics.com/#pricing). | [Website](http://prebidanalytics.com/overview-examples)          |          0.22 |
-| PubWise                                                          | Free, see [terms](http://admin.pubwise.io/terms)                                    | [Website](https://pubwise.io/)                                   |          0.24 |
+| PubWise                                                          | Free & Paid, see [terms](http://admin.pubwise.io/terms)                                    | [Website](https://pubwise.io/)                                   |          0.24 |
 
 None of these analytics options are endorsed or supported by Prebid.org.
 


### PR DESCRIPTION
A refresh of links for preferred pages. The pricing page at this moment is basically empty, but will have content by the time this is released on the Prebid.org site. The content will only be a description of pricing structure and high level terms.