### PR TITLE
update exclude list in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -155,7 +155,7 @@ nav_sections:
 
 port: 8080
 
-exclude: ['README.md', 'LICENSE', 'bower.json', 'Gemfile.lock', 'Gemfile']
+exclude: ['README.md', 'LICENSE', 'bower.json', 'Gemfile.lock', 'Gemfile', 'vendor']
 
 gems:
   - jekyll-mentions


### PR DESCRIPTION
When running through the initial setup steps in the repo's README, I was encountering an error when attempting the run the server with the latest version of Jekyll 3.3.0.

This error was addressed by adding `vendor` to the exclude list in the `_config.yml` file.  Submitting this change so it's part of master and addresses this issue going forward.

See related issue #521.