### PR TITLE
Change 'Gamoshi Gambid' to simply Gamoshi

### DIFF
--- a/dev-docs/bidders/gambid.md
+++ b/dev-docs/bidders/gambid.md
@@ -1,6 +1,6 @@
 ---
 layout: bidder
-title: Gamoshi Gambid
+title: Gamoshi
 description: Prebid Gambid Bidder Adaptor
 top_nav_section: dev_docs
 nav_section: reference


### PR DESCRIPTION
This is a minor change to the adapter title from "Gamoshi Gambid" to simply "Gamoshi" as it's commonly used.

This will also affect the checkbox in the Download page, right? (in addition to the "Bidder's Params" page)