### PR TITLE
Add multiformat docs: developers, ad ops, example code

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,6 +70,9 @@ nav_sections:
     code: quick-start
     name: DEVELOPER QUICK START
   - top_nav: dev_docs
+    code: prebid-multiformat
+    name: PREBID MULTI-FORMAT (ALPHA)
+  - top_nav: dev_docs
     code: prebid-video
     name: PREBID VIDEO (BETA)
   - top_nav: dev_docs

--- a/adops/setting-up-prebid-multiformat-in-dfp.md
+++ b/adops/setting-up-prebid-multiformat-in-dfp.md
@@ -16,7 +16,7 @@ nav_section: tutorials
 
 This page shows how to set up your ad server so that you can serve multiformat ads.
 
-Multiformat ads allow you to declare multiple media types on a single ad unit.  For example, you can set up one ad on the page that could show a banner, native, or video ad, depending on which had the highest bid.
+Multiformat ads allow you to declare multiple media types on a single ad unit.  For example, you can set up one ad on the page that could show a banner, native, or outstream video ad, depending on which had the highest bid.
 
 {: .alert.alert-info :}
 For instructions, on how to set up multiformat ads from the engineering side, see [Show Multiformat Ads with Prebid.js]({{site.baseurl}}/dev-docs/show-multiformat-ads.html).

--- a/adops/setting-up-prebid-multiformat-in-dfp.md
+++ b/adops/setting-up-prebid-multiformat-in-dfp.md
@@ -14,6 +14,30 @@ nav_section: tutorials
 # Setting up Prebid Multi-Format in DFP
 {: .no_toc}
 
+This page shows how to set up your ad server so that you can serve multi-format ads.
+
+Multi-format ads allow you to declare multiple media types on a single ad unit.  For example, you can set up one ad on the page that could show a banner, native, or video ad, depending on which had the highest bid.
+
+{: .alert.alert-info :}
+For instructions, on how to set up multi-format ads from the engineering side, see [Show Multi-Format Ads with Prebid.js]({{site.baseurl}}/dev-docs/show-multiformat-ads.html).
+
+* TOC
+{: toc }
+
+## Step 1. Add an Order
+
+## Step 2. Add a Line Item for each Media Type
+
+## Step 3. Add a Creative (<span style="color: rgb(255,0,0);">FIXME</span>: <strong>for each media type?</strong>)
+
+## Step 4. Attach Creatives to the Appropriate Line Items
+
+## Step 5. Duplicate Creatives
+
+## Step 6. Duplicate Line Items
+
+## Step 7. Create Orders for your other Demand Partners (Bidders)
+
 ## Related Topics
 
 + [Show Multi-Format Ads with Prebid.js]({{site.baseurl}}/dev-docs/show-multiformat-ads.html)

--- a/adops/setting-up-prebid-multiformat-in-dfp.md
+++ b/adops/setting-up-prebid-multiformat-in-dfp.md
@@ -26,20 +26,48 @@ For instructions, on how to set up multiformat ads from the engineering side, se
 
 ## Step 1. Add an Order
 
-## Step 2. Add a Line Item for each Media Type
+In DFP, create a new order for each of your header bidding partners.
 
-## Step 3. Add a Creative (<span style="color: rgb(255,0,0);">FIXME</span>: <strong>for each media type?</strong>)
+Repeat this step and step 2 when you are adding a new partner.
 
-## Step 4. Attach Creatives to the Appropriate Line Items
+## Step 2. Add Line Items and Creatives for each Media Type
 
-## Step 5. Duplicate Creatives
+Because of the way multiformat support works in Prebid.js, for each price bucket, you will need to set up line items for each of the following formats:
 
-## Step 6. Duplicate Line Items
++ One for [banner and outstream video][bannerAdSetup].  Banners and outstream videos will serve into a DFP banner creative.
 
