### PR TITLE
Added modules to download page

### DIFF
--- a/dev-docs/modules/currency.md
+++ b/dev-docs/modules/currency.md
@@ -4,6 +4,8 @@ title: Module - Currency
 description: Converts bids to the ad server currency
 top_nav_section: dev_docs
 nav_section: modules
+module_code : currency
+display_name : Currency
 ---
 
 <div class="bs-docs-section" markdown="1">

--- a/dev-docs/modules/dfp_express.md
+++ b/dev-docs/modules/dfp_express.md
@@ -4,6 +4,8 @@ title: Module - DFP Express
 description: Simplified installation mechanism for publishers that have DFP in their pages
 top_nav_section: dev_docs
 nav_section: modules
+module_code : express
+display_name : DFP Express
 ---
 
 <div class="bs-docs-section" markdown="1">

--- a/dev-docs/modules/dfp_video.md
+++ b/dev-docs/modules/dfp_video.md
@@ -1,36 +1,33 @@
 ---
 layout: page
-title: Module - Dfp Video
+title: Module - DFP Video
 description: Addition of DFP Video to the Prebid package
 top_nav_section: dev_docs
 nav_section: modules
 module_code : dfpAdServerVideo
-display_name : Dfp Video
+display_name : DFP Video
 ---
 
 <div class="bs-docs-section" markdown="1">
 
-# DFP Video Module
+# DFP Video
 {:.no_toc}
 
-This module is required to use the Prebid Instream video examples with DFP Adserver.
-
-## Instructions for adding Dfp Video code to a Prebid package
+This module is required to use the Prebid Instream video examples with DFP Adserver. For instructions showing how to add this module to Prebid.js, see below.
 
 ### Step 1:  Prepare the base Prebid file as usual
 
 The standard options:
 
 - Build from a locally-cloned git repo 
