### PR TITLE
Fix analytic note formatting

### DIFF
--- a/dev-docs/integrate-with-the-prebid-analytics-api.md
+++ b/dev-docs/integrate-with-the-prebid-analytics-api.md
@@ -125,6 +125,7 @@ There are two breaking changes to the data emitted from analytic events for Preb
 1. Events that previously emitted a `requestId` property now emit that data as the `auctionId` property  
 2. The `BID_TIMEOUT` event that previously emitted an array of bidder code strings now emits an array of objects containing `bidId`, `bidder`, `adUnitCode`, and `auctionId` for timed out bids  
 
+
 1. Create a JS file under `modules` with the name of the bidder suffixed with 'AnalyticsAdapter', e.g., `exAnalyticsAdapter.js`
 
 2. Create an analytics adapter to listen for Prebid events and call the analytics library or server. See the existing *AnalyticsAdapter.js files in the repo under [modules](https://github.com/prebid/Prebid.js/tree/master/modules).


### PR DESCRIPTION
@rmloveland On http://prebid.org/dev-docs/integrate-with-the-prebid-analytics-api.html it looks like I didn't get the formatting quite right for the analytics 1.0 note because the two points aren't inside the warning box. Added a blank line which I think separates two lists in markdown, hoping this fixes it