### PR TITLE
fixed typo of missing commas in json for example

### DIFF
--- a/dev-docs/get-started-with-prebid-server.md
+++ b/dev-docs/get-started-with-prebid-server.md
@@ -76,8 +76,8 @@ pbjs.que.push(function() {
             bidders: ['appnexus', 'pubmatic'],
             timeout: 1000,
             adapter: 'prebidServer',
-            endpoint: 'https://prebid.adnxs.com/pbs/v1/auction'
-            syncEndpoint: 'https://prebid.adnxs.com/pbs/v1/cookie_sync'
+            endpoint: 'https://prebid.adnxs.com/pbs/v1/auction',
+            syncEndpoint: 'https://prebid.adnxs.com/pbs/v1/cookie_sync',
             cookieSet: true,
             cookiesetUrl: 'https://acdn.adnxs.com/cookieset/cs.js'
         }


### PR DESCRIPTION
Missing commas in the example for copy/pasters (like myself).