-- Receive the email package from the Prebid [Download](http://prebid.org/download.html) page
+- Receive the email package from the Prebid [Download]({{site.baseurl}}/download.html) page
  
 ### Step 2: Integrate into your prebid.js configuration
 
-The method exposes the `pbjs.adServers.dfp.buildVideoUrl` method to use. See the Show Video Ads with DFP guide link below for a full example. 
-
+The method exposes the [`pbjs.adServers.dfp.buildVideoUrl`]({{site.baseurl}}/dev-docs/publisher-api-reference.html#module_pbjs.adServers.dfp.buildVideoUrl) method to use. For an example, see the DFP video guide linked below.
 
 ## Further Reading
 
-+ [Show Video Ads with DFP guide](http://prebid.org/dev-docs/show-video-with-a-dfp-video-tag.html)
++ [Show Video Ads with DFP]({{site.baseurl}}/dev-docs/show-video-with-a-dfp-video-tag.html)
 
 </div>

--- a/dev-docs/modules/dfp_video.md
+++ b/dev-docs/modules/dfp_video.md
@@ -1,0 +1,36 @@
+---
+layout: page
+title: Module - Dfp Video
+description: Addition of DFP Video to the Prebid package
+top_nav_section: dev_docs
+nav_section: modules
+module_code : dfpAdServerVideo
+display_name : Dfp Video
+---
+
+<div class="bs-docs-section" markdown="1">
+
+# DFP Video Module
+{:.no_toc}
+
+This module is required to use the Prebid Instream video examples with DFP Adserver.
+
+## Instructions for adding Dfp Video code to a Prebid package
+
+### Step 1:  Prepare the base Prebid file as usual
+
+The standard options:
+
+- Build from a locally-cloned git repo 
+- Receive the email package from the Prebid [Download](http://prebid.org/download.html) page
+ 
+### Step 2: Integrate into your prebid.js configuration
+
+The method exposes the `pbjs.adServers.dfp.buildVideoUrl` method to use. See the Show Video Ads with DFP guide link below for a full example. 
+
+
+## Further Reading
+
++ [Show Video Ads with DFP guide](http://prebid.org/dev-docs/show-video-with-a-dfp-video-tag.html)
+
+</div>

--- a/dev-docs/modules/digitrust.md
+++ b/dev-docs/modules/digitrust.md
@@ -4,6 +4,8 @@ title: Module - DigiTrust
 description: Addition of DigiTrust to the Prebid package
 top_nav_section: dev_docs
 nav_section: modules
+module_code : digitTrust
+display_name : DigiTrust
 ---
 
 <div class="bs-docs-section" markdown="1">

--- a/dev-docs/modules/index.md
+++ b/dev-docs/modules/index.md
@@ -37,6 +37,7 @@ If you are looking for bidder adapter parameters, see [Bidders' Params]({{site.b
 | [**DFP Express**]({{site.baseurl}}/dev-docs/modules/dfp_express.html) | A simplified installation mechanism for publishers that have DoubleClick Google Publisher Tag (GPT) ad calls in their pages. |
 | [**DigiTrust**]({{site.baseurl}}/dev-docs/modules/digitrust.html) | A method of including the standard cross-domain ID in a DigiTrust package. |
 | [**Server-to-Server Testing**]({{site.baseurl}}/dev-docs/modules/s2sTesting.html) | Adds A/B test support for easing into server-side header bidding. |
+| [**DFP Video**]({{site.baseurl}}/dev-docs/modules/dfp_video.html) | Required for serving instream video through DFP |
 
 ## Further Reading
 

--- a/dev-docs/modules/index.md
+++ b/dev-docs/modules/index.md
@@ -37,7 +37,7 @@ If you are looking for bidder adapter parameters, see [Bidders' Params]({{site.b
 | [**DFP Express**]({{site.baseurl}}/dev-docs/modules/dfp_express.html) | A simplified installation mechanism for publishers that have DoubleClick Google Publisher Tag (GPT) ad calls in their pages. |
 | [**DigiTrust**]({{site.baseurl}}/dev-docs/modules/digitrust.html) | A method of including the standard cross-domain ID in a DigiTrust package. |
 | [**Server-to-Server Testing**]({{site.baseurl}}/dev-docs/modules/s2sTesting.html) | Adds A/B test support for easing into server-side header bidding. |
-| [**DFP Video**]({{site.baseurl}}/dev-docs/modules/dfp_video.html) | Required for serving instream video through DFP |
+| [**DFP Video**]({{site.baseurl}}/dev-docs/modules/dfp_video.html) | Required for serving instream video through DFP. |
 
 ## Further Reading
 

--- a/dev-docs/modules/s2sTesting.md
+++ b/dev-docs/modules/s2sTesting.md
@@ -4,6 +4,8 @@ title: Module - Prebid Server Testing
 description: Adds A/B test support to ease analysis of server-side header bidding
 top_nav_section: dev_docs
 nav_section: modules
+module_code : s2sTesting
+display_name : Prebid Server Testing
 ---
 
 <div class="bs-docs-section" markdown="1">

--- a/dev-docs/modules/s2sTesting.md
+++ b/dev-docs/modules/s2sTesting.md
@@ -1,11 +1,11 @@
 ---
 layout: page
-title: Module - Prebid Server Testing
+title: Module - Server-to-Server Testing
 description: Adds A/B test support to ease analysis of server-side header bidding
 top_nav_section: dev_docs
 nav_section: modules
 module_code : s2sTesting
-display_name : Prebid Server Testing
+display_name : Server-to-Server Testing
 ---
 
 <div class="bs-docs-section" markdown="1">
@@ -21,20 +21,20 @@ additional options for controlling how requests are sent:
 * Global A/B control - defines what percent of requests should be satisfied via the server and which by the traditional client-based method. This is cross AdUnit-configuration.
 * AdUnit A/B control - the ratio of server-to-client requests can be overridden at the AdUnit level.
 
-The package is built by specifying the s2sTesting module on the build command. For example:
+The package is built by specifying the `s2sTesting` module on the build command. For example:
 
 ```
 gulp build --modules=rubiconBidAdapter,appnexusAstBidAdapter,prebidServerBidAdapter,s2sTesting
 ```
 
-The expectation is the s2sTesting module will used for a limited period.
+The expectation is the Server-to-Server Testing module will used for a limited period.
 During the test period, the publisher analyzes metrics from various places
 to gauge the impact of moving header bidding to the server. After the test
 period is complete, regardless of outcome, A/B testing would be turned off
 and this module no longer included in the PrebidJS build.
 
 ## Features
-With the s2sTesting module, the following enhancements are provided:
+With the Server-to-Server Testing module, the following enhancements are provided:
 
 New 'bidderControl' options in s2sConfig. E.g.
 

--- a/download.md
+++ b/download.md
@@ -76,7 +76,7 @@ function get_form_data() {
     for (var i = 0; i < bidder_check_boxes.length; i++) {
         var box = bidder_check_boxes[i];
         if (box.checked) {
-            bidders.push(box.getAttribute('bidderCode'));
+            bidders.push(box.getAttribute('moduleCode'));
         }
     }
 
@@ -116,6 +116,7 @@ To improve the speed and load time of your site, build Prebid.js for only the he
 ### Option 1: Select header bidding partners
 
 {% assign bidder_pages = (site.pages | where: "layout", "bidder") %}
+{% assign module_pages = (site.pages | where: "nav_section", "modules") %}
 
 <form>
 <div class="row">
@@ -129,9 +130,9 @@ To improve the speed and load time of your site, build Prebid.js for only the he
  <div class="checkbox">
   <label>
   {% if page.aliasCode %} 
-    <input type="checkbox" bidderCode="{{ page.aliasCode }}" class="bidder-check-box"> {{ page.title }}
+    <input type="checkbox" moduleCode="{{ page.aliasCode }}BidAdapter" class="bidder-check-box"> {{ page.title }}
   {% else %}
-    <input type="checkbox" bidderCode="{{ page.biddercode }}" class="bidder-check-box"> {{ page.title }}
+    <input type="checkbox" moduleCode="{{ page.biddercode }}BidAdapter" class="bidder-check-box"> {{ page.title }}
   {% endif %}
       
     </label>
@@ -210,6 +211,18 @@ To improve the speed and load time of your site, build Prebid.js for only the he
 
 </div>
 <br/>
+<div class="row">
+ <h4>Modules</h4>
+ {% for page in module_pages %}
+ <div class="col-md-4">
+ <div class="checkbox">
+  <label> <input type="checkbox" moduleCode="{{ page.module_code }}" class="bidder-check-box"> {{ page.display_name }}</label>
+</div>
+</div>
+ {% endfor %}
+</div>
+
+<br>
 <p>
 (Version 0.33.0)
 </p>


### PR DESCRIPTION
This adds an option for bundling modules when you compile prebid.js

Note: This needs a corresponding change on the download endpoint. Please don't merge directly