### PR TITLE
Update indexExchange.md

### DIFF
--- a/dev-docs/bidders/indexExchange.md
+++ b/dev-docs/bidders/indexExchange.md
@@ -154,18 +154,20 @@ var adUnits = [{
     bids: [{
         bidder: 'ix',
         params: {
-            siteId: '4622',
+            siteId: '12345',
             size: [300, 250]
         }
     }, {
         bidder: 'ix',
         params: {
-            siteId: '6242',
+            siteId: '12345',
             size: [300, 600]
         }
     }]
 }];
 ```
+
+Please note that you can re-use the existing `siteId` within the same flex position.
 
 ##### 2. Include `ixBidAdapter` in your build process
 


### PR DESCRIPTION
Please see: https://github.com/prebid/Prebid.js/pull/2598

Clarify use of `siteId` and fix mismatch of `siteId` for 'flex position' units based on documentation emailed out:
https://gallery.mailchimp.com/41ac5884406c48bd6f31af7a1/files/09ffb712-5455-4c0c-8453-592c5a3bcb67/Prebid_1.0_Upgrade_Doc_052118_v2.pdf

Further clarification is recommended, given the comment in the FAQ:

> An IX site ID maps to a single size, whereas an ad unit can have multiple sizes. To ensure that the right site ID is mapped to the correct size in the ad unit we require the size to be explicitly stated.

...which contradicts the statement in the upgrade documentation linked above, which states:

> Please note that you can re-use the existing `siteId` within the same flex position.