### PR TITLE
add gdpr support to pubmatic bidders page

### DIFF
--- a/dev-docs/bidders/pubmatic.md
+++ b/dev-docs/bidders/pubmatic.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: pubmatic
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+gdpr_supported: true
 ---
 
 ### Prebid Server Note:


### PR DESCRIPTION
Update the Pubmatic bidders page to flag they now support GDPR.

original PR in PBJS: https://github.com/prebid/Prebid.js/pull/2469