### PR TITLE
gdpr-support for underdogmedia

### DIFF
--- a/dev-docs/bidders/underdogmedia.md
+++ b/dev-docs/bidders/underdogmedia.md
@@ -8,6 +8,7 @@ hide: true
 biddercode: underdogmedia
 biddercode_longer_than_12: true
 prebid_1_0_supported : true
+gdpr_supported: true
 ---
 
 ### bid params


### PR DESCRIPTION
underdogmedia bid adapter now supports gdpr module.

relevant pull request:
https://github.com/prebid/Prebid.js/pull/2679