### PR TITLE
Fix typos in examples (bids is not a child of mediaTypes)

### DIFF
--- a/dev-docs/publisher-api-reference-old.md
+++ b/dev-docs/publisher-api-reference-old.md
@@ -623,40 +623,42 @@ See the table below for the list of properties in the `mediaTypes` object of the
 For an example of a native ad unit, see below.  For more detailed instructions, see [Show Native Ads]({{site.baseurl}}/dev-docs/show-native-ads.html).
 
 ```javascript
-    pbjs.addAdUnits({
-        code: slot.code,
-        mediaTypes: {
-            native: {
-                image: {
-                    required: true,
-                    sizes: [150, 50]
-                },
-                title: {
-                    required: true,
-                    len: 80
-                },
-                sponsoredBy: {
-                    required: true
-                },
-                clickUrl: {
-                    required: true
-                },
-                body: {
-                    required: true
-                },
-                icon: {
-                    required: true,
-                    sizes: [50, 50]
-                }
+pbjs.addAdUnits({
+    code: slot.code,
+    mediaTypes: {
+        native: {
+            image: {
+                required: true,
+                sizes: [150, 50]
             },
-            bids: [{
-                bidder: 'appnexus',
-                params: {
-                    placementId: 13232354
-                }
-            }, ]
+            title: {
+                required: true,
+                len: 80
+            },
+            sponsoredBy: {
+                required: true
+            },
+            clickUrl: {
+                required: true
+            },
+            body: {
+                required: true
+            },
+            icon: {
+                required: true,
+                sizes: [50, 50]
+            }
         }
-    })
+    },
+    bids: [
+        {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13232354
+            }
+        }
+    ]
+});
 ```
 
 {% include dev-docs/native-image-asset-sizes.md %}
@@ -724,15 +726,17 @@ pbjs.addAdUnits({
     code: slot.code,
     mediaTypes: {
         banner: {
-            sizes: [[300, 250], [300, 600]]
-        },
-        bids: [{
+            sizes: [[300, 250]]
+        }
+    },
+    bids: [
+        {
             bidder: 'appnexus',
             params: {
                 placementId: 13144370
             }
-        }, ]
-    }
+        }
+    ]
 })
 ```
 

--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -491,40 +491,42 @@ See the table below for the list of properties in the `mediaTypes` object of the
 For an example of a native ad unit, see below.  For more detailed instructions, see [Show Native Ads]({{site.baseurl}}/dev-docs/show-native-ads.html).
 
 ```javascript
-    pbjs.addAdUnits({
-        code: slot.code,
-        mediaTypes: {
-            native: {
-                image: {
-                    required: true,
-                    sizes: [150, 50]
-                },
-                title: {
-                    required: true,
-                    len: 80
-                },
-                sponsoredBy: {
-                    required: true
-                },
-                clickUrl: {
-                    required: true
-                },
-                body: {
-                    required: true
-                },
-                icon: {
-                    required: true,
-                    sizes: [50, 50]
-                }
+pbjs.addAdUnits({
+    code: slot.code,
+    mediaTypes: {
+        native: {
+            image: {
+                required: true,
+                sizes: [150, 50]
             },
-            bids: [{
-                bidder: 'appnexus',
-                params: {
-                    placementId: 13232354
-                }
-            }, ]
+            title: {
+                required: true,
+                len: 80
+            },
+            sponsoredBy: {
+                required: true
+            },
+            clickUrl: {
+                required: true
+            },
+            body: {
+                required: true
+            },
+            icon: {
+                required: true,
+                sizes: [50, 50]
+            }
         }
-    })
+    },
+    bids: [
+        {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13232354
+            }
+        }
+    ]
+});
 ```
 
 {% include dev-docs/native-image-asset-sizes.md %}
@@ -592,15 +594,17 @@ pbjs.addAdUnits({
     code: slot.code,
     mediaTypes: {
         banner: {
-            sizes: [[300, 250], [300, 600]]
-        },
-        bids: [{
+            sizes: [[300, 250]]
+        }
+    },
+    bids: [
+        {
             bidder: 'appnexus',
             params: {
                 placementId: 13144370
             }
-        }, ]
-    }
+        }
+    ]
 })
 ```
 


### PR DESCRIPTION
These same examples are also in adunit-reference.md but they were correct in that file, so I copied them to publisher-api-reference.md and publisher-api-reference-old.md where they were incorrect.

More generally, it might make sense to reorganize the docs so the same information is not copy/pasted in multiple places, but I wouldn't want to do that in my first PR :)