### PR TITLE
Update C1X Adapter docs 

### DIFF
--- a/dev-docs/bidders/c1x.md
+++ b/dev-docs/bidders/c1x.md
@@ -25,7 +25,6 @@ The C1X Header Bidding adaptor requires approval from the C1X team. Please reach
 |:-----------|:---------|:------------|:-----------------|
 | `siteId` | required | Site ID from which the request is originating | `'999'` |
 | `pixelId` | optional | Publisher's pixel ID | `'12345'` |
-| `endpoint` | optional | Production bidder endpoint provided by C1X. If omitting, default endpoint is our staging | `'http://ht-integration.c1exchange.com:9000/ht'` |
 | `floorPriceMap` | optional | Minimum floor prices needed from the DSP's to enter the auction | `{'300x250': 4.00,'300x600': 3.00}` |
 | `dspid` | optional | DSP ID | `'4321'` |
-
+| `pageurl` | optional | Url of the webpage where the request is originating from | `'4321'` |


### PR DESCRIPTION
We've upgraded our adapter to Prebid v1.0 so we need to update the bidder's param doc 