### PR TITLE
all video examples use tempTag and not dynamicTag

### DIFF
--- a/examples/video/jwPlatformPrebidDemo.html
+++ b/examples/video/jwPlatformPrebidDemo.html
@@ -12,9 +12,9 @@
     pbjs.que = pbjs.que || [];
 
     // define invokeVideoPlayer in advance in case we get the bids back from prebid before the entire page loads
-    var dynamicTag = false;
+    var tempTag = false;
     var invokeVideoPlayer = function(url){
-      dynamicTag = url;
+      tempTag = url;
     }
 
     /*
@@ -134,9 +134,9 @@
       });
     }
 
-    if (dynamicTag) {
-        invokeVideoPlayer(dynamicTag);
-        dynamicTag = false;
+    if (tempTag) {
+        invokeVideoPlayer(tempTag);
+        tempTag = false;
     }
   </script>
 </body>

--- a/examples/video/klt-demo.html
+++ b/examples/video/klt-demo.html
@@ -24,9 +24,9 @@
         In this first version it simply stores the winning VAST to use
         later. */
 
-	 var dynamicTag = false;
+	 var tempTag = false;
 	 var invokeVideoPlayer = function(url){
-	   dynamicTag = url;
+	   tempTag = url;
 	 }
 
 	 /* Prebid video ad unit */
@@ -184,9 +184,9 @@
         meaning the 'real' version of `invokeVideoPlayer` was already
         called. */
 
-	 if (dynamicTag) {
-	   invokeVideoPlayer(dynamicTag);
-	   dynamicTag = false;
+	 if (tempTag) {
+	   invokeVideoPlayer(tempTag);
+	   tempTag = false;
 	 }
 	</script>
   </body>

--- a/examples/video/ooyala-demo.html
+++ b/examples/video/ooyala-demo.html
@@ -53,9 +53,9 @@
         ad. In this first version it simply stores the winning VAST to
         use later.  */
 
-     var dynamicTag = false;
+     var tempTag = false;
      var invokeVideoPlayer = function(url){
-       dynamicTag = url;
+       tempTag = url;
      }
 
      /* Prebid video ad unit */
@@ -236,9 +236,9 @@
         the "real" version of `invokeVideoPlayer` was already called.
       */
 
-     if (dynamicTag) {
-       invokeVideoPlayer(dynamicTag);
-       dynamicTag = false;
+     if (tempTag) {
+       invokeVideoPlayer(tempTag);
+       tempTag = false;
      }
     </script>
   </body>


### PR DESCRIPTION
This also fixes a bug that currently exists in the Kaltura demo.