### PR TITLE
Update Yieldlab params with new naming

### DIFF
--- a/dev-docs/bidders/yieldlab.md
+++ b/dev-docs/bidders/yieldlab.md
@@ -21,6 +21,6 @@ prebid_1_0_supported : true
 {: .table .table-bordered .table-striped }
 | Name | Scope | Description | Example |
 | :--- | :---- | :---------- | :------ |
-| `placementId` | required | The Yieldlab placement ID | '12345' |
-| `accountId` | required | The Yieldlab account ID | '12345' |
+| `adslotId` | required | Yieldlab Adslot ID | '12345' |
+| `supplyId` | required | Yieldlab Supply ID. Please reach out to your account management for more information. | '12345' |
 | `adSize` | required | Override the default prebid size | '970x250' |


### PR DESCRIPTION
Changed params to the actual naming used by Yieldlab to avoid confusion from customers. 

Corresponding to Pull Request: https://github.com/prebid/Prebid.js/pull/2231