### PR TITLE
Add Sharethrough GDPR compliance info

### DIFF
--- a/dev-docs/bidders/sharethrough.md
+++ b/dev-docs/bidders/sharethrough.md
@@ -9,6 +9,7 @@ biddercode: sharethrough
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
 media_types: native
+gdpr_supported: true
 ---
 
 ### Note:


### PR DESCRIPTION
Since the Sharethrough adapter is up to date here: https://github.com/prebid/Prebid.js/pull/2563#pullrequestreview-121911292

This updates the sharethrough bidder README. 