### PR TITLE
Set the s2sconfig to enabled in the video examples.

### DIFF
--- a/examples/video/jwplatform-pbserver-demo.html
+++ b/examples/video/jwplatform-pbserver-demo.html
@@ -64,6 +64,7 @@
                     debug: true,
                     s2sConfig: {
                         endpoint: 'http://prebid.adnxs.com/pbs/v1/openrtb2/auction',
+                        enabled: true,
                         accountId: 'c9d412ee-3cc6-4b66-9326-9f49d528f13e',
                         bidders: ['appnexus']
                     }

--- a/examples/video/jwplayer-pbserver-demo.html
+++ b/examples/video/jwplayer-pbserver-demo.html
@@ -72,6 +72,7 @@
                     enableSendAllBids: true,
                     s2sConfig: {
                         endpoint: 'http://prebid.adnxs.com/pbs/v1/openrtb2/auction',
+                        enabled: true,
                         accountId: 'c9d412ee-3cc6-4b66-9326-9f49d528f13e',
                         bidders: ['appnexus']
                     }

--- a/examples/video/jwplayer7-pbserver-demo.html
+++ b/examples/video/jwplayer7-pbserver-demo.html
@@ -71,6 +71,7 @@
                     enableSendAllBids: true,
                     s2sConfig: {
                         endpoint: 'http://prebid.adnxs.com/pbs/v1/openrtb2/auction',
+                        enabled: true,
                         accountId: 'c9d412ee-3cc6-4b66-9326-9f49d528f13e',
                         bidders: ['appnexus']
                     }

--- a/examples/video/jwplaylist-pbserver-demo.html
+++ b/examples/video/jwplaylist-pbserver-demo.html
@@ -72,6 +72,7 @@
                     debug: true,
                     s2sConfig: {
                         endpoint: 'http://prebid.adnxs.com/pbs/v1/openrtb2/auction',
+                        enabled: true,
                         accountId: 'c9d412ee-3cc6-4b66-9326-9f49d528f13e',
                         bidders: ['appnexus']
                     }

--- a/examples/video/kaltura-pbserver-demo.html
+++ b/examples/video/kaltura-pbserver-demo.html
@@ -66,6 +66,7 @@
                     debug: true,
                     s2sConfig: {
                         endpoint: 'http://prebid.adnxs.com/pbs/v1/openrtb2/auction',
+                        enabled: true,
                         accountId: 'c9d412ee-3cc6-4b66-9326-9f49d528f13e',
                         bidders: ['appnexus']
                     }

--- a/examples/video/ooyala-pbserver-demo.html
+++ b/examples/video/ooyala-pbserver-demo.html
@@ -96,6 +96,7 @@
                     debug: true,
                     s2sConfig: {
                         endpoint: 'http://prebid.adnxs.com/pbs/v1/openrtb2/auction',
+                        enabled: true,
                         accountId: 'c9d412ee-3cc6-4b66-9326-9f49d528f13e', // replace this with your account id
                         bidders: ['appnexus']
                     }

--- a/examples/video/videojs-pbserver-demo.html
+++ b/examples/video/videojs-pbserver-demo.html
@@ -74,6 +74,7 @@
                     debug: true,
                     s2sConfig: {
                         endpoint: 'http://prebid.adnxs.com/pbs/v1/openrtb2/auction',
+                        enabled: true,
                         accountId: 'c9d412ee-3cc6-4b66-9326-9f49d528f13e', // replace this with your account id
                         bidders: ['appnexus']
                     }


### PR DESCRIPTION
The Prebid Server Video examples weren't actually using Prebid Server, because `s2sconfig.enabled` wasn't set to true.

This fixes that.