### PR TITLE
Add index files to hosted examples

### DIFF
--- a/dev-docs/show-native-ads.md
+++ b/dev-docs/show-native-ads.md
@@ -195,6 +195,7 @@ A native `image` ad unit can be set up in the manner below:
 ## Working Examples
 
 + [Prebid Native with two slots]({{site.github.url}}/examples/native/native-demo.html)
++ [Prebid Native Examples]({{site.github.url}}/examples/native)
 
 ## Related Topics
 

--- a/dev-docs/show-outstream-video-ads.md
+++ b/dev-docs/show-outstream-video-ads.md
@@ -166,6 +166,7 @@ Below, find links to end-to-end "working examples" demonstrating Prebid Outstrea
 
 + [Outstream with two adapters]({{site.github.url}}/examples/video/outstream/outstream-dfp-two-adapters-demo.html)
 + [Outstream without an Ad Server]({{site.github.url}}/examples/video/outstream/outstream-no-adserver-demo.html)
++ [Prebid Video Examples]({{site.github.url}}/examples/video)
 
 ## Related Topics
 

--- a/dev-docs/show-video-with-a-dfp-video-tag.md
+++ b/dev-docs/show-video-with-a-dfp-video-tag.md
@@ -173,6 +173,7 @@ Below, find links to end-to-end "working examples" integrating Prebid.js demand 
 + [Brightcove]({{site.github.url}}/examples/video/bc-demo.html)
 + [Kaltura]({{site.github.url}}/examples/video/klt-demo.html)
 + [Ooyala]({{site.github.url}}/examples/video/ooyala-demo.html)
++ [Prebid Video Examples]({{site.github.url}}/examples/video)
 
 ## Related Topics
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,10 +1,10 @@
-<h1>Prebid Hosted Examples</h1>
+<h1>Prebid.org Hosted Examples</h1>
 
 <ul>
   <li>
-    <a href="./video/index.html">Video</a>
+    <a href="./video/index.html">Prebid Video</a>
   </li>
     <li>
-    <a href="./native/index.html">Native</a>
+    <a href="./native/index.html">Prebid Native</a>
   </li>
 </ul>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,10 @@
+<h1>Prebid Hosted Examples</h1>
+
+<ul>
+  <li>
+    <a href="./video/index.html">Video</a>
+  </li>
+    <li>
+    <a href="./native/index.html">Native</a>
+  </li>
+</ul>

--- a/examples/native/index.html
+++ b/examples/native/index.html
@@ -1,0 +1,9 @@
+<h1>Prebid Native Examples</h1>
+
+<ul>
+  <li>
+    <a href="native-demo.html">
+    Prebid Native with two slots
+    </a>
+  </li>
+</ul>

--- a/examples/native/index.html
+++ b/examples/native/index.html
@@ -2,8 +2,6 @@
 
 <ul>
   <li>
-    <a href="native-demo.html">
-    Prebid Native with two slots
-    </a>
+    <a href="native-demo.html">Prebid Native with two slots</a>
   </li>
 </ul>

--- a/examples/video/index.html
+++ b/examples/video/index.html
@@ -1,0 +1,66 @@
+<h1>Prebid Video Examples</h1>
+
+<h2>Instream</h2>
+
+<h3>Using Prebid.js (Client-side only)</h3>
+
+<ul>
+  <li>
+    <a href="bc-demo.html">Brightcove</a>
+  </li>
+  <li>
+    <a href="jwPlatformPrebidDemo.html">JW Player (Platform)</a>
+  </li>
+  <li>
+    <a href="jwPlayerPrebid.html">JW Player</a>
+  </li>
+  <li>
+    <a href="jwPlaylistUniqueAds.html">JW Player (Playlist)</a>
+  </li>
+  <li>
+    <a href="videojs-demo.html">VideoJS</a>
+  </li>
+  <li>
+    <a href="klt-demo.html">Kaltura</a>
+  </li>
+  <li>
+    <a href="ooyala-demo.html">Ooyala</a>
+  </li>
+</ul>
+
+<h3>Using Prebid.js with Prebid Server</h3>
+
+<ul>
+  <li>
+    <a href="jwplatform-pbserver-demo.html">JW Player (Platform)</a>
+  </li>
+  <li>
+    <a href="jwplayer-pbserver-demo.html">JW Player</a>
+  </li>
+  <li>
+    <a href="jwplayer7-pbserver-demo.html">JW Player (v7)</a>
+  </li>
+  <li>
+    <a href="jwplaylist-pbserver-demo.html">JW Player (Playlist)</a>
+  </li>
+  <li>
+    <a href="kaltura-pbserver-demo.html">Kaltura</a>
+  </li>
+  <li>
+    <a href="videojs-pbserver-demo.html">VideoJS</a>
+  </li>
+  <li>
+    <a href="ooyala-pbserver-demo.html">Ooyala</a>
+  </li>
+</ul>
+
+<h2>Outstream</h2>
+
+<ul>
+  <li>
+    <a href="outstream/outstream-dfp-two-adapters-demo.html">Prebid.js DFP Outstream with Two Adapters</a>
+  </li>
+  <li>
+    <a href="outstream/outstream-no-adserver-demo.html">Prebid.js DFP Outstream without Adserver</a>
+  </li>
+</ul>

--- a/examples/video/index.html
+++ b/examples/video/index.html
@@ -1,8 +1,8 @@
 <h1>Prebid Video Examples</h1>
 
-<h2>Instream</h2>
+<h2>Instream Video</h2>
 
-<h3>Using Prebid.js (Client-side only)</h3>
+<h3>Prebid.js (using only client-side adapters)</h3>
 
 <ul>
   <li>
@@ -28,7 +28,7 @@
   </li>
 </ul>
 
-<h3>Using Prebid.js with Prebid Server</h3>
+<h3>Prebid.js (using Prebid Server)</h3>
 
 <ul>
   <li>
@@ -54,7 +54,7 @@
   </li>
 </ul>
 
-<h2>Outstream</h2>
+<h2>Outstream Video</h2>
 
 <ul>
   <li>


### PR DESCRIPTION
This makes it easier for a reader to click through and see all of the
video/native/etc. examples in one place.