### PR TITLE
update gitignore file 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Gemfile.lock
 /dist/jquery
 /.idea
 .DS_Store
+/vendor
+/.bundle


### PR DESCRIPTION
As a follow-up to the changes introduced through #522 & #523, I'd to submit this change to the .gitignore file to include to new directories that don't need to be tracked.  

These directories are made as a result of the `bundle install --path vendor/bundle` command and are not relevant to the master branch when doing commits.