### PR TITLE
dynamic table for Bidders with Video and Native Demand section on bidders page

### DIFF
--- a/dev-docs/bidders.md
+++ b/dev-docs/bidders.md
@@ -72,49 +72,21 @@ The following parameters in the `bidResponse` object are common across all bidde
 ## Bidders with Video and Native Demand
 {: .no_toc }
 
-{: .table .table-bordered .table-striped }
-| Bidder          | Supported Media Types | Prebid 1.0 Support? |
-|-----------------+-----------------------+---------------------|
-| adgeneration    | native                | X                   |
-| adkernelAdn     | video                 | X                   |
-| adkernel        | video                 | X                   |
-| admixer         | video                 | X                   |
-| adxcg           | video,native          | X                   |
-| aol             | video                 | X                   |
-| appnexus        | video,native          | X                   |
-| audienceNetwork | video,native          | X                   |
-| beachfront      | video                 | X                   |
-| conversant      | video                 | X                   |
-| freewheelSSP    | video                 | X                   |
-| gamma           | video                 | X                   |
-| getintent       | video                 | X                   |
-| gumgum          | native                | X                   |
-| mantis          | video,native          | X                   |
-| mobfox          | video                 | X                   |
-| openx           | video                 | X                   |
-| optimatic       | video                 | X                   |
-| platformio      | native                | X                   |
-| prebidServer    | video                 | X                   |
-| pulsepoint      | native                | X                   |
-| quantcast       | video                 | X                   |
-| readpeak        | native                | X                   |
-| rhythmone       | video                 | X                   |
-| rockyou         | video                 | X                   |
-| rubicon         | video                 | X                   |
-| sekindoUM       | video                 | X                   |
-| sharethrough    | native                | X                   |
-| vertamedia      | video                 | X                   |
-| yieldlab        | video                 | X                   |
-| yieldmo         | native                | X                   |
-| aerserv         | video                 |                     |
-| appnexusAst     | video,native          |                     |
-| criteo          | native                |                     |
-| indexExchange   | video                 |                     |
-| pulsepointLite  | native                |                     |
-| spotx           | video                 |                     |
-| stickyadstv     | native                |                     |
-| tremor          | video                 |                     |
-| unruly          | video,native          |                     |
+{% assign bidder_pages = site.pages | where: "layout", "bidder" %}
+<table class="table table-bordered table-striped">
+<thead><tr>
+<th>Bidder</th>
+<th>Supported Media Types</th>
+<th> Prebid 1.0 Support?</th>
+</tr></thead>
+<tbody>
+{% for page in bidder_pages %}
+{% if page.media_types %}
+<tr><td> {{page.biddercode}} </td><td> {% if page.media_types contains 'video' and page.media_types contains 'native' %} video, native {% elsif page.media_types contains 'native' %} native {% elsif page.media_types contains 'video' %} video {% endif %} </td><td> {% if page.prebid_1_0_supported %}X{% endif %} </td></tr>
+{% endif %}
+{% endfor %}
+</tbody>
+</table>
 
 <a name="prebid-server-bidders"></a>
 

--- a/dev-docs/bidders/adform.md
+++ b/dev-docs/bidders/adform.md
@@ -13,6 +13,7 @@ biddercode: adform
 biddercode_longer_than_12: false
 
 prebid_1_0_supported : true
+media_types: video
 ---
 
 

--- a/dev-docs/bidders/adgeneration.md
+++ b/dev-docs/bidders/adgeneration.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: adgeneration
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: native
 ---
 
 

--- a/dev-docs/bidders/adkernel.md
+++ b/dev-docs/bidders/adkernel.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: adkernel
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: video
 ---
 
 ### Note:

--- a/dev-docs/bidders/adkernelAdn.md
+++ b/dev-docs/bidders/adkernelAdn.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: adkernelAdn
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: video
 ---
 
 ### Note:

--- a/dev-docs/bidders/admixer.md
+++ b/dev-docs/bidders/admixer.md
@@ -11,7 +11,8 @@ hide: true
 biddercode: admixer
 
 biddercode_longer_than_12: false
-
+prebid_1_0_supported: true
+media_types: video
 
 ---
 

--- a/dev-docs/bidders/adxcg.md
+++ b/dev-docs/bidders/adxcg.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: adxcg
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: native, video
 ---
 
 ### bid params

--- a/dev-docs/bidders/aerserv.md
+++ b/dev-docs/bidders/aerserv.md
@@ -11,6 +11,7 @@ hide: true
 biddercode: aerserv
 
 biddercode_longer_than_12: false
+media_types: video
 
 ---
 

--- a/dev-docs/bidders/aol.md
+++ b/dev-docs/bidders/aol.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: aol
 biddercode_longer_than_12: false
 prebid_1_0_supported: true