-## Step 7. Create Orders for your other Demand Partners (Bidders)
++ One for [native][nativeAdSetup].  Native ads will serve into a native creative with native format and styles
+
+### Banner/Outstream
+
+Follow the instructions for creating line items and creatives in [Send all bids to the ad server][bannerAdSetup], with the following changes:
+
++ Add key-value targeting for the `hb_format` key: `video, banner`
+    + This will allow either banner or outstream video to serve
++ Make sure that you're targeting the right sizes for both banner ads and any outstream ads you want to serve in this slot, e.g.,
+    + 1x1 for outstream (or whatever size you pass into DFP as your outstream impression)
+    + whatever banner sizes are valid for your site / use case
+
+### Native
+
+Follow the instructions for creating line items, creatives, custom native formats, and native styles in [Show Native Ads][nativeAdSetup], with the following changes:
+
++ Add key-value targeting for the `hb_format` key: `native`
++ Make sure you're targeting the right sizes for the native ads you want to serve:
+    + Fixed-size native, where you specify the sizes
+    + Fluid, which expands to fit whatever space it's put in
+    + Either fluid or fixed-size can be created from the same [custom native format][createCustomNativeFormat]
+    + For more information on fluid vs. fixed, see [the DFP docs](https://support.google.com/dfp_premium/answer/6366914?hl=en)
 
 ## Related Topics
 
-+ [Show Multiformat Ads with Prebid.js]({{site.baseurl}}/dev-docs/show-multiformat-ads.html)
++ [Show Multiformat Ads with Prebid.js]({{site.baseurl}}/dev-docs/show-multiformat-ads.html) (Engineering setup)
++ [Multiformat Example]({{site.baseurl}}/dev-docs/examples/multiformat-example.html) (Example code)
 
 </div>
+
+<!-- Reference Links -->
+
+[bannerAdSetup]: {{site.baseurl}}/adops/send-all-bids-adops.html
+[nativeAdSetup]: {{site.baseurl}}/adops/setting-up-prebid-native-in-dfp.html
+[createCustomNativeFormat]: {{site.baseurl}}/adops/setting-up-prebid-native-in-dfp.html#create-a-custom-native-ad-format

--- a/adops/setting-up-prebid-multiformat-in-dfp.md
+++ b/adops/setting-up-prebid-multiformat-in-dfp.md
@@ -1,8 +1,8 @@
 ---
 layout: page
-title: Setting up Prebid Multi-Format in DFP
-head_title: Setting up Prebid Multi-Format in DFP
-description: Setting up Prebid Multi-Format in DFP
+title: Setting up Prebid Multiformat in DFP
+head_title: Setting up Prebid Multiformat in DFP
+description: Setting up Prebid Multiformat in DFP
 pid: 3
 hide: false
 top_nav_section: adops
@@ -11,15 +11,15 @@ nav_section: tutorials
 
 <div class="bs-docs-section" markdown="1">
 
-# Setting up Prebid Multi-Format in DFP
+# Setting up Prebid Multiformat in DFP
 {: .no_toc}
 
-This page shows how to set up your ad server so that you can serve multi-format ads.
+This page shows how to set up your ad server so that you can serve multiformat ads.
 
-Multi-format ads allow you to declare multiple media types on a single ad unit.  For example, you can set up one ad on the page that could show a banner, native, or video ad, depending on which had the highest bid.
+Multiformat ads allow you to declare multiple media types on a single ad unit.  For example, you can set up one ad on the page that could show a banner, native, or video ad, depending on which had the highest bid.
 
 {: .alert.alert-info :}
-For instructions, on how to set up multi-format ads from the engineering side, see [Show Multi-Format Ads with Prebid.js]({{site.baseurl}}/dev-docs/show-multiformat-ads.html).
+For instructions, on how to set up multiformat ads from the engineering side, see [Show Multiformat Ads with Prebid.js]({{site.baseurl}}/dev-docs/show-multiformat-ads.html).
 
 * TOC
 {: toc }
@@ -40,6 +40,6 @@ For instructions, on how to set up multi-format ads from the engineering side, s
 
 ## Related Topics
 
-+ [Show Multi-Format Ads with Prebid.js]({{site.baseurl}}/dev-docs/show-multiformat-ads.html)
++ [Show Multiformat Ads with Prebid.js]({{site.baseurl}}/dev-docs/show-multiformat-ads.html)
 
 </div>

--- a/adops/setting-up-prebid-multiformat-in-dfp.md
+++ b/adops/setting-up-prebid-multiformat-in-dfp.md
@@ -1,0 +1,21 @@
+---
+layout: page
+title: Setting up Prebid Multi-Format in DFP
+head_title: Setting up Prebid Multi-Format in DFP
+description: Setting up Prebid Multi-Format in DFP
+pid: 3
+hide: false
+top_nav_section: adops
+nav_section: tutorials
+---
+
+<div class="bs-docs-section" markdown="1">
+
+# Setting up Prebid Multi-Format in DFP
+{: .no_toc}
+
+## Related Topics
+
++ [Show Multi-Format Ads with Prebid.js]({{site.baseurl}}/dev-docs/show-multiformat-ads.html)
+
+</div>

--- a/dev-docs/docs-by-format.md
+++ b/dev-docs/docs-by-format.md
@@ -20,20 +20,20 @@ For ad ops and other ad server-related information, see [our Ad Ops documentatio
 {:toc}
 
 {: .table .table-bordered .table-striped }
-| Format              | Page                                                                                                                             |
-|---------------------+----------------------------------------------------------------------------------------------------------------------------------|
-| *Multi-Format*      | [Show Multi-Format Ads with Prebid.js]({{site.baseurl}}/dev-docs/show-multiformat-ads.html) (Engineering setup)                  |
-|                     | [Setting up Prebid Multi-Format in DFP]({{site.baseurl}}/adops/setting-up-prebid-multiformat-in-dfp.html) (Ad ops setup)         |
-| *AMP*               | [How Prebid on AMP Works]({{site.github.url}}/dev-docs/how-prebid-on-amp-works.html)                                             |
-|                     | [Show Prebid Ads on AMP Pages (Alpha)]({{site.github.url}}/dev-docs/show-prebid-ads-on-amp-pages.html)                           |
-| *Video* (instream)  | [Show Video Ads with a DFP Video Tag]({{site.github.url}}/dev-docs/show-video-with-a-dfp-video-tag.html) (With lots of examples) |
-|                     | [How to Add a New Video Bidder Adapter]({{site.github.url}}/dev-docs/how-to-add-a-new-video-bidder-adaptor.html)                 |
-| *Video* (outstream) | [Show Outstream Video Ads]({{site.github.url}}/dev-docs/show-outstream-video-ads.html)                                           |
-|                     | [Outstream Video Example]({{site.github.url}}/dev-docs/examples/outstream-video-example.html)                                    |
-| *Standard Display*  | [Basic Prebid.js Example]({{site.github.url}}/dev-docs/examples/basic-example.html)                                              |
-|                     | [Getting Started]({{site.github.url}}/dev-docs/getting-started.html)                                                             |
-|                     | [Ad Unit Refresh / Infinite Scroll Example]({{site.github.url}}/dev-docs/examples/adunit-refresh.html)                           |
-| *Native*            | [Show Native Ads with Prebid.js]({{site.github.url}}/dev-docs/show-native-ads.html) (Engineering setup)                          |
-|                     | [Setting up Prebid Native in DFP]({{site.github.url}}/adops/setting-up-prebid-native-in-dfp.html) (Ad Ops setup)                 |
+| Format                                                              | Page                                                                                                                             |
+|---------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------|
+| *Multi-Format (banner, native, outstream video all in one ad unit)* | [Show Multi-Format Ads with Prebid.js]({{site.baseurl}}/dev-docs/show-multiformat-ads.html) (Engineering setup)                  |
+|                                                                     | [Setting up Prebid Multi-Format in DFP]({{site.baseurl}}/adops/setting-up-prebid-multiformat-in-dfp.html) (Ad ops setup)         |
+| *AMP*                                                               | [How Prebid on AMP Works]({{site.github.url}}/dev-docs/how-prebid-on-amp-works.html)                                             |
+|                                                                     | [Show Prebid Ads on AMP Pages (Alpha)]({{site.github.url}}/dev-docs/show-prebid-ads-on-amp-pages.html)                           |
+| *Video* (instream)                                                  | [Show Video Ads with a DFP Video Tag]({{site.github.url}}/dev-docs/show-video-with-a-dfp-video-tag.html) (With lots of examples) |
+|                                                                     | [How to Add a New Video Bidder Adapter]({{site.github.url}}/dev-docs/how-to-add-a-new-video-bidder-adaptor.html)                 |
+| *Video* (outstream)                                                 | [Show Outstream Video Ads]({{site.github.url}}/dev-docs/show-outstream-video-ads.html)                                           |
+|                                                                     | [Outstream Video Example]({{site.github.url}}/dev-docs/examples/outstream-video-example.html)                                    |
+| *Standard Display*                                                  | [Basic Prebid.js Example]({{site.github.url}}/dev-docs/examples/basic-example.html)                                              |
+|                                                                     | [Getting Started]({{site.github.url}}/dev-docs/getting-started.html)                                                             |
+|                                                                     | [Ad Unit Refresh / Infinite Scroll Example]({{site.github.url}}/dev-docs/examples/adunit-refresh.html)                           |
+| *Native*                                                            | [Show Native Ads with Prebid.js]({{site.github.url}}/dev-docs/show-native-ads.html) (Engineering setup)                          |
+|                                                                     | [Setting up Prebid Native in DFP]({{site.github.url}}/adops/setting-up-prebid-native-in-dfp.html) (Ad Ops setup)                 |
 
 </div>

--- a/dev-docs/docs-by-format.md
+++ b/dev-docs/docs-by-format.md
@@ -22,6 +22,8 @@ For ad ops and other ad server-related information, see [our Ad Ops documentatio
 {: .table .table-bordered .table-striped }
 | Format              | Page                                                                                                                             |
 |---------------------+----------------------------------------------------------------------------------------------------------------------------------|
+| *Multi-Format*      | [Show Multi-Format Ads with Prebid.js]({{site.baseurl}}/dev-docs/show-multiformat-ads.html) (Engineering setup)                  |
+|                     | [Setting up Prebid Multi-Format in DFP]({{site.baseurl}}/adops/setting-up-prebid-multiformat-in-dfp.html) (Ad ops setup)         |
 | *AMP*               | [How Prebid on AMP Works]({{site.github.url}}/dev-docs/how-prebid-on-amp-works.html)                                             |
 |                     | [Show Prebid Ads on AMP Pages (Alpha)]({{site.github.url}}/dev-docs/show-prebid-ads-on-amp-pages.html)                           |
 | *Video* (instream)  | [Show Video Ads with a DFP Video Tag]({{site.github.url}}/dev-docs/show-video-with-a-dfp-video-tag.html) (With lots of examples) |

--- a/dev-docs/examples/multiformat-example.md
+++ b/dev-docs/examples/multiformat-example.md
@@ -1,15 +1,15 @@
 ---
 layout: example
-title: Prebid.js Multi-Format Example
-description: Prebid.js Multi-Format Example
+title: Prebid.js Multiformat Example
+description: Prebid.js Multiformat Example
 top_nav_section: dev_docs
 nav_section: quick-start
 about:
-- Multi-format ads allow you to declare multiple media types on a single ad unit
+- Multiformat ads allow you to declare multiple media types on a single ad unit
 - Set up one ad unit that could show a banner, native, or video ad
 - Any bidder that supports at least one of the listed media types can participate in the auction for that ad unit
-- For engineering setup instructions, see <a href="/dev-docs/show-multiformat-ads.html">Show Multi-format ads</a>
-- For ad ops setup instructions, see <a href="/adops/setting-up-prebid-multiformat-in-dfp.html">Setting up Prebid Multi-Format in DFP</a>
+- For engineering setup instructions, see <a href="/dev-docs/show-multiformat-ads.html">Show Multiformat ads</a>
+- For ad ops setup instructions, see <a href="/adops/setting-up-prebid-multiformat-in-dfp.html">Setting up Prebid Multiformat in DFP</a>
 jsfiddle_link: jsfiddle.net/prebid/mg81j0rw/3/embedded/html,result
 code_lines: 110
 code_height: 2389

--- a/dev-docs/examples/multiformat-example.md
+++ b/dev-docs/examples/multiformat-example.md
@@ -10,7 +10,7 @@ about:
 - Any bidder that supports at least one of the listed media types can participate in the auction for that ad unit
 - For engineering setup instructions, see <a href="/dev-docs/show-multiformat-ads.html">Show Multi-format ads</a>
 - For ad ops setup instructions, see <a href="/adops/setting-up-prebid-multiformat-in-dfp.html">Setting up Prebid Multi-Format in DFP</a>
-jsfiddle_link: jsfiddle.net/prebid/mg81j0rw/2/embedded/html,result
+jsfiddle_link: jsfiddle.net/prebid/mg81j0rw/3/embedded/html,result
 code_lines: 110
 code_height: 2389
 use_old_example_style: false

--- a/dev-docs/examples/multiformat-example.md
+++ b/dev-docs/examples/multiformat-example.md
@@ -5,13 +5,14 @@ description: Prebid.js Multi-Format Example
 top_nav_section: dev_docs
 nav_section: quick-start
 about:
-- <a href="/blog/dfp-instant-load">Instant Load</a> integration with DFP GPT single request asynchronous mode
-- One set of line items for all bidders, or for each bidder (Both setups work with this example)
-- Standard keyword targeting setup (<a href="/dev-docs/publisher-api-reference.html#bidderSettingsDefault">reference</a>).
-- Standard price granularity
-jsfiddle_link: jsfiddle.net/prebid/bhn3xk2j/458/embedded/html,result
+- Multi-format ads allow you to declare multiple media types on a single ad unit
+- Set up one ad unit that could show a banner, native, or video ad
+- Any bidder that supports at least one of the listed media types can participate in the auction for that ad unit
+- For engineering setup instructions, see <a href="/dev-docs/show-multiformat-ads.html">Show Multi-format ads</a>
+- For ad ops setup instructions, see <a href="/adops/setting-up-prebid-multiformat-in-dfp.html">Setting up Prebid Multi-Format in DFP</a>
+jsfiddle_link: jsfiddle.net/prebid/mg81j0rw/2/embedded/html,result
 code_lines: 110
 code_height: 2389
 use_old_example_style: false
-pid: 10
+pid: 11
 ---

--- a/dev-docs/examples/multiformat-example.md
+++ b/dev-docs/examples/multiformat-example.md
@@ -6,7 +6,7 @@ top_nav_section: dev_docs
 nav_section: quick-start
 about:
 - Multiformat ads allow you to declare multiple media types on a single ad unit
-- Set up one ad unit that could show a banner, native, or video ad
+- Set up one ad unit that could show a banner, native, or outstream video ad
 - Any bidder that supports at least one of the listed media types can participate in the auction for that ad unit
 - For engineering setup instructions, see <a href="/dev-docs/show-multiformat-ads.html">Show Multiformat ads</a>
 - For ad ops setup instructions, see <a href="/adops/setting-up-prebid-multiformat-in-dfp.html">Setting up Prebid Multiformat in DFP</a>

--- a/dev-docs/examples/multiformat-example.md
+++ b/dev-docs/examples/multiformat-example.md
@@ -8,7 +8,7 @@ about:
 - Multiformat ads allow you to declare multiple media types on a single ad unit
 - Set up one ad unit that could show a banner, native, or outstream video ad
 - Any bidder that supports at least one of the listed media types can participate in the auction for that ad unit
-- For engineering setup instructions, see <a href="/dev-docs/show-multiformat-ads.html">Show Multiformat ads</a>
+- For engineering setup instructions, see <a href="/dev-docs/show-multiformat-ads.html">Show Multiformat Ads</a>
 - For ad ops setup instructions, see <a href="/adops/setting-up-prebid-multiformat-in-dfp.html">Setting up Prebid Multiformat in DFP</a>
 jsfiddle_link: jsfiddle.net/prebid/mg81j0rw/3/embedded/html,result
 code_lines: 110

--- a/dev-docs/examples/multiformat-example.md
+++ b/dev-docs/examples/multiformat-example.md
@@ -1,0 +1,17 @@
+---
+layout: example
+title: Prebid.js Multi-Format Example
+description: Prebid.js Multi-Format Example
+top_nav_section: dev_docs
+nav_section: quick-start
+about:
+- <a href="/blog/dfp-instant-load">Instant Load</a> integration with DFP GPT single request asynchronous mode
+- One set of line items for all bidders, or for each bidder (Both setups work with this example)
+- Standard keyword targeting setup (<a href="/dev-docs/publisher-api-reference.html#bidderSettingsDefault">reference</a>).
+- Standard price granularity
+jsfiddle_link: jsfiddle.net/prebid/bhn3xk2j/458/embedded/html,result
+code_lines: 110
+code_height: 2389
+use_old_example_style: false
+pid: 10
+---

--- a/dev-docs/show-multiformat-ads.md
+++ b/dev-docs/show-multiformat-ads.md
@@ -123,7 +123,7 @@ Add a tag like the following to your page.  Depending on who wins the auction, a
 
 ## Working Examples
 
-+ [Prebid.js Multiformat Example]({{site.baseurl}}/dev-docs/examples/multiformat-example.html)
++ [Multiformat Example]({{site.baseurl}}/dev-docs/examples/multiformat-example.html)
 
 ## Related Topics
 

--- a/dev-docs/show-multiformat-ads.md
+++ b/dev-docs/show-multiformat-ads.md
@@ -15,7 +15,7 @@ nav_section: prebid-multiformat
 
 This page has instructions for showing multi-format ads using Prebid.js.
 
-Multi-format ads allow you to declare multiple media types on a single ad unit.
+Multi-format ads allow you to declare multiple media types on a single ad unit.  For example, you can set up one ad unit that could show a banner, native, or video ad, depending on which had the highest bid. 
 
 Once declared, any bidder that supports at least one of the media types can participate in the auction for that ad unit.
 

--- a/dev-docs/show-multiformat-ads.md
+++ b/dev-docs/show-multiformat-ads.md
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: Show Multi-Format Ads with Prebid.js
-description: Show Multi-Format Ads with Prebid.js
+title: Show Multiformat Ads with Prebid.js
+description: Show Multiformat Ads with Prebid.js
 pid: 0
 is_top_nav: yeah
 top_nav_section: dev_docs
@@ -10,28 +10,28 @@ nav_section: prebid-multiformat
 
 <div class="bs-docs-section" markdown="1">
 
-# Show Multi-Format Ads with Prebid.js
+# Show Multiformat Ads with Prebid.js
 {: .no_toc }
 
-This page has instructions for showing multi-format ads using Prebid.js.
+This page has instructions for showing multiformat ads using Prebid.js.
 
-Multi-format ads allow you to declare multiple media types on a single ad unit.  For example, you can set up one ad unit that could show a banner, native, or video ad, depending on which had the highest bid. 
+Multiformat ads allow you to declare multiple media types on a single ad unit.  For example, you can set up one ad unit that could show a banner, native, or video ad, depending on which had the highest bid. 
 
 Once declared, any bidder that supports at least one of the media types can participate in the auction for that ad unit.
 
 {: .alert.alert-info :}
-For ad ops setup instructions, see [Setting up Prebid Multi-Format in DFP]({{site.baseurl}}/adops/setting-up-prebid-multiformat-in-dfp.html).
+For ad ops setup instructions, see [Setting up Prebid Multiformat in DFP]({{site.baseurl}}/adops/setting-up-prebid-multiformat-in-dfp.html).
 
 * TOC
 {:toc}
 
-## How Multi-Format Ads Work
+## How Multiformat Ads Work
 
-Multi-format ads allow you to say that a single ad unit may be filled by any eligible banner, video, or native ad.
+Multiformat ads allow you to say that a single ad unit may be filled by any eligible banner, video, or native ad.
 
-At a high level, Prebid.js supports multi-format ads as follows:
+At a high level, Prebid.js supports multiformat ads as follows:
 
-1. For each multi-format ad unit, make a list of each of the media types defined for that ad unit
+1. For each multiformat ad unit, make a list of each of the media types defined for that ad unit
 2. Loop through each of the bidders specified on the ad unit, checking it against the list of media types to see if the bidder is eligible to bid
 3. Send bid requests to each bidder that supports at least one of the media types on the ad unit
 
@@ -39,7 +39,7 @@ The following key is added to your ad server targeting, and set to the value of 
 
 + `hb_format`
 
-The ad ops team will reference this key in the ad server to set targeting.  For ad ops setup instructions, see [Setting up Prebid Multi-Format in DFP]({{site.baseurl}}/adops/setting-up-prebid-multiformat-in-dfp.html).
+The ad ops team will reference this key in the ad server to set targeting.  For ad ops setup instructions, see [Setting up Prebid Multiformat in DFP]({{site.baseurl}}/adops/setting-up-prebid-multiformat-in-dfp.html).
 
 ## Prerequisites
 
@@ -51,7 +51,7 @@ Keep the following prerequisites in mind during the implementation:
 
 This section describes the implementation using code samples, but ignores some of the details that are common to all Prebid.js setups.
 
-### 1. Add multi-format ad units
+### 1. Add multiformat ad units
 
 In the ad unit below, we define the requirements for each media type that could serve: banner, native, or video.
 
@@ -123,10 +123,10 @@ Add a tag like the following to your page.  Depending on who wins the auction, a
 
 ## Working Examples
 
-+ [Prebid.js Multi-Format Example]({{site.baseurl}}/dev-docs/examples/multiformat-example.html)
++ [Prebid.js Multiformat Example]({{site.baseurl}}/dev-docs/examples/multiformat-example.html)
 
 ## Related Topics
 
-+ [Setting up Prebid Multi-Format in DFP]({{site.baseurl}}/adops/setting-up-prebid-multiformat-in-dfp.html)
++ [Setting up Prebid Multiformat in DFP]({{site.baseurl}}/adops/setting-up-prebid-multiformat-in-dfp.html)
 
 </div>

--- a/dev-docs/show-multiformat-ads.md
+++ b/dev-docs/show-multiformat-ads.md
@@ -19,21 +19,106 @@ Multi-format ads allow you to declare multiple media types on a single ad unit.
 
 Once declared, any bidder that supports at least one of the media types can participate in the auction for that ad unit.
 
+* TOC
+{:toc}
+
 ## How Multi-Format Ads Work
 
 Multi-format ads allow you to say that a single ad unit may be filled by any eligible banner, video, or native ad.
 
-At a high level, Prebid.js supports multi-format as follows:
+At a high level, Prebid.js supports multi-format ads as follows:
 
 1. For each multi-format ad unit, make a list of each of the media types defined for that ad unit
 2. Loop through each of the bidders on the ad unit, checking it against the list of media types to see if the bidder is eligible to bid
 3. Send bid requests to each bidder that supports at least one of the media types on the ad unit
 
+The following key is added to your ad server targeting, and set to the value of the bid response's `mediaType` property.
+
++ `hb_mediatype`
+
+The ad ops team will reference this key in the ad server to set targeting.  For ad ops setup instructions, see [Setting up Prebid Multi-Format in DFP]({{site.baseurl}}/adops/setting-up-prebid-multiformat-in-dfp.html).
+
 ## Prerequisites
+
+Keep the following prerequisites in mind during the implementation:
+
++ Make sure to work with bidders that support demand for the media types you want, particularly native and video.  To see which bidders have native and/or video demand, see [Bidders with Video and Native Demand](#bidders-with-video-and-native-demand).
 
 ## Implementation
 
+This section describes the implementation using code samples, but ignores some of the details that are common to all Prebid.js setups.
+
+### 1. Add multi-format ad units
+
+In the ad unit below, we define the requirements for each media type that could serve: banner, native, or video.
+
+```javascript
+
+    pbjs.addAdUnits({
+        code: 'div-banner-outstream-native',
+        mediaTypes: {
+            banner: {
+                sizes: [
+                    [300, 250],
+                    [300, 50]
+                ]
+            },
+            native: {
+                image: {
+                    sizes: [
+                        [300, 250],
+                        [300, 50]
+                    ]
+                }
+            },
+            video: {
+                context: 'outstream',
+                playerSize: [640, 480]
+            },
+        },
+        bids: [
+
+            {
+                bidder: 'bannerBidder',
+                params: {
+                    placementId: '481'
+                }
+            },
+
+            {
+                bidder: 'nativeBidder',
+                params: {
+                    titleAsset: '516'
+                }
+            },
+
+            {
+                bidder: 'videoBidder',
+                params: {
+                    vidId: '234'
+                }
+            },
+
+        ]
+    });
+```
+
+### 2. Add your tag to the page body
+
+```html
+    <div id='div-banner-outstream-native'>
+        <p>No response</p>
+        <script type='text/javascript'>
+            googletag.cmd.push(function () {
+                googletag.display('div-banner-outstream-native');
+            });
+        </script>
+    </div>
+```
+
 ## Working Examples
+
++ [Prebid.js Multi-Format Example]({{site.baseurl}}/dev-docs/examples/multiformat-example.html)
 
 ## Related Topics
 

--- a/dev-docs/show-multiformat-ads.md
+++ b/dev-docs/show-multiformat-ads.md
@@ -37,7 +37,7 @@ At a high level, Prebid.js supports multi-format ads as follows:
 
 The following key is added to your ad server targeting, and set to the value of the bid response's `mediaType` property.
 
-+ `hb_mediatype`
++ `hb_format`
 
 The ad ops team will reference this key in the ad server to set targeting.  For ad ops setup instructions, see [Setting up Prebid Multi-Format in DFP]({{site.baseurl}}/adops/setting-up-prebid-multiformat-in-dfp.html).
 

--- a/dev-docs/show-multiformat-ads.md
+++ b/dev-docs/show-multiformat-ads.md
@@ -15,7 +15,7 @@ nav_section: prebid-multiformat
 
 This page has instructions for showing multiformat ads using Prebid.js.
 
-Multiformat ads allow you to declare multiple media types on a single ad unit.  For example, you can set up one ad unit that could show a banner, native, or video ad, depending on which had the highest bid. 
+Multiformat ads allow you to declare multiple media types on a single ad unit.  For example, you can set up one ad unit that could show a banner, native, or outstream video ad, depending on which had the highest bid. 
 
 Once declared, any bidder that supports at least one of the media types can participate in the auction for that ad unit.
 

--- a/dev-docs/show-multiformat-ads.md
+++ b/dev-docs/show-multiformat-ads.md
@@ -19,6 +19,9 @@ Multi-format ads allow you to declare multiple media types on a single ad unit. 
 
 Once declared, any bidder that supports at least one of the media types can participate in the auction for that ad unit.
 
+{: .alert.alert-info :}
+For ad ops setup instructions, see [Setting up Prebid Multi-Format in DFP]({{site.baseurl}}/adops/setting-up-prebid-multiformat-in-dfp.html).
+
 * TOC
 {:toc}
 
@@ -29,7 +32,7 @@ Multi-format ads allow you to say that a single ad unit may be filled by any eli
 At a high level, Prebid.js supports multi-format ads as follows:
 
 1. For each multi-format ad unit, make a list of each of the media types defined for that ad unit
-2. Loop through each of the bidders on the ad unit, checking it against the list of media types to see if the bidder is eligible to bid
+2. Loop through each of the bidders specified on the ad unit, checking it against the list of media types to see if the bidder is eligible to bid
 3. Send bid requests to each bidder that supports at least one of the media types on the ad unit
 
 The following key is added to your ad server targeting, and set to the value of the bid response's `mediaType` property.
@@ -42,7 +45,7 @@ The ad ops team will reference this key in the ad server to set targeting.  For 
 
 Keep the following prerequisites in mind during the implementation:
 
-+ Make sure to work with bidders that support demand for the media types you want, particularly native and video.  To see which bidders have native and/or video demand, see [Bidders with Video and Native Demand](#bidders-with-video-and-native-demand).
++ Make sure to work with bidders that support demand for the media types you want, particularly native and video.  To see which bidders have native and/or video demand, see [Bidders with Video and Native Demand]({{site.baseurl}}/dev-docs/bidders.html#bidders-with-video-and-native-demand).
 
 ## Implementation
 
@@ -104,6 +107,8 @@ In the ad unit below, we define the requirements for each media type that could 
 ```
 
 ### 2. Add your tag to the page body
+
+Add a tag like the following to your page.  Depending on who wins the auction, a banner, outstream, or native ad should serve.
 
 ```html
     <div id='div-banner-outstream-native'>

--- a/dev-docs/show-multiformat-ads.md
+++ b/dev-docs/show-multiformat-ads.md
@@ -1,0 +1,42 @@
+---
+layout: page
+title: Show Multi-Format Ads with Prebid.js
+description: Show Multi-Format Ads with Prebid.js
+pid: 0
+is_top_nav: yeah
+top_nav_section: dev_docs
+nav_section: prebid-multiformat
+---
+
+<div class="bs-docs-section" markdown="1">
+
+# Show Multi-Format Ads with Prebid.js
+{: .no_toc }
+
+This page has instructions for showing multi-format ads using Prebid.js.
+
+Multi-format ads allow you to declare multiple media types on a single ad unit.
+
+Once declared, any bidder that supports at least one of the media types can participate in the auction for that ad unit.
+
+## How Multi-Format Ads Work
+
+Multi-format ads allow you to say that a single ad unit may be filled by any eligible banner, video, or native ad.
+
+At a high level, Prebid.js supports multi-format as follows:
+
+1. For each multi-format ad unit, make a list of each of the media types defined for that ad unit
+2. Loop through each of the bidders on the ad unit, checking it against the list of media types to see if the bidder is eligible to bid
+3. Send bid requests to each bidder that supports at least one of the media types on the ad unit
+
+## Prerequisites
+
+## Implementation
+
+## Working Examples
+
+## Related Topics
+
++ [Setting up Prebid Multi-Format in DFP]({{site.baseurl}}/adops/setting-up-prebid-multiformat-in-dfp.html)
+
+</div>

--- a/examples/multiformat_example.html
+++ b/examples/multiformat_example.html
@@ -1,0 +1,214 @@
+<!-- -*- Mode: Web; -*- -->
+<html>
+  <head>
+    <link rel="icon" 
+          type="image/png" 
+          href="/favicon.png">
+    <script>
+     var googletag = googletag || {};
+     googletag.cmd = googletag.cmd || [];
+
+     var pbjs = pbjs || {};
+     pbjs.que = pbjs.que || [];
+     var PREBID_TIMEOUT = 3000;
+
+     var date = new Date().getTime();
+
+     function initAdserver() {
+       if (pbjs.initAdserverSet) return;
+
+       googletag.cmd.push(function () {
+         pbjs.que.push(function () {
+           pbjs.enableSendAllBids();
+           pbjs.setTargetingForGPTAsync();
+           googletag.pubads().refresh();
+         });
+       });
+
+       pbjs.initAdserverSet = true;
+     }
+
+     // Load GPT when timeout is reached.
+     setTimeout(initAdserver, PREBID_TIMEOUT);
+
+     pbjs.que.push(function() {
+         var adUnits = [{
+                 code: '/19968336/prebid_native_example_1',
+                 sizes: [
+                     [360, 360]
+                 ],
+                 mediaTypes: {
+                     banner: {
+                         sizes: [
+                             [300, 250],
+                             [300, 600],
+                             [300, 50]
+                         ]
+                     }
+                     video: {
+                         context: 'outstream',
+                         playerSize: [640, 480]
+                     },
+                     native: {
+                         title: {
+                             required: true
+                         },
+                         image: {
+                             required: true,
+                             sizes: [
+                                 [300, 250],
+                                 [300, 50],
+                                 [300, 600]
+                             ]
+                         },
+                         sponsoredBy: {
+                             required: true
+                         }
+                     }
+                 },
+                 bids: [{
+                     bidder: 'appnexusAst',
+                     params: {
+                         placementId: 9880618,
+                         allowSmallerSizes: true
+                     }
+                 }]
+             },
+             {
+                 code: '/19968336/prebid_native_example_2',
+                 sizes: [
+                     [1, 1]
+                 ],
+                 mediaTypes: {
+                     native: {
+                         title: {
+                             required: true
+                         },
+                         body: {
+                             required: true
+                         },
+                         image: {
+                             required: true
+                         },
+                         sponsoredBy: {
+                             required: true
+                         },
+                         icon: {
+                             required: false
+                         },
+                     }
+                 },
+                 bids: [{
+                     bidder: 'appnexusAst',
+                     params: {
+                         placementId: 9880618,
+                         allowSmallerSizes: true
+                     }
+                 }]
+             }
+         ];
+
+         pbjs.addAdUnits(adUnits);
+
+         pbjs.bidderSettings = {
+             standard: {
+                 adserverTargeting: [{
+                     key: "hb_bidder",
+                     val: function(bidResponse) {
+                         return bidResponse.bidderCode;
+                     }
+                 }, {
+                     key: "hb_adid",
+                     val: function(bidResponse) {
+                         return bidResponse.adId;
+                     }
+                 }, {
+                     key: "hb_pb",
+                     val: function(bidResponse) {
+                         return '10.00';
+                     }
+                 }, {
+                     key: "hb_size",
+                     val: function(bidResponse) {
+                         return bidResponse.size;
+
+                     }
+                 }]
+             }
+         };
+
+         pbjs.setPriceGranularity('medium');
+
+         pbjs.requestBids({
+             bidsBackHandler: function(bidResponses) {
+                 initAdserver();
+             }
+         });
+
+     });
+
+     (function () {
+       var d = document, pbs = d.createElement("script"), pro = d.location.protocal;
+       pbs.type = "text/javascript";
+       pbs.src = 'http://acdn.adnxs.com/prebid/not-for-prod/prebid.js';
+       var target = document.getElementsByTagName("head")[0];
+       target.insertBefore(pbs, target.firstChild);
+     })();
+
+     //load GPT library here
+     (function () {
+       var gads = document.createElement('script');
+       gads.async = true;
+       gads.type = 'text/javascript';
+       var useSSL = 'https:' == document.location.protocol;
+       gads.src = (useSSL ? 'https:' : 'http:') +
+                  '//www.googletagservices.com/tag/js/gpt.js';
+       var node = document.getElementsByTagName('script')[0];
+       node.parentNode.insertBefore(gads, node);
+     })();
+    </script>
+
+
+    <script>
+     // GPT setup
+     googletag.cmd.push(function () {
+       var slot1 = googletag.defineSlot('/19968336/prebid_native_example_1', [[360, 360]], 'div-1').addService(googletag.pubads());
+       var slot2 = googletag.defineSlot('/19968336/prebid_native_example_2', 'fluid', 'div-2').addService(googletag.pubads());
+
+       // This allows us to load Prebid and GPT in parallel
+       googletag.pubads().disableInitialLoad();
+       googletag.pubads().enableSingleRequest();
+       googletag.enableServices();
+     });
+
+    </script>
+  </head>
+
+  <body>
+
+    <h2>Prebid Native</h2>
+    <div id='div-1'>
+      <p>No response</p>
+      <script type='text/javascript'>
+       googletag.cmd.push(function () {
+         googletag.display('div-1');
+       });
+      </script>
+    </div>
+
+    <br>
+    <br>
+
+    <div id='div-2'>
+      <p>No response</p>
+      <script type='text/javascript'>
+       googletag.cmd.push(function () {
+         googletag.display('div-2');
+       });
+      </script>
+    </div>
+
+
+  </body>
+
+</html>

--- a/examples/multiformat_example.html
+++ b/examples/multiformat_example.html
@@ -67,7 +67,7 @@
                      }
                  },
                  bids: [{
-                     bidder: 'appnexusAst',
+                     bidder: 'appnexus',
                      params: {
                          placementId: 9880618,
                          allowSmallerSizes: true
@@ -99,7 +99,7 @@
                      }
                  },
                  bids: [{
-                     bidder: 'appnexusAst',
+                     bidder: 'appnexus',
                      params: {
                          placementId: 9880618,
                          allowSmallerSizes: true
@@ -150,7 +150,7 @@
      (function () {
        var d = document, pbs = d.createElement("script"), pro = d.location.protocal;
        pbs.type = "text/javascript";
-       pbs.src = 'http://acdn.adnxs.com/prebid/not-for-prod/prebid.js';
+       pbs.src = 'http://acdn.adnxs.com/prebid/not-for-prod/1/prebid.js';
        var target = document.getElementsByTagName("head")[0];
        target.insertBefore(pbs, target.firstChild);
      })();


### PR DESCRIPTION
This PR has:

+ multiformat ad ops setup (which is basically presented here as a "diff" from the existing instructions for (1) speed, and (2) not wanting to replicate tons of existing, already-vetted content

+ multiformat developer setup

+ multiformat examples (which are based on Lane's example code but will need to be checked once the CDN is updated with the 1.2 release)