### PR TITLE
update cache URL

### DIFF
--- a/adops/setting-up-prebid-video-in-dfp.md
+++ b/adops/setting-up-prebid-video-in-dfp.md
@@ -46,22 +46,10 @@ Be sure to duplicate your line item and video creative for each Prebid price buc
 
 2\. In the dialog that appears, set the **creative set type** to **"Redirect"**
 
-3\. Set the **VAST tag URL** to the cache location. Note that each bidder may have a different cache location URL.
+3\. Set the **VAST tag URL** to the cache location. Note that each bidder, e.g. Rubicon Project, may have a different cache location URL.
 
-Prebid.js versions 1.6+, 0.34.6+:
-{% highlight html %}
-   https://prebid.adnxs.com/pbc/v1/cache?uuid=%%PATTERN:hb_cache_id%%
-or
-   https://prebid-server.rubiconproject.com/cache?uuid=%%PATTERN:hb_cache_id%%
-or
-   [other bidder cache location]
-{% endhighlight %}
-
-Prebid.js versions 1.0-1.5, 0.x-0.34.5:
 {% highlight html %}
    https://prebid.adnxs.com/pbc/v1/cache?uuid=%%PATTERN:hb_uuid%%
-or
-   https://prebid-server.rubiconproject.com/cache?uuid=%%PATTERN:hb_uuid%%
 or
    [other bidder cache location]
 {% endhighlight %}

--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -835,12 +835,6 @@ Prebid.js will set 6 keys (`hb_bidder`, `hb_adid`, `hb_pb`, `hb_size`, `hb_sourc
 In addition, video will receive two additional keys: `hb_cache_id` and `hb_uuid`.
 The key value pair targeting is applied to the bid's corresponding ad unit. Your ad ops team will have the ad server's line items and creatives to utilize these keys.
 
-   {: .alert.alert-warning :}
-   Note that `hb_cache_id` will be the video ad server targeting variable going forward.
-   In previous versions, mobile used `hb_cache_id` and video used `hb_uuid`. There will be a
-   transition period where both of these values are provided to the ad server.
-   Please begin converting video creatives to use `hb_cache_id`.
-
 If you'd like to customize the key value pairs, you can overwrite the settings as the below example shows. *Note* that once you updated the settings, let your ad ops team know about the change, so they can update the line item targeting accordingly. See the [Ad Ops](../adops.html) documentation for more information.
 
 <a name="bidderSettingsDefault"></a>


### PR DESCRIPTION
- removing Rubicon URL in advance of our coming platform change
- hb_cache_id was never implemented for video - removing that for now until all the pieces are in place