### PR TITLE
update adform bidders page for GDPR support

### DIFF
--- a/dev-docs/bidders/adform.md
+++ b/dev-docs/bidders/adform.md
@@ -14,6 +14,7 @@ biddercode_longer_than_12: false
 
 prebid_1_0_supported : true
 media_types: video
+gdpr_supported: true
 ---
 
 


### PR DESCRIPTION
Update the Adform bidders page to flag they now support GDPR.

original PR in PBJS: https://github.com/prebid/Prebid.js/pull/2396