### PR TITLE
Proguard exemptions

### DIFF
--- a/prebid-mobile/code-integration-android.md
+++ b/prebid-mobile/code-integration-android.md
@@ -179,6 +179,10 @@ To avoid PrebidServerAdapter class being obfuscated and prebid not working, add 
 -keep class org.prebid.mobile.prebidserver.PrebidServerAdapter {
    public *;
 }
+
+-keepnames class org.prebid.mobile.prebidserver.PrebidServerAdapter {
+   public *;
+}
 ```
 
 </div>

--- a/prebid-mobile/code-integration-android.md
+++ b/prebid-mobile/code-integration-android.md
@@ -173,6 +173,12 @@ To avoid dfp class being obfuscated and prebid not working, add the following li
    public *;
 }
 ```
-
+### Primary Ad Server is DFP
+To avoid PrebidServerAdapter class being obfuscated and prebid not working, add the following lines to your proguard file:
+```
+-keep class org.prebid.mobile.prebidserver.PrebidServerAdapter {
+   public *;
+}
+```
 
 </div>

--- a/prebid-mobile/code-integration-android.md
+++ b/prebid-mobile/code-integration-android.md
@@ -173,7 +173,7 @@ To avoid dfp class being obfuscated and prebid not working, add the following li
    public *;
 }
 ```
-### Primary Ad Server is DFP
+
 To avoid PrebidServerAdapter class being obfuscated and prebid not working, add the following lines to your proguard file:
 ```
 -keep class org.prebid.mobile.prebidserver.PrebidServerAdapter {


### PR DESCRIPTION
Important to add PrebidServerAdapter package in proguard exemptions or you will get an error during the Prebid initialisation:
UNABLE_TO_INITIALIZE_DEMAND_SOURCE("Unable to instantiating the adapter.")

It is indeed failing to access PrebidServerAdapter package and raise an error when trying to create an instance of the class "org.prebid.mobile.prebidserver.PrebidServerAdapter" (line 141 of prebid.java)