### PR TITLE
Add PBS bidder info

### DIFF
--- a/assets/js/prebid-server-api.js
+++ b/assets/js/prebid-server-api.js
@@ -21,6 +21,11 @@ var pbs = function() {
   return {
     // Calls onSuccess() with a list of Prebid Server bidders, like ["appnexus", "adform", "adtelligent", ...],
     // or onFailure with the HTTP status & response text if the call failed.
-    fetchBidders: getJSON.bind(null, "https://prebid.adnxs.com/pbs/v1/info/bidders")
+    fetchBidders: getJSON.bind(null, "https://prebid.adnxs.com/pbs/v1/info/bidders"),
+    // calls onSuccess() with something like:
+    //   {"maintainer":{"email":"info@prebid.org"},"capabilities":{"app":{"mediaTypes":["banner","native"]},"site":{"mediaTypes":["banner","video","native"]}}}
+    fetchBidderInfo: function(bidder, onSuccess, onFailure) {
+      getJSON("http://prebid.adnxs.com/pbs/v1/info/bidders/" + bidder, onSuccess, onFailure);
+    }
   }
 }()

--- a/dev-docs/prebid-server-bidders.md
+++ b/dev-docs/prebid-server-bidders.md
@@ -77,6 +77,11 @@ All the Prebid Server bidders are listed below. Select one, and then choose an o
       });
       return button;
     }
+    function newParagraph(text) {
+      var p = document.createElement("p");
+      p.textContent = text;
+      return p;
+    }
     function makeList(elements) {
       var ul = document.createElement("ul");
       for (var i = 0; i < elements.length; i++) {
@@ -98,23 +103,17 @@ All the Prebid Server bidders are listed below. Select one, and then choose an o
       var output = document.getElementById("output-workspace");
       output.innerHTML = "";
       function showBidderInfo(info) {
-        var contact = document.createElement("p");
-        contact.textContent = "Contact email: " + info.maintainer.email;
-        output.appendChild(contact);
-        function process(capabilities, source, client) {
+        output.appendChild(newParagraph("Contact email: " + info.maintainer.email));
+        function printCapabilities(capabilities, source, client) {
           if (capabilities) {
-            var site  = document.createElement("p");
-            site.textContent = "For " + source + " traffic, this bidder supports the following Media Types:";
-            output.appendChild(site);
+            output.appendChild(newParagraph("For " + source + " traffic, this bidder supports the following Media Types:"));
             output.appendChild(makeList(capabilities.mediaTypes));
           } else {
-            var noSite  = document.createElement("p");
-            noSite.textContent = "This bidder does not support " + source + " traffic. Don't use it in " + client + ".";
-            output.appendChild(noSite);
+            output.appendChild(newParagraph("This bidder does not support " + source + " traffic. Don't use it in " + client + "."));
           }
         }
-        process(info.capabilities.site, "Web", "Prebid.js");
-        process(info.capabilities.app, "Mobile App", "Prebid Mobile");
+        printCapabilities(info.capabilities.site, "Web", "Prebid.js");
+        printCapabilities(info.capabilities.app, "Mobile App", "Prebid Mobile");
       }
       function onBidderInfoErr(status, err) {
         var errMsg = document.createElement("p");


### PR DESCRIPTION
Adds another option to the PBS Bidders dropdown.

This one shows the contact email and supported media types per platform.