### PR TITLE
Add Yieldlab adapter docs to website

### DIFF
--- a/dev-docs/bidders/yieldlab.md
+++ b/dev-docs/bidders/yieldlab.md
@@ -1,0 +1,26 @@
+---
+layout: bidder
+title: Yieldlab
+description: Prebid Yieldlab Bidder Adapter
+
+top_nav_section: dev_docs
+nav_section: reference
+hide: true
+
+biddercode: yieldlab
+biddercode_longer_than_12: false
+
+prebid_1_0_supported : true
+
+---
+
+
+
+### bid params
+
+{: .table .table-bordered .table-striped }
+| Name | Scope | Description | Example |
+| :--- | :---- | :---------- | :------ |
+| `placementId` | required | The Yieldlab placement ID | '12345' |
+| `accountId` | required | The Yieldlab account ID | '12345' |
+| `adSize` | required | Override the default prebid size | '970x250' |


### PR DESCRIPTION
This is the documentation for new prebid Adapter - Yieldlab. Related to this PR - https://github.com/prebid/Prebid.js/pull/1967