### PR TITLE
Prebid Server dev docs updated per 1.0 changes

### DIFF
--- a/dev-docs/bidders/prebidServer.md
+++ b/dev-docs/bidders/prebidServer.md
@@ -34,12 +34,12 @@ Configuration options
 {: .table .table-bordered .table-striped }
 | Field        | Type          | Required? | Description                                                              |
 |--------------+---------------+-----------+--------------------------------------------------------------------------|
-| `accountId`  | String        | X         | Prebid Server account ID                                                 |
-| `enabled`    | Boolean       | X         | Enables S2S; default: `false`                                            |
-| `bidders`    | Array[String] | X         | List of bidder codes; must have been enabled during Prebid.js build      |
+| `accountId`  | String        | X         | Prebid Server account ID.                                                |
+| `enabled`    | Boolean       | X         | Enables S2S; default: `false`.                                           |
+| `bidders`    | Array[String] | X         | List of bidder codes; must have been enabled during Prebid.js build.     |
 | `endpoint`   | String        | X         | Set the endpoint. For example: `https://prebid.adnxs.com/pbs/v1/auction` |
-| `timeout`    | Number        |           | Bidder timeout, in milliseconds; default: `1000`                         |
-| `syncEndpoint` | String     |           | Configures the user-sync endpoint. Highly recommended                     |
-| `adapter`    | String        |           | Adapter code; default: `"prebidServer"`                                  |
-| `cookieSet`  | Boolean       |           | Set to `false` to opt out of cookieset/link rewriting; default: `true`   |
+| `timeout`    | Number        |           | Bidder timeout, in milliseconds; default: `1000`.                         |
+| `syncEndpoint` | String     |           | Configures the user-sync endpoint. Highly recommended.                    |
+| `adapter`    | String        |           | Adapter code; default: `"prebidServer"`.                                  |
+| `cookieSet`  | Boolean       |           | Set to `false` to opt out of cookieset/link rewriting; default: `true`.   |
 | `secure`     | Integer       |           | Override Prebid Server's determination of whether the request needs secure assets. Set to `1` to force secure assets on the response, or `0` for non-secure assets. |

--- a/dev-docs/bidders/prebidServer.md
+++ b/dev-docs/bidders/prebidServer.md
@@ -32,11 +32,14 @@ pbjs.setS2SConfig({
 Configuration options
 
 {: .table .table-bordered .table-striped }
-| Name | Required? | Description
-|:-----------|:-----------|:---------------------------|
-| `accountId` | required | string:required: account ID obtained in sign up process |
-| `enabled` | required | boolean:required: enables s2s - default false |
-| `bidders` | required | array[string]:required: of bidder codes to enable S2S. |
-| `syncEndpoint` | optional | string:optional sets user-sync endpoint. |
-| `timeout` | optional | number:optional timeout in ms for bidders called via the S2S endpoint.|
-| `cookieSet` | optional | boolean:optional: If `false` (not recommended), opt out of link rewriting to improve cookie syncing. |
+| Field        | Type          | Required? | Description                                                              |
+|--------------+---------------+-----------+--------------------------------------------------------------------------|
+| `accountId`  | String        | X         | Prebid Server account ID                                                 |
+| `enabled`    | Boolean       | X         | Enables S2S; default: `false`                                            |
+| `bidders`    | Array[String] | X         | List of bidder codes; must have been enabled during Prebid.js build      |
+| `endpoint`   | String        | X         | Set the endpoint. For example: `https://prebid.adnxs.com/pbs/v1/auction` |
+| `timeout`    | Number        |           | Bidder timeout, in milliseconds; default: `1000`                         |
+| `syncEndpoint` | String     |           | Configures the user-sync endpoint. Highly recommended                     |
+| `adapter`    | String        |           | Adapter code; default: `"prebidServer"`                                  |
+| `cookieSet`  | Boolean       |           | Set to `false` to opt out of cookieset/link rewriting; default: `true`   |
+| `secure`     | Integer       |           | Override Prebid Server's determination of whether the request needs secure assets. Set to `1` to force secure assets on the response, or `0` for non-secure assets. |

--- a/dev-docs/get-started-with-prebid-server.md
+++ b/dev-docs/get-started-with-prebid-server.md
@@ -94,7 +94,7 @@ pbjs.que.push(function() {
 
 ### The `s2sConfig` object
 
-See [Prebid Server adapter docs]({{site.baseurl}}/dev-docs/add-a-prebid-server-adapter.html) for a list of the fields in the `s2sConfig` object:
+See the [Prebid Server adapter docs]({{site.baseurl}}/dev-docs/add-a-prebid-server-adapter.html) for a list of the fields in the `s2sConfig` object.
 
 
 {: .alert.alert-info :}

--- a/dev-docs/get-started-with-prebid-server.md
+++ b/dev-docs/get-started-with-prebid-server.md
@@ -94,20 +94,8 @@ pbjs.que.push(function() {
 
 ### The `s2sConfig` object
 
-See below for a list of the fields in the `s2sConfig` object:
+See [Prebid Server adapter docs]({{site.baseurl}}/dev-docs/add-a-prebid-server-adapter.html) for a list of the fields in the `s2sConfig` object:
 
-{: .table .table-bordered .table-striped }
-| Field       | Type          | Required? | Description                                                            |
-|-------------+---------------+-----------+------------------------------------------------------------------------|
-| `accountId` | String        | X         | Prebid Server account ID                                               |
-| `enabled`   | Boolean       | X         | Enables S2S; default: `false`                                          |
-| `bidders`   | Array[String] | X         | List of bidder codes; must have been enabled during Prebid.js build    |
-| `timeout`   | Number        |           | Bidder timeout, in milliseconds; default: `1000`                       |
-| `syncEndpoint` | String     |           | Configures the user-sync endpoint. Highly recommended                  |
-| `adapter`   | String        |           | Adapter code; default: `"prebidServer"`                                |
-| `endpoint`  | String        |           | Will override the default endpoint                                     |
-| `cookieSet` | Boolean       |           | Set to `false` to opt out of cookieset/link rewriting; default: `true` |
-| `secure`    | Integer       |           | Override Prebid Server's determination of whether the request needs secure assets. Set to `1` to force secure assets on the response, or `0` for non-secure assets. |
 
 {: .alert.alert-info :}
 **Additional `cookieSet` details**  


### PR DESCRIPTION
These are changes per new 1.0 requirements, specifically the `endpoint` url no longer has a default value and needs to be specified. 

Also added a link since we had duplicate information. 