### PR TITLE
Update download page to point to 0.34.4

### DIFF
--- a/download.md
+++ b/download.md
@@ -135,7 +135,7 @@ To improve the speed and load time of your site, build Prebid.js for only the he
 <h4>Select Prebid Version</h4>
 <select class="selectpicker">
   <!-- empty value indicates legacy --> 
-  <option value="">0.34.3</option>
+  <option value="">0.34.4</option>
   <option>1.3.1</option>
 </select>
 


### PR DESCRIPTION
I saw that the release for 0.34.4 was created 8 days ago. Just hoping to get the download page updated to reflect that. :)

Thanks.