### PR TITLE
Update beachfront doc

### DIFF
--- a/dev-docs/bidders/beachfront.md
+++ b/dev-docs/bidders/beachfront.md
@@ -10,15 +10,11 @@ biddercode_longer_than_12: false
 prebid_1_0_supported : true
 ---
 
-### Note:
-
-The Beachfront adapter currently supports video ads only.
-
 ### bid params
 
 {: .table .table-bordered .table-striped }
 
-| Name     | Scope    | Description             | Example  |
-| :------- | :------- | :---------------------- | :------  |
-| appId  - | required | Beachfront Exchange ID  | `'11bc5dd5-7421-4dd8-c926-40fa653bec76'` |
-| bidfloor | required | Bid floor               | `0.01` |
+| Name       | Scope    | Description             | Example  |
+| :--------- | :------- | :---------------------- | :------  |
+| `appId`    | required | Beachfront Exchange ID  | `'11bc5dd5-7421-4dd8-c926-40fa653bec76'` |
+| `bidfloor` | required | Bid floor               | `0.01` |


### PR DESCRIPTION
Removes note about video only support. The beachfront bidder will also support banner ads.