### PR TITLE
Download page updates for prebid analytics  module include

### DIFF
--- a/download.md
+++ b/download.md
@@ -229,13 +229,6 @@ To improve the speed and load time of your site, build Prebid.js for only the he
     </label>
   </div>
 </div>
-<div class="col-md-4">
-  <div class="checkbox">
-    <label>
-      <input type="checkbox" analyticscode="yuktamedia" class="analytics-check-box"> YuktaMedia Analytics
-    </label>
-  </div>
-</div>
 
 </div>
 <br/>

--- a/download.md
+++ b/download.md
@@ -229,6 +229,13 @@ To improve the speed and load time of your site, build Prebid.js for only the he
     </label>
   </div>
 </div>
+<div class="col-md-4">
+  <div class="checkbox">
+    <label>
+      <input type="checkbox" analyticscode="yuktamedia" class="analytics-check-box"> Yuktamedia Analytics
+    </label>
+  </div>
+</div>
 
 </div>
 <br/>

--- a/download.md
+++ b/download.md
@@ -229,6 +229,13 @@ To improve the speed and load time of your site, build Prebid.js for only the he
     </label>
   </div>
 </div>
+<div class="col-md-4">
+  <div class="checkbox">
+    <label>
+      <input type="checkbox" analyticscode="yuktamedia" class="analytics-check-box"> YuktaMedia Analytics
+    </label>
+  </div>
+</div>
 
 </div>
 <br/>

--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -24,7 +24,7 @@ There are several analytics adapter plugins available to track header bidding pe
 | PubWise                                                          | Free & Paid, see [pricing](https://pubwise.io/pricing/)                                    | [Website](https://pubwise.io/pubwise/)                                   |          0.24 |
 | Assertive Yield (contact for adapter) | Free to try (Large accounts $0.002 CPM or sampled < 10mm/m imp.) | [Website](https://yield.assertcom.de) | |
 | Vuble                                                            | Contact vendor                                                                      | [Website](https://vuble.tv/us/prebid/)                           |               |
-| YuktaMedia Analytics                                                      | Contact vendor                                                                      | [website](https://yuktamedia.com/prebid/)                                        | 1.0.0 |
+| YuktaMedia Analytics                                                      | Contact vendor                                                                      | [website](https://yuktamedia.com/publishers/prebid/)                                        | 1.0.0 |
 
 None of these analytics options are endorsed or supported by Prebid.org.
 

--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -24,6 +24,7 @@ There are several analytics adapter plugins available to track header bidding pe
 | PubWise                                                          | Free & Paid, see [pricing](https://pubwise.io/pricing/)                                    | [Website](https://pubwise.io/pubwise/)                                   |          0.24 |
 | Assertive Yield (contact for adapter) | Free to try (Large accounts $0.002 CPM or sampled < 10mm/m imp.) | [Website](https://yield.assertcom.de) | |
 | Vuble                                                            | Contact vendor                                                                      | [Website](https://vuble.tv/us/prebid/)                           |               |
+| YuktaMedia Analytics                                                      | Contact vendor                                                                      | [website](https://yuktamedia.com/prebid/)                                        | 1.0.0 |
 
 None of these analytics options are endorsed or supported by Prebid.org.
 


### PR DESCRIPTION
I have submitted PR for analytic adapter and it is merged in master [#2392](https://github.com/prebid/Prebid.js/pull/2392) I also submitted PR [#710](https://github.com/prebid/prebid.github.io/pull/710) in document repository to update analytics page with yuktamedia adapter it is also merged and available in analytics page but Adapter is still not included in download page. Can you please update download page with adapter added in list.
 
Issue [#755](https://github.com/prebid/prebid.github.io/issues/755)