### PR TITLE
Update s2sconfig references

### DIFF
--- a/dev-docs/bidders/prebidServer.md
+++ b/dev-docs/bidders/prebidServer.md
@@ -18,16 +18,16 @@ Sign up for account on [prebid.adnxs.com](https://prebid.adnxs.com)
 
 ### bid params
 
-Bid params are sourced from the adapter configurations set for client side. These do not need to change for Prebid Server. 
+Bid params are sourced from the adapter configurations set for client side. These do not need to change for Prebid Server.
 
 ### Configuration
-To enable prebid server, set the following configuration. 
+To enable prebid server, set the following configuration.
 
 ```
 pbjs.setConfig({
     s2sConfig: {
         accountId : '12345',
-        bidders : ['appnexus','pubmatic', 'rubicon'], 
+        bidders : ['appnexus','pubmatic', 'rubicon'],
         defaultVendor: 'appnexus'
     }
 });
@@ -39,9 +39,9 @@ Configuration options
 |--------------+---------------+-----------+--------------------------------------------------------------------------|
 | `accountId`  | String        | X         | Prebid Server account ID.                                                |
 | `bidders`    | Array[String] | X         | List of bidder codes; must have been enabled during Prebid.js build.     |
-| `defaultVendor` | String     |           | Automatically includes all following options in the config with vendor's default values.  Individual properties can be overridden by including them in the config along with this setting. | 
+| `defaultVendor` | String     |           | Automatically includes all following options in the config with vendor's default values.  Individual properties can be overridden by including them in the config along with this setting. |
 | `enabled`    | Boolean       | X         | Enables S2S; default: `false`.                                           |
-| `endpoint`   | String        | X         | Set the endpoint. For example: `https://prebid.adnxs.com/pbs/v1/auction` |
+| `endpoint`   | String        | X         | Set the endpoint. For example: `https://prebid.adnxs.com/pbs/v1/openrtb2/auction` |
 | `timeout`    | Number        |           | Bidder timeout, in milliseconds; default: `1000`.                         |
 | `syncEndpoint` | String     |           | Configures the user-sync endpoint. Highly recommended.                    |
 | `adapter`    | String        |           | Adapter code; default: `"prebidServer"`.                                  |

--- a/dev-docs/get-started-with-prebid-server.md
+++ b/dev-docs/get-started-with-prebid-server.md
@@ -122,7 +122,7 @@ pbjs.que.push(function() {
 
 {: .alert.alert-info :}
 **OpenRTB Endpoint**
-If your `s2sConfig.endpoint` points to a url containing the path `openrtb2/auction`, such as the AppNexus-hosted endpoint https://prebid.adnxs.com/pbs/v1/openrtb2/auction', Prebid will communicate with that endpoint using the OpenRTB protocol.
+If your `s2sConfig.endpoint` points to a url containing the path `/openrtb2/`, such as the AppNexus-hosted endpoint https://prebid.adnxs.com/pbs/v1/openrtb2/auction', Prebid will communicate with that endpoint using the OpenRTB protocol.
 
 {: .alert.alert-info :}
 **Additional `cookieSet` details**

--- a/dev-docs/get-started-with-prebid-server.md
+++ b/dev-docs/get-started-with-prebid-server.md
@@ -21,7 +21,7 @@ Using Prebid Server, you can move demand partners server-side, eliminating most 
 This should help you make more money without sacrificing user experience.
 
 {: .alert.alert-success :}
-**Prebid Server is open source!**  
+**Prebid Server is open source!**
 Prebid Server is an open source project.  [The source code is hosted under the Prebid organization on Github](https://github.com/prebid/prebid-server).
 
 * TOC
@@ -76,7 +76,7 @@ pbjs.que.push(function() {
             bidders: ['appnexus', 'pubmatic'],
             timeout: 1000,
             adapter: 'prebidServer',
-            endpoint: 'https://prebid.adnxs.com/pbs/v1/auction',
+            endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction',
             syncEndpoint: 'https://prebid.adnxs.com/pbs/v1/cookie_sync',
             cookieSet: true,
             cookiesetUrl: 'https://acdn.adnxs.com/cookieset/cs.js'
@@ -104,7 +104,7 @@ pbjs.que.push(function() {
 
     pbjs.setConfig({
         s2sConfig: {
-            accountId: '1',            
+            accountId: '1',
             bidders: ['appnexus', 'pubmatic'],
             defaultVendor: 'appnexus'
         }
@@ -121,13 +121,13 @@ pbjs.que.push(function() {
 {% endhighlight %}
 
 {: .alert.alert-info :}
-**OpenRTB Endpoint**  
-If your `s2sConfig.endpoint` points to a url containing the path `openrtb2/auction`, such as the AppNexus-hosted endpoint https://prebid.adnxs.com/pbs/v1/openrtb2/auction', Prebid will communicate with that endpoint using the OpenRTB protocol.  
+**OpenRTB Endpoint**
+If your `s2sConfig.endpoint` points to a url containing the path `openrtb2/auction`, such as the AppNexus-hosted endpoint https://prebid.adnxs.com/pbs/v1/openrtb2/auction', Prebid will communicate with that endpoint using the OpenRTB protocol.
 
 {: .alert.alert-info :}
-**Additional `cookieSet` details**  
-If set to `true`:  
-&bull; Prebid.js will overwrite all links on page to redirect through a persistent cookie URL  
+**Additional `cookieSet` details**
+If set to `true`:
+&bull; Prebid.js will overwrite all links on page to redirect through a persistent cookie URL
 &bull; Prebid.js will display a footer message on Safari indicating that cookies will be placed on browsers that block 3rd party cookies
 
 <a name="prebid-server-video-openrtb" />

--- a/dev-docs/prebid-1.0-API.md
+++ b/dev-docs/prebid-1.0-API.md
@@ -80,7 +80,7 @@ pbjs.setConfig({
 
 ## No More Default Endpoints
 
-In Prebid 0.x there were defaults for the Prebid Server endpoints and the video cache URL. With 1.0, these defaults have been removed to be vendor neutral, so all publisher pages must define them via pbjs.setConfig(). The same functionality as 0.x may be achieved as shown below: 
+In Prebid 0.x there were defaults for the Prebid Server endpoints and the video cache URL. With 1.0, these defaults have been removed to be vendor neutral, so all publisher pages must define them via pbjs.setConfig(). The same functionality as 0.x may be achieved as shown below:
 
 {% highlight js %}
 
@@ -88,7 +88,7 @@ pbjs.setConfig({
     cache: {url: "https://prebid.adnxs.com/pbc/v1/cache"},
     s2sConfig: {
         ...
-        endpoint: "https://prebid.adnxs.com/pbs/v1/auction",
+        endpoint: "https://prebid.adnxs.com/pbs/v1/openrtb2/auction",
         syncEndpoint: "https://prebid.adnxs.com/pbs/v1/cookie_sync",
         ...
     }
@@ -96,7 +96,7 @@ pbjs.setConfig({
 
 {% endhighlight %}
 
-## Size Mapping Changes 
+## Size Mapping Changes
 
 The previous [`sizeMapping` functionality]({{site.baseurl}}/dev-docs/examples/size-mapping.html) will be removed and replaced by a `sizeConfig` parameter to the `pbjs.setConfig` method that provides a more powerful way to describe types of devices and
 screens.
@@ -234,9 +234,9 @@ adUnit = {
             context: 'outstream',
             playerSize: [600, 480]
         },
-        banner: { 
+        banner: {
             sizes: [300, 250],
-            ...options 
+            ...options
         },
         native: { ...options }
     },

--- a/dev-docs/publisher-api-reference-old.md
+++ b/dev-docs/publisher-api-reference-old.md
@@ -1426,7 +1426,7 @@ pbjs.setConfig({
         enabled: true,
         timeout: 1000,
         adapter: 'prebidServer',
-        endpoint: 'https://prebid.adnxs.com/pbs/v1/auction',
+        endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction',
         syncEndpoint: 'https://prebid.adnxs.com/pbs/v1/cookie_sync'
         cookieSet: true,
         cookieSetUrl: 'https://acdn.adnxs.com/cookieset/cs.js',
@@ -1664,7 +1664,7 @@ labelAll: ["A", "B"]
 Only one conditional may be specified on a given AdUnit or bid -- if both `labelAny` and `labelAll` are specified, only the first one will be utilized and an error will be logged to the console. It is allowable for an AdUnit to have one condition and a bid to have another.
 
 {: .alert.alert-warning :}
-If either `labeAny` or `labelAll` values is an empty array, it evaluates to `true`. 
+If either `labeAny` or `labelAll` values is an empty array, it evaluates to `true`.
 
 Label targeting on the ad unit looks like the following:
 

--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -1084,7 +1084,7 @@ For more information about the asynchronous event loop and `setTimeout`, see [Ho
 
 #### Send All Bids
 
-Sending all bids is the default, but should you wish to turn it off: 
+Sending all bids is the default, but should you wish to turn it off:
 
 {% highlight js %}
 pbjs.setConfig({ enableSendAllBids: false })
@@ -1150,7 +1150,7 @@ pbjs.setConfig({ cookieSyncDelay: 100 )
 
 #### Price Granularity
 
-This config is used to configure which price bucket is used for the `hb_pb` keyword. 
+This config is used to configure which price bucket is used for the `hb_pb` keyword.
 For an example showing how to use this method, see the [Simplified price bucket setup](/dev-docs/examples/simplified-price-bucket-setup.html).
 
 {% highlight js %}
@@ -1268,7 +1268,7 @@ pbjs.setConfig({
         enabled: true,
         timeout: 1000,
         adapter: 'prebidServer',
-        endpoint: 'https://prebid.adnxs.com/pbs/v1/auction',
+        endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction',
         syncEndpoint: 'https://prebid.adnxs.com/pbs/v1/cookie_sync'
         cookieSet: true,
         cookieSetUrl: 'https://acdn.adnxs.com/cookieset/cs.js',


### PR DESCRIPTION
`/auction` on PBS was replaced by `/openrtb2/auction` quite a while ago.

This just updates the docs to fix it. Looks like my IDE trimmed a bunch of trailing whitespace too. I can undo this if it makes review easier, but... we probably shouldn't have trailing whitespace anyway.