+media_types: video
 ---
 
 ### Note:

--- a/dev-docs/bidders/appnexus-ast.md
+++ b/dev-docs/bidders/appnexus-ast.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: appnexusAst
 biddercode_longer_than_12: false
 prebid_1_0_supported : false
+media_types: native, video
 ---
 
 Advantages of using the `appnexusAst` adapter over the `appnexus`

--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -8,6 +8,7 @@ biddercode: appnexus
 biddercode_longer_than_12: false
 hide: true
 prebid_1_0_supported : true
+media_types: video, native
 ---
 
 **Table of Contents**

--- a/dev-docs/bidders/audienceNetwork.md
+++ b/dev-docs/bidders/audienceNetwork.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: audienceNetwork
 biddercode_longer_than_12: true
 prebid_1_0_supported : true
+media_types: native, video
 ---
 
 #### send all bids ad server keys

--- a/dev-docs/bidders/beachfront.md
+++ b/dev-docs/bidders/beachfront.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: beachfront
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: video
 ---
 
 ### bid params

--- a/dev-docs/bidders/conversant.md
+++ b/dev-docs/bidders/conversant.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: conversant
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: video
 ---
 
 

--- a/dev-docs/bidders/criteo.md
+++ b/dev-docs/bidders/criteo.md
@@ -13,6 +13,7 @@ biddercode: criteo
 biddercode_longer_than_12: false
 
 bidder_supports_deals: false
+media_types: native
 
 ---
 

--- a/dev-docs/bidders/freewheel.md
+++ b/dev-docs/bidders/freewheel.md
@@ -12,6 +12,7 @@ biddercode: freewheel-ssp
 
 biddercode_longer_than_12: true
 prebid_1_0_supported : true
+media_types: video
 
 ---
 

--- a/dev-docs/bidders/gamma.md
+++ b/dev-docs/bidders/gamma.md
@@ -7,6 +7,7 @@ nav_section: reference
 hide: true
 biddercode: gamma
 prebid_1_0_supported : true
+media_types: video
 ---
 
 ### bid params

--- a/dev-docs/bidders/getintent.md
+++ b/dev-docs/bidders/getintent.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: getintent
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: video
 ---
 
 

--- a/dev-docs/bidders/gumgum.md
+++ b/dev-docs/bidders/gumgum.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: gumgum
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: native
 ---
 
 ### Note:

--- a/dev-docs/bidders/indexExchange.md
+++ b/dev-docs/bidders/indexExchange.md
@@ -11,6 +11,7 @@ hide: true
 biddercode: indexExchange
 
 biddercode_longer_than_12: true
+media_types: video
 
 ---
 

--- a/dev-docs/bidders/lifestreet.md
+++ b/dev-docs/bidders/lifestreet.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: lifestreet
 biddercode_longer_than_12: false
 prebid_1_0_supported: true
+media_types: video
 ---
 
 

--- a/dev-docs/bidders/mantis.md
+++ b/dev-docs/bidders/mantis.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: mantis
 prebid_1_0_supported : true
 biddercode_longer_than_12: false
+media_types: native, video
 
 ---
 

--- a/dev-docs/bidders/mobfox.md
+++ b/dev-docs/bidders/mobfox.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: mobfox
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: video
 ---
 
 ### bid params

--- a/dev-docs/bidders/openx.md
+++ b/dev-docs/bidders/openx.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: openx
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: video
 ---
 
 

--- a/dev-docs/bidders/optimatic.md
+++ b/dev-docs/bidders/optimatic.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: optimatic
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: video
 ---
 
 ### Note:

--- a/dev-docs/bidders/platformio.md
+++ b/dev-docs/bidders/platformio.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: platformio
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: native
 ---
 
 ### bid params

--- a/dev-docs/bidders/prebidServer.md
+++ b/dev-docs/bidders/prebidServer.md
@@ -8,6 +8,7 @@ biddercode: prebidServer
 biddercode_longer_than_12: true
 hide: true
 prebid_1_0_supported : true
+media_types: video
 ---
 
 ### Sign up

--- a/dev-docs/bidders/pulsepoint.md
+++ b/dev-docs/bidders/pulsepoint.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: pulsepoint
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: native
 ---
 
 

--- a/dev-docs/bidders/pulsepointlite.md
+++ b/dev-docs/bidders/pulsepointlite.md
@@ -11,6 +11,7 @@ hide: true
 biddercode: pulsepointLite
 
 biddercode_longer_than_12: true
+media_types: native
 
 ---
 

--- a/dev-docs/bidders/quantcast.md
+++ b/dev-docs/bidders/quantcast.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: quantcast
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: video
 ---
 
 

--- a/dev-docs/bidders/quantum.md
+++ b/dev-docs/bidders/quantum.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: quantum
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: native
 ---
 
 

