### PR TITLE
Add Gamoshi's Gambid adapter documentation

### DIFF
--- a/dev-docs/bidders/gambid.md
+++ b/dev-docs/bidders/gambid.md
@@ -1,0 +1,24 @@
+---
+layout: bidder
+title: Gamoshi Gambid
+description: Prebid Gambid Bidder Adaptor
+top_nav_section: dev_docs
+nav_section: reference
+biddercode: gambid
+biddercode_longer_than_12: false
+hide: true
+prebid_1_0_supported : true
+media_types: banner, video
+gdpr_supported: true
+---
+
+### Bid params
+
+{: .table .table-bordered .table-striped }
+| Name              | Scope    | Description                                                   | Example              |
+|-------------------+----------+---------------------------------------------------------------+----------------------|
+| `supplyPartnerId` | required | ID of the supply partner you created in the Gambid dashboard. | `"12345"`            |
+| `rtbEndpoint`     | optional | If you have a whitelabel account on Gamoshi, specify it here. | `"rtb.mybidder.com"` |
+
+This adapter only requires you to provide your supply partner ID, and optionally your RTB endpoint, in order to request
+bids from your Gamoshi Gambid account.


### PR DESCRIPTION
This PR adds documentation for Gamoshi's Gambid adapter, recently merged back to Prebid.js and released in [`1.13.0`](https://github.com/prebid/Prebid.js/releases/tag/1.13.0) via PR [#2625](https://github.com/prebid/Prebid.js/pull/2625).