### PR TITLE
Update prebid cache usage to follow 1.0

### DIFF
--- a/dev-docs/show-video-with-a-dfp-video-tag.md
+++ b/dev-docs/show-video-with-a-dfp-video-tag.md
@@ -97,7 +97,10 @@ pbjs.que.push(function() {
     pbjs.addAdUnits(videoAdUnit);
 
     pbjs.setConfig({
-        usePrebidCache: true
+        /* Or whatever your preferred video cache URL is */
+        cache: {
+            url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        }
     });
 
     pbjs.requestBids({


### PR DESCRIPTION
This PR addresses https://github.com/prebid/prebid.github.io/issues/482

However, it cannot be merged unless/until we update the Prebid.js version that is on the CDN at 

https://acdn.adnxs.com/prebid/not-for-prod/prebid.js

to 1.0

(Unless there is another CDN URL we are using for 1.0, and we're leaving that one pre-1.0 for now, in which case I will update this PR to use the new URL.)