### PR TITLE
fixed unclosed anchor on bidders page

### DIFF
--- a/dev-docs/bidders.md
+++ b/dev-docs/bidders.md
@@ -137,7 +137,7 @@ Demand from the bidders listed below is available via the [Prebid Server integra
 {% for page in bidder_pages %}
 
 <div class="bs-docs-section" markdown="1">
-<h2><a name="{{ page.biddercode }}" />{{ page.title }}</h2>
+<h2><a name="{{ page.biddercode }}" >{{ page.title }}</a></h2>
 
 {% if page.s2s_only == true %}  
 <h3>Note:</h3> This is a S2S adapter only.


### PR DESCRIPTION
Currently on the http://prebid.org/dev-docs/bidders.html page, when you mouse over any of the bidders (where they have the their param details) the text displays lines as if it's a link.

This PR fixes the anchor tag that wasn't being closed properly and allows the bidder details information to appear as normal text.