### PR TITLE
Update dev-docs gumgum.md file to include prebid 1.0 support flag

### DIFF
--- a/dev-docs/bidders/gumgum.md
+++ b/dev-docs/bidders/gumgum.md
@@ -2,16 +2,12 @@
 layout: bidder
 title: GumGum
 description: Prebid GumGum Bidder Adaptor
-
 top_nav_section: dev_docs
 nav_section: reference
-
 hide: true
-
 biddercode: gumgum
-
 biddercode_longer_than_12: false
-
+prebid_1_0_supported : true
 ---
 
 ### Note:
@@ -25,5 +21,5 @@ information.
 {: .table .table-bordered .table-striped }
 | Name       | Scope    | Description | Example          |
 |:-----------|:---------|:------------|:-----------------|
-| `inScreen` | optional | Tracking ID | `'MyTrackingID'` |
+| `inScreen` | optional | Tracking ID | `'ggumtest'`     |
 | `inSlot`   | optional | Slot ID     | `9`              |


### PR DESCRIPTION
Hi Prebid.

GumGum would like to update the dev-doc for its Adapter, now that we support prebid 1.0