### PR TITLE
Issue #712, Support/Videos menu option was confusing

### DIFF
--- a/_includes/main_nav.html
+++ b/_includes/main_nav.html
@@ -80,7 +80,7 @@
                     <ul class="dropdown-menu">
                         <li><a href="{{site.baseurl}}/support/">Get Help</a></li>
                         <li><a href="{{site.baseurl}}/dev-docs/prebid-troubleshooting-guide.html">Troubleshooting</a></li>
-                        <li><a href="{{site.baseurl}}/videos/">Videos</a></li>
+                        <li><a href="{{site.baseurl}}/videos/">Training Videos</a></li>
                         <li><a href="http://stackoverflow.com/questions/tagged/prebid.js">Stack Overflow</a></li>
                         <li><a href="https://reddit.com/r/adops">Ad Ops Reddit</a></li>
                         <li><a href="https://redditadops.slack.com/messages/C0HVALS8P"><strong>#headerbidding</strong> channel (Reddit Ad Ops Slack)</a></li>


### PR DESCRIPTION
Rename Videos option under Support menu to "Training Videos" to avoid confusion, per Issue #712 