--- a/dev-docs/bidders/readpeak.md
+++ b/dev-docs/bidders/readpeak.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: readpeak
 biddercode_longer_than_12: false
 prebid_1_0_supported: true
+media_types: native
 ---
 
 ### bid params

--- a/dev-docs/bidders/rhythmone.md
+++ b/dev-docs/bidders/rhythmone.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: rhythmone
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: video
 ---
 
 

--- a/dev-docs/bidders/rockyou.md
+++ b/dev-docs/bidders/rockyou.md
@@ -8,6 +8,7 @@ biddercode: rockyou
 biddercode_longer_than_12: false
 hide: true
 prebid_1_0_supported: true
+media_types: video
 ---
 
 ### bid params

--- a/dev-docs/bidders/rubicon.md
+++ b/dev-docs/bidders/rubicon.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: rubicon
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: video
 ---
 
 

--- a/dev-docs/bidders/sekindo.md
+++ b/dev-docs/bidders/sekindo.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: sekindoUM
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: video
 ---
 
 ### bid params

--- a/dev-docs/bidders/sharethrough.md
+++ b/dev-docs/bidders/sharethrough.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: sharethrough
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: native
 ---
 
 ### Note:

--- a/dev-docs/bidders/smartadserver.md
+++ b/dev-docs/bidders/smartadserver.md
@@ -13,6 +13,7 @@ biddercode: smartadserver
 biddercode_longer_than_12: false
 
 prebid_1_0_supported: true
+media_types: video
 
 ---
 

--- a/dev-docs/bidders/smartyads.md
+++ b/dev-docs/bidders/smartyads.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: smartyads
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: native
 
 ---
 

--- a/dev-docs/bidders/spotx.md
+++ b/dev-docs/bidders/spotx.md
@@ -11,7 +11,7 @@ hide: true
 biddercode: spotx
 
 biddercode_longer_than_12: false
-
+media_types: video
 
 ---
 

--- a/dev-docs/bidders/stickyadstv.md
+++ b/dev-docs/bidders/stickyadstv.md
@@ -1,0 +1,12 @@
+---
+layout: bidder
+title: StickyAdsTv
+description: Prebid StickyAdsTv Bidder Adaptor
+top_nav_section: dev_docs
+nav_section: reference
+hide: true
+biddercode: stickyadstv
+biddercode_longer_than_12: false
+media_types: native
+
+---

--- a/dev-docs/bidders/tremor.md
+++ b/dev-docs/bidders/tremor.md
@@ -7,6 +7,7 @@ nav_section: reference
 hide: true
 biddercode: tremor
 biddercode_longer_than_12: false
+media_types: video
 ---
 
 This is the `tremor` adapter

--- a/dev-docs/bidders/unruly.md
+++ b/dev-docs/bidders/unruly.md
@@ -7,6 +7,7 @@ nav_section: reference
 hide: true
 biddercode: unruly
 biddercode_longer_than_12: false
+media_types: native, video
 ---
 
 ### bid params

--- a/dev-docs/bidders/vertamedia.md
+++ b/dev-docs/bidders/vertamedia.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: vertamedia
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: video
 ---
 
 ### Bid params

--- a/dev-docs/bidders/vuble.md
+++ b/dev-docs/bidders/vuble.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: vuble
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: video
 ---
 
 ### Note:

--- a/dev-docs/bidders/yieldlab.md
+++ b/dev-docs/bidders/yieldlab.md
@@ -11,6 +11,7 @@ biddercode: yieldlab
 biddercode_longer_than_12: false
 
 prebid_1_0_supported : true
+media_types: video
 
 ---
 

--- a/dev-docs/bidders/yieldmo.md
+++ b/dev-docs/bidders/yieldmo.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: yieldmo
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: native
 
 ---
 


### PR DESCRIPTION
This PR introduces a dynamically built table to replace the previously hard-coded table for the Bidders with Video and Native Demand section of the `dev-docs/bidders.md` page.

This dynamic table relies on a new variable stored in the bidders' page named `media_types`; it accepts a comma separated list of the `native` and `video` media types.  In the future, any adapters that add support for these types just need to update their bidders page (similar to how they flagged themselves for prebid 1.0).

I have updated all the adapters that were part of the previous hard-coded table, as well as finding the other (1.x) adapters that support video/native that weren't part of the previous table.  

Notes on the bidder updates:
- the bidder `stickyadstv` did not have their own bidder page, so I made a bare-bones one for them so they're included in the table.
- the following bidders should be part of this table, but I have not included them in this PR.  They have open docs PR to either submit their bidder page or update the old hard-coded table.  These bidders are: `adtelligent`, `ebdr`,`platformio`  They should be added in a subsequent PR.