### PR TITLE
Add AJA adapter docs

### DIFF
--- a/dev-docs/bidders/aja.md
+++ b/dev-docs/bidders/aja.md
@@ -1,0 +1,19 @@
+---
+layout: bidder
+title: AJA Inc.
+description: Prebid AJA Inc. Bidder Adaptor
+top_nav_section: dev_docs
+nav_section: reference
+hide: true
+biddercode: aja
+biddercode_longer_than_12: false
+prebid_1_0_supported: true
+media_types: video
+---
+
+### bid params
+
+{: .table .table-bordered .table-striped }
+| Name  | Scope    | Description  | Example | Type     |
+|-------|----------|--------------|---------|----------|
+| `asi` | required | `as slot id` |         | `string` |

--- a/dev-docs/bidders/aja.md
+++ b/dev-docs/bidders/aja.md
@@ -11,9 +11,13 @@ prebid_1_0_supported: true
 media_types: video
 ---
 
+### Note:
+
+The AJA Bidding adaptor requires setup and approval before beginning. Please reach out to <ssp_support@aja-kk.co.jp> for more details
+
 ### bid params
 
 {: .table .table-bordered .table-striped }
-| Name  | Scope    | Description  | Example | Type     |
-|-------|----------|--------------|---------|----------|
-| `asi` | required | `as slot id` |         | `string` |
+| Name  | Scope    | Description         | Example    | Type     |
+|-------|----------|---------------------|------------|----------|
+| `asi` | required | ad spot hash code   | `'123abc'` | `string` |


### PR DESCRIPTION
This adds documentation to the AJA bidder adapter, in relation to https://github.com/prebid/Prebid.js/pull/2934