### PR TITLE
adding gdpr support flag to brt alias of apn

### DIFF
--- a/dev-docs/bidders/brealtime.md
+++ b/dev-docs/bidders/brealtime.md
@@ -14,7 +14,7 @@ aliasCode : appnexus
 
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
-
+gdpr_supported: true
 ---
 
 


### PR DESCRIPTION
Submitting approval to list bRealTime as a GDPR supported adapter on the Prebid GDPR consent management module page. We are leveraging the Appnexus adapter which has GDPR support included and also have a number of initiatives internally to be our company is fully GDPR complaint prior to the 25th. 

Please let me know if anything else is needed to be listed. Thank you! 