### PR TITLE
Added a list of Prebid Server adapters

### DIFF
--- a/assets/js/prebid-server-api.js
+++ b/assets/js/prebid-server-api.js
@@ -1,5 +1,4 @@
 var pbs = function() {
-
   function getJSON(url, onSuccess, onFailure) {
     req = new XMLHttpRequest();
     req.onreadystatechange = function() {
@@ -18,8 +17,6 @@ var pbs = function() {
   return {
     // Calls onSuccess() with a list of Prebid Server bidders, like ["appnexus", "adform", "adtelligent", ...],
     // or onFailure with the HTTP status & response text if the call failed.
-    fetchBidders: function(onSuccess, onFailure) {
-      getJSON("https://prebid.adnxs.com/pbs/v1/info/bidders", onSuccess, onFailure)
-    }
+    fetchBidders: getJSON.bind(null, "https://prebid.adnxs.com/pbs/v1/info/bidders")
   }
 }()

--- a/assets/js/prebid-server-api.js
+++ b/assets/js/prebid-server-api.js
@@ -4,7 +4,11 @@ var pbs = function() {
     req.onreadystatechange = function() {
       if (req.readyState === 4) {
         if (req.status === 200) {
-          onSuccess(JSON.parse(req.responseText));
+          try {
+            onSuccess(JSON.parse(req.responseText));
+          } catch (e) {
+            onFailure(req.status, e.message)
+          }
         } else {
           onFailure(req.status, req.responseText);
         }

--- a/assets/js/prebid-server-api.js
+++ b/assets/js/prebid-server-api.js
@@ -1,0 +1,25 @@
+var pbs = function() {
+
+  function getJSON(url, onSuccess, onFailure) {
+    req = new XMLHttpRequest();
+    req.onreadystatechange = function() {
+      if (req.readyState === 4) {
+        if (req.status === 200) {
+          onSuccess(JSON.parse(req.responseText));
+        } else {
+          onFailure(req.status, req.responseText);
+        }
+      }
+    }
+    req.open("GET", url);
+    req.send();
+  }
+
+  return {
+    // Calls onSuccess() with a list of Prebid Server bidders, like ["appnexus", "adform", "adtelligent", ...],
+    // or onFailure with the HTTP status & response text if the call failed.
+    fetchBidders: function(onSuccess, onFailure) {
+      getJSON("https://prebid.adnxs.com/pbs/v1/info/bidders", onSuccess, onFailure)
+    }
+  }
+}()

--- a/dev-docs/get-started-with-prebid-server.md
+++ b/dev-docs/get-started-with-prebid-server.md
@@ -184,7 +184,7 @@ var adUnit1 = {
     function onError(status, err) {
         var list = document.getElementById("prebid-server-bidder-list");
         var err = document.createElement("span")
-        err.innerHTML = "Failed to fetch Prebid Server adapters. HTTP status: " + status + ". response:  " + err;
+        err.innerHTML = "Failed to fetch Prebid Server adapters. HTTP status: " + status + ". error: " + err;
         list.parentNode.replaceChild(list, err)
     }
     pbs.fetchBidders(onSuccess, onError);

--- a/dev-docs/get-started-with-prebid-server.md
+++ b/dev-docs/get-started-with-prebid-server.md
@@ -7,18 +7,18 @@ top_nav_section: dev_docs
 nav_section: prebid-server
 ---
 
+<script type="text/javascript" src="{{site.baseurl}}/assets/js/prebid-server-api.js"></script>
 <div class="bs-docs-section" markdown="1">
 
 # Get Started with Prebid Server
 {:.no_toc}
 
-This page has instructions for adding Prebid Server to Prebid.js.
+Prebid Server improves your page's performance by running the header bidding auction on a server.
+This will improve your page's load time, which should improve your users' experience.
 
-For many publishers, client-side header bidding is a balancing act between the inclusion of demand partners and impact to the page.
+The following adapters are supported by Prebid Server:
 
-Using Prebid Server, you can move demand partners server-side, eliminating most of the latency impact that comes with adding more partners.
-
-This should help you make more money without sacrificing user experience.
+<ul id="prebid-server-bidder-list"></ul>
 
 {: .alert.alert-success :}
 **Prebid Server is open source!**
@@ -170,3 +170,23 @@ var adUnit1 = {
 + [Add a Bidder Adapter to Prebid Server]({{site.baseurl}}/dev-docs/add-a-prebid-server-adapter.html)
 
 </div>
+<script type="text/javascript" async>
+(function() {
+    function onSuccess(bidders) {
+        bidders.sort();
+        var list = document.getElementById("prebid-server-bidder-list");
+        for (var i = 0; i < bidders.length; i++) {
+            var thisElement = document.createElement("li")
+            thisElement.innerHTML = bidders[i]
+            list.appendChild(thisElement)
+        }
+    }
+    function onError(status, err) {
+        var list = document.getElementById("prebid-server-bidder-list");
+        var err = document.createElement("span")
+        err.innerHTML = "Failed to fetch Prebid Server adapters. HTTP status: " + status + ". response:  " + err;
+        list.parentNode.replaceChild(list, err)
+    }
+    pbs.fetchBidders(onSuccess, onError);
+})()
+</script>

--- a/dev-docs/get-started-with-prebid-server.md
+++ b/dev-docs/get-started-with-prebid-server.md
@@ -16,7 +16,7 @@ nav_section: prebid-server
 Prebid Server improves your page's performance by running the header bidding auction on a server.
 This will improve your page's load time, which should improve your users' experience.
 
-The following adapters are supported by Prebid Server:
+The following adapters are supported by the latest tagged version of Prebid Server:
 
 <ul id="prebid-server-bidder-list"></ul>
 


### PR DESCRIPTION
This is a proof-of-concept to show how docs can be dynamically generated using the Prebid Server API.

This just adds a list of Prebid Server bidders to the top of the page. When we release new versions, it will update automatically.

I know @jeanstemp plans to revamp the PBS pages in general, so I'm sure there are better places than this... but at the moment, I don't really know where they would be :x.