### PR TITLE
update freewheel bider adapter doc

### DIFF
--- a/dev-docs/bidders/freewheel.md
+++ b/dev-docs/bidders/freewheel.md
@@ -1,17 +1,17 @@
 ---
 layout: bidder
-title: StickyAdsTV
-description: Prebid StickyAdsTV Bidder Adaptor
+title: FreeWheel-ssp
+description: Freewheel Bidder Adaptor
 
 top_nav_section: dev_docs
 nav_section: reference
 
 hide: true
 
-biddercode: stickyadstv
+biddercode: freewheel-ssp
 
-biddercode_longer_than_12: false
-
+biddercode_longer_than_12: true
+prebid_1_0_supported : true
 
 ---
 


### PR DESCRIPTION
When updating our bidder adaptor to our new company name, there was some mistake in the documentation,.

I've remove the stickyadtv md file, replacing it with freesheel-ssp doc.

also added **prebid_1_0_supported:true** in it.

(as suggested by Roffray in this thread: https://github.com/prebid/prebid.github.io/issues/620#issuecomment-371770251 )
