### PR TITLE
pbjs.markWinningBidAsUsed(adUnitCode) documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ In alphabetical order:
 + Bart van Bragt <github.com@vanbragt.com>
 + Bret Gorsline <bgorsline@rubiconproject.com>
 + Carson Banov <carson@spanishdict.com>
++ Casper van Wezel <casper@poki.com>
 + Chris Hepner <me@chrishepner.info>
 + Christopher Allene <christopher.allene@piximedia.fr>
 + Dan Harton <dan@sparklit.com>

--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -58,8 +58,6 @@ Some methods were deprecated in Prebid 1.0. [Archived pre-1.0 documentation]({{s
   * [.adServers.dfp.buildVideoUrl(options)](#module_pbjs.adServers.dfp.buildVideoUrl)
   * [.markWinningBidAsUsed(markBidRequest)](#module_pbjs.markWinningBidAsUsed)
 
-
-
 <a name="module_pbjs.getAdserverTargeting"></a>
 
 ### pbjs.getAdserverTargeting() ⇒ `object`

--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -56,6 +56,9 @@ Some methods were deprecated in Prebid 1.0. [Archived pre-1.0 documentation]({{s
     * [Troubleshooting your config](#setConfig-Troubleshooting-your-configuration)
   * [.getConfig([string])](#module_pbjs.getConfig)
   * [.adServers.dfp.buildVideoUrl(options)](#module_pbjs.adServers.dfp.buildVideoUrl)
+  * [.markWinningBidAsUsed(adUnitCode)](#module_pbjs.markWinningBidAsUsed)
+
+
 
 <a name="module_pbjs.getAdserverTargeting"></a>
 
@@ -1110,12 +1113,12 @@ For more information about the asynchronous event loop and `setTimeout`, see [Ho
 <a name="setConfig-Max-Requests-Per-Origin" />
 
 Since browsers have a limit of how many requests they will allow to a specific domain before they block, Prebid.js
-will queue auctions that would cause requests to a specific origin to exceed that limit.  The limit is different 
-for each browser. Prebid.js defaults to a max of `4` requests per origin.  That value can be configured with 
+will queue auctions that would cause requests to a specific origin to exceed that limit.  The limit is different
+for each browser. Prebid.js defaults to a max of `4` requests per origin.  That value can be configured with
 `maxRequestsPerOrigin`.
 
 {% highlight js %}
-// most browsers allow at least 6 requests, but your results may vary for your user base.  Sometimes using all 
+// most browsers allow at least 6 requests, but your results may vary for your user base.  Sometimes using all
 // `6` requests can impact performance negatively for users with poor internet connections.
 pbjs.setConfig({ maxRequestsPerOrigin: 6 });
 
@@ -1782,7 +1785,26 @@ var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
 });
 ```
 
+<a name="module_pbjs.requestBids"></a>
+
 {: .alert.alert-warning :}
 In the event of collisions, querystring values passed via `options.params` take precedence over those passed via `options.url`.
+
+<hr class="full-rule">
+
+<a name="module_pbjs.markWinningBidAsUsed"></a>
+
+### pbjs.markWinningBidAsUsed(adUnitCode)
+
+This function can be used to mark the winning bid as used. This is useful when running multiple video advertisements on the page, since these are not automatically marked as “rendered”.
+
+**Kind**: static method of [pbjs](#module_pbjs)
+
+
+{: .table .table-bordered .table-striped }
+| Param | Scope | Type | Description |
+| --- | --- | --- | --- |
+| adUnitCode | Required | `String` | the adUnitCode for which we'll mark the winning bid |
+
 
 </div>

--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -1795,15 +1795,16 @@ In the event of collisions, querystring values passed via `options.params` take 
 ### pbjs.markWinningBidAsUsed(markBidRequest)
 
 This function can be used to mark the winning bid as used. This is useful when running multiple video advertisements on the page, since these are not automatically marked as “rendered”.
+If you know the adId, then be specific, otherwise Prebid will retrieve the winning bid for the adUnitCode and mark it accordingly.
 
 #### Argument Reference
 
-##### The `markBidRequest` object
+##### The `markBidRequest` object (use one or both)
 
 {: .table .table-bordered .table-striped }
 | Param | Type | Description |
 | --- | --- | --- |
-| adUnitCode | `string` | The ad unit code |
-| adId | `string` | The id representing the ad we want to mark |
+| adUnitCode | `string` | (Optional) The ad unit code |
+| adId | `string` | (Optional) The id representing the ad we want to mark |
 
 </div>

--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -56,7 +56,7 @@ Some methods were deprecated in Prebid 1.0. [Archived pre-1.0 documentation]({{s
     * [Troubleshooting your config](#setConfig-Troubleshooting-your-configuration)
   * [.getConfig([string])](#module_pbjs.getConfig)
   * [.adServers.dfp.buildVideoUrl(options)](#module_pbjs.adServers.dfp.buildVideoUrl)
-  * [.markWinningBidAsUsed(adUnitCode)](#module_pbjs.markWinningBidAsUsed)
+  * [.markWinningBidAsUsed(markBidRequest)](#module_pbjs.markWinningBidAsUsed)
 
 
 
@@ -1794,17 +1794,18 @@ In the event of collisions, querystring values passed via `options.params` take 
 
 <a name="module_pbjs.markWinningBidAsUsed"></a>
 
-### pbjs.markWinningBidAsUsed(adUnitCode)
+### pbjs.markWinningBidAsUsed(markBidRequest)
 
 This function can be used to mark the winning bid as used. This is useful when running multiple video advertisements on the page, since these are not automatically marked as “rendered”.
 
-**Kind**: static method of [pbjs](#module_pbjs)
+#### Argument Reference
 
+##### The `markBidRequest` object
 
 {: .table .table-bordered .table-striped }
-| Param | Scope | Type | Description |
-| --- | --- | --- | --- |
-| adUnitCode | Required | `String` | the adUnitCode for which we'll mark the winning bid |
-
+| Param | Type | Description |
+| --- | --- | --- |
+| adUnitCode | `string` | The ad unit code |
+| adId | `string` | The id representing the ad we want to mark |
 
 </div>

--- a/dev-docs/show-video-with-a-dfp-video-tag.md
+++ b/dev-docs/show-video-with-a-dfp-video-tag.md
@@ -127,6 +127,28 @@ You can show video ads even if Prebid Cache is disabled.  However, there are som
     + If Prebid Cache is enabled, Prebid does not set the `description_url` field to the bid response's `bid.vastUrl`. It just attaches the bid's ad server targeting and builds the URL based on user input.
     + If Prebid Cache is disabled, Prebid sets the `description_url` field to the bid response's `bid.vastUrl`.
 
+#### Notes on multiple video advertisements on one page
+
+Display banners are rendered with the help of the renderAd function. This function automatically marks a bid as used. In the case of video we use a VAST-chain to display the advertisement, this has the downside that there is no way to automatically mark the video as shown. If you run multiple video-advertisements on the same page you’ll need to proactively mark the ad as shown or risk serving the same advertisements multiple times.
+
+```javascript
+pbjs.requestBids({
+    bidsBackHandler: function(bids) {
+        var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
+            adUnit: videoAdUnit,
+            params: {
+                iu: '/19968336/prebid_cache_video_adunit'
+            }
+        });
+
+        // Mark the bid, used in buildVideoUrl, as used
+        pbjs.markWinningBidAsUsed(videoAdUnit.code)
+
+        invokeVideoPlayer(videoUrl);
+    }
+});
+```
+
 ### 4. Invoke video player on Prebid video URL
 
 In the body of the page, the following HTML and JS will show the ad:

--- a/dev-docs/show-video-with-a-dfp-video-tag.md
+++ b/dev-docs/show-video-with-a-dfp-video-tag.md
@@ -134,15 +134,22 @@ Display banners are rendered with the help of the renderAd function. This functi
 ```javascript
 pbjs.requestBids({
     bidsBackHandler: function(bids) {
+        // The video advertisement you want to show
+        const bid = ...
+
         var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
             adUnit: videoAdUnit,
+            bid: bid
             params: {
                 iu: '/19968336/prebid_cache_video_adunit'
             }
         });
 
         // Mark the bid, used in buildVideoUrl, as used
-        pbjs.markWinningBidAsUsed(videoAdUnit.code)
+        pbjs.markWinningBidAsUsed({
+            adUnitCode: videoAdUnit.code
+            adId: bid.adId
+        });
 
         invokeVideoPlayer(videoUrl);
     }

--- a/dev-docs/show-video-with-a-dfp-video-tag.md
+++ b/dev-docs/show-video-with-a-dfp-video-tag.md
@@ -134,12 +134,8 @@ Display banners are rendered with the help of the renderAd function. This functi
 ```javascript
 pbjs.requestBids({
     bidsBackHandler: function(bids) {
-        // The video advertisement you want to show
-        const bid = ...
-
         var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
             adUnit: videoAdUnit,
-            bid: bid
             params: {
                 iu: '/19968336/prebid_cache_video_adunit'
             }
@@ -147,8 +143,8 @@ pbjs.requestBids({
 
         // Mark the bid, used in buildVideoUrl, as used
         pbjs.markWinningBidAsUsed({
-            adUnitCode: videoAdUnit.code
-            adId: bid.adId
+            adUnitCode: videoAdUnit.code // optional if you know the adId
+            adId: bid.adId // optional
         });
 
         invokeVideoPlayer(videoUrl);


### PR DESCRIPTION
Documentation for a new (global) function pbjs.markWinningBidAsUsed(adUnitCode) as discussed in https://github.com/prebid/Prebid.js/issues/2282