### PR TITLE
Yieldbot bidder doc pbjs 1.0 support metadata

### DIFF
--- a/dev-docs/bidders/yieldbot.md
+++ b/dev-docs/bidders/yieldbot.md
@@ -11,6 +11,7 @@ hide: true
 biddercode: yieldbot
 
 biddercode_longer_than_12: false
+prebid_1_0_supported : true
 
 ---
 


### PR DESCRIPTION
Adds metadata field `prebid_1_0_supported` to Yieldbot bidder developer docs.

***Ref:***
- https://github.com/prebid/Prebid.js/pull/2135#issuecomment-369955633