### PR TITLE
Create setting-up-prebid.js-with-Smart-Ad-Server

### DIFF
--- a/adops/docs-by-ad-server.md
+++ b/adops/docs-by-ad-server.md
@@ -15,7 +15,7 @@ nav_section: reference
 
 This page has all of our Ad Ops setup docs, broken out by ad server.
 
-For code samples and other on-page implementation docs, see [our docs for developers]({{site.github.url}}/dev-docs/getting-started.html).
+For code samples and other on-page implementation docs, see [our docs for developers]({{site.baseurl}}/dev-docs/getting-started.html).
 
 * TOC
 {:toc}
@@ -23,11 +23,12 @@ For code samples and other on-page implementation docs, see [our docs for develo
 {: .table .table-bordered .table-striped }
 | Server       | Page                                                                                                                                    |
 |--------------+-----------------------------------------------------------------------------------------------------------------------------------------|
-| **DFP**      | [Step by step guide to DFP setup]({{site.github.url}}/adops/step-by-step.html)                                                          |
-|              | [Send all bids to the ad server]({{site.github.url}}/adops/send-all-bids-adops.html)                                                    |
-|              | [Setting up Prebid for AMP in DFP]({{site.github.url}}/adops/setting-up-prebid-for-amp-in-dfp.html)                                     |
-|              | [Setting up Prebid Video in DFP]({{site.github.url}}/adops/setting-up-prebid-video-in-dfp.html)                                         |
-|              | [Setting up Prebid Native in DFP]({{site.github.url}}/adops/setting-up-prebid-native-in-dfp.html)                                       |
-| **AppNexus** | [Setting up Prebid with the AppNexus Publisher Ad Server]({{site.github.url}}/adops/setting-up-prebid-with-the-appnexus-ad-server.html) |
+| **DFP**      | [Step by step guide to DFP setup]({{site.baseurl}}/adops/step-by-step.html)                                                          |
+|              | [Send all bids to the ad server]({{site.baseurl}}/adops/send-all-bids-adops.html)                                                    |
+|              | [Setting up Prebid for AMP in DFP]({{site.baseurl}}/adops/setting-up-prebid-for-amp-in-dfp.html)                                     |
+|              | [Setting up Prebid Video in DFP]({{site.baseurl}}/adops/setting-up-prebid-video-in-dfp.html)                                         |
+|              | [Setting up Prebid Native in DFP]({{site.baseurl}}/adops/setting-up-prebid-native-in-dfp.html)                                       |
+| **AppNexus** | [Setting up Prebid with the AppNexus Publisher Ad Server]({{site.baseurl}}/adops/setting-up-prebid-with-the-appnexus-ad-server.html) |
+| **Smart Ad Server** | [Setting up Prebid.js with Smart Ad Server]({{site.baseurl}}/adops/setting-up-prebidjs-with-Smart-Ad-Server.html) |
 
 </div>

--- a/adops/setting-up-prebid.js-with-Smart-Ad-Server
+++ b/adops/setting-up-prebid.js-with-Smart-Ad-Server
@@ -1,0 +1,62 @@
+---
+layout: page
+title: Setting up prebid.js with Smart Ad Server
+head_title: Setting up prebid.js with Smart Ad Server
+description: Setting up prebid.js with Smart Ad Server
+pid: 3
+hide: false
+top_nav_section: adops
+nav_section: tutorials
+---
+
+<div class="bs-docs-section" markdown="1">
+# Setting up prebid.js with Smart Ad Server
+## Introduction
+This article describes the basic steps to set up prebid.js with Smart Ad Server.
+
+Comprehensive documentation is available in the article [Holistic+ Setup](https://support.smartadserver.com/s/article/Holistic-Setup) in Smart’s Help Center. This documentation may be more up to date than the explanations below.
+
+For some of the setup steps described below, you need to have a login to [Smart’s UI](https://manage.smartadserver.com/). 
+
+## How it works
+
+ - you implement the prebid.js header bidding wrapper as well as Smart’s ad tags on your website
+ - the header auction winner’s data (bidder name, CPM, currency) is passed with the ad call executed by Smart’s ad tag
+ - in Smart’s UI, you simply set up an RTB+ insertion in order to establish the competition between the header auction winner and Smart’s connected monetization partners (DSPs);  there is no need to set up multiple line items, price buckets, keyword targeting etc.
+ - at the same time, Smart’s holistic yield algorithm will make sure your direct (guaranteed) campaigns meet their targets
+ - finally, the impression is either given to (1) Smart’s own RTB+ (bid higher than in header action) or (2) a direct campaign (if required to meet targets) or (3) the header auction winner (if Smart’s own RTB+ had no higher bid)
+
+## Setup
+### Step 1 - Implement the wrapper
+Proceed as follows:
+- go to the [prebid.js download page](http://prebid.org/download.html)
+- select the relevant **Bidder Adapter(s)**, an **Analytics Adapter** (optional) and **Module(s)** (optional)
+- download the code
+- consult the [Bidders' Params](http://prebid.org/dev-docs/bidders.html) to get help for filling the parameters
+- make sure you specify the timeout; the timeout is the maximum time to wait until the next step (the Smart ad call) is executed - even if some partners have not responded yet
+- implement the prebid.js file on the site
+
+This step is also documented [here](https://support.smartadserver.com/s/article/Holistic-Setup#implement-wrapper).
+### Step 2 - Implement Smart’s tag
+Smart’s OneCall tagging is strongly recommended. With OneCall, you can set header bidding data per `tagId`. The `tagId` is the Id of the container (`<div>`), where the ad will be displayed. The `tagId` format is `sas_<formatId>` (e. g.: `sas_1234`).
+
+Make sure you use Smart’s **new OneCall tagging**, which uses POST requests with all the necessary information in the request body; simply check if you see the `formats` array in your tag. If you see `formatId`, you are still dealing with an old tag - in this case, get back to your service contact at Smart.
+
+For samples of both the new and legacy Onecall as well as a full implementation example, read [here](https://support.smartadserver.com/s/article/Holistic-Setup#onecall). 
+
+**Additional resources**:
+- [Implementation with Smart’s Standard Call tagging](https://support.smartadserver.com/s/article/Holistic-Setup#implement-smart-tag)
+- [Full tagging guide](https://support.smartadserver.com/s/article/Tagging-guide) 
+### Step 3 - Setup in Smart’s UI
+Things to keep in mind for the Setup in [Smart’s UI](https://manage.smartadserver.com/):
+- in the RTB+ insertion, you must enable the checkbox "Activate Holistic yield mode" (in the "General settings" section of the insertion)
+- RTB+ must be enabled and configured (global settings in the network)
+- the Holistic+ feature must be enabled on the network
+- you must use the official and Holistic RTB+ script templates in the insertions
+
+For more details, read [here](https://support.smartadserver.com/s/article/Holistic-Setup#setup-ui).
+### Step 4 - Get reporting
+Read these articles to learn more about the available header bidding reporting:
+- [Holistic Dashboard](https://support.smartadserver.com/s/article/Holistic-dashboard) - provides a fast and easy overview of basic metrics by delivery channel and RTB product
+- [Big Data Reports](https://support.smartadserver.com/s/article/Holistic-Setup#bdr) - provides full, in-depth reporting with header bidding related dimensions and metrics
+</div>

--- a/adops/setting-up-prebidjs-with-Smart-Ad-Server.md
+++ b/adops/setting-up-prebidjs-with-Smart-Ad-Server.md
@@ -1,8 +1,8 @@
 ---
 layout: page
 title: Setting up prebid.js with Smart Ad Server
-head_title: Setting up prebid.js with Smart Ad Server
-description: Setting up prebid.js with Smart Ad Server
+head_title: Setting up Prebid.js with Smart Ad Server
+description: Setting up Prebid.js with Smart Ad Server
 pid: 3
 hide: false
 top_nav_section: adops

--- a/adops/setting-up-prebidjs-with-Smart-Ad-Server.md
+++ b/adops/setting-up-prebidjs-with-Smart-Ad-Server.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Setting up prebid.js with Smart Ad Server
+title: Setting up Prebid.js with Smart Ad Server
 head_title: Setting up Prebid.js with Smart Ad Server
 description: Setting up Prebid.js with Smart Ad Server
 pid: 3
@@ -10,9 +10,9 @@ nav_section: tutorials
 ---
 
 <div class="bs-docs-section" markdown="1">
-# Setting up prebid.js with Smart Ad Server
+# Setting up Prebid.js with Smart Ad Server
 ## Introduction
-This article describes the basic steps to set up prebid.js with Smart Ad Server.
+This article describes the basic steps to set up Prebid.js with Smart Ad Server.
 
 Comprehensive documentation is available in the article [Holistic+ Setup](https://support.smartadserver.com/s/article/Holistic-Setup) in Smart’s Help Center. This documentation may be more up to date than the explanations below.
 
@@ -20,43 +20,45 @@ For some of the setup steps described below, you need to have a login to [Smart�
 
 ## How it works
 
- - you implement the prebid.js header bidding wrapper as well as Smart’s ad tags on your website
- - the header auction winner’s data (bidder name, CPM, currency) is passed with the ad call executed by Smart’s ad tag
- - in Smart’s UI, you simply set up an RTB+ insertion in order to establish the competition between the header auction winner and Smart’s connected monetization partners (DSPs);  there is no need to set up multiple line items, price buckets, keyword targeting etc.
- - at the same time, Smart’s holistic yield algorithm will make sure your direct (guaranteed) campaigns meet their targets
- - finally, the impression is either given to (1) Smart’s own RTB+ (bid higher than in header action) or (2) a direct campaign (if required to meet targets) or (3) the header auction winner (if Smart’s own RTB+ had no higher bid)
+ - You implement the Prebid.js header bidding wrapper as well as Smart’s ad tags on your website.
+ - The header auction winner’s data (bidder name, CPM, currency) is passed with the ad call executed by Smart’s ad tag.
+ - In Smart’s UI, you simply set up an RTB+ insertion in order to establish the competition between the header auction winner and Smart’s connected monetization partners (DSPs);  there is no need to set up multiple line items, price buckets, keyword targeting etc.
+ - At the same time, Smart’s holistic yield algorithm will make sure your direct (guaranteed) campaigns meet their targets.
+ - Finally, the impression is given to the highest bid: (1) Smart’s own RTB+ (2) a direct campaign or (3) the header auction winner.
 
 ## Setup
 ### Step 1 - Implement the wrapper
 Proceed as follows:
-- go to the [prebid.js download page](http://prebid.org/download.html)
-- select the relevant **Bidder Adapter(s)**, an **Analytics Adapter** (optional) and **Module(s)** (optional)
-- download the code
-- consult the [Bidders' Params](http://prebid.org/dev-docs/bidders.html) to get help for filling the parameters
-- make sure you specify the timeout; the timeout is the maximum time to wait until the next step (the Smart ad call) is executed - even if some partners have not responded yet
-- implement the prebid.js file on the site
+- Go to the [Prebid.js download page](http://prebid.org/download.html).
+- Select the relevant **Bidder Adapter(s)**, an **Analytics Adapter** (optional) and **Module(s)** (optional).
+- Download the code.
+- Consult the [Bidders' Params]({{site.baseurl}}/dev-docs/bidders.html) to get help for filling the parameters.
+- Make sure you specify the timeout; the timeout is the maximum time to wait until the Smart ad call is executed - even if some partners have not responded yet.
+- Implement the Prebid.js file on the site.
 
 This step is also documented [here](https://support.smartadserver.com/s/article/Holistic-Setup#implement-wrapper).
+
 ### Step 2 - Implement Smart’s tag
-Smart’s OneCall tagging is strongly recommended. With OneCall, you can set header bidding data per `tagId`. The `tagId` is the Id of the container (`<div>`), where the ad will be displayed. The `tagId` format is `sas_<formatId>` (e. g.: `sas_1234`).
+Smart’s OneCall tagging is strongly recommended. With OneCall, you can set header bidding data per `tagId`. The `tagId` is the Id of the container (`<div>`), where the ad will be displayed. The `tagId` format is `sas_<formatId>`. e.g. `sas_1234`.
 
 Make sure you use Smart’s **new OneCall tagging**, which uses POST requests with all the necessary information in the request body; simply check if you see the `formats` array in your tag. If you see `formatId`, you are still dealing with an old tag - in this case, get back to your service contact at Smart.
 
-For samples of both the new and legacy Onecall as well as a full implementation example, read [here](https://support.smartadserver.com/s/article/Holistic-Setup#onecall). 
+For samples of both the new and legacy OneCall as well as a full implementation example, read [here](https://support.smartadserver.com/s/article/Holistic-Setup#onecall). 
 
 **Additional resources**:
 - [Implementation with Smart’s Standard Call tagging](https://support.smartadserver.com/s/article/Holistic-Setup#implement-smart-tag)
 - [Full tagging guide](https://support.smartadserver.com/s/article/Tagging-guide) 
+
 ### Step 3 - Setup in Smart’s UI
 Things to keep in mind for the Setup in [Smart’s UI](https://manage.smartadserver.com/):
-- in the RTB+ insertion, you must enable the checkbox "Activate Holistic yield mode" (in the "General settings" section of the insertion)
-- RTB+ must be enabled and configured (global settings in the network)
-- the Holistic+ feature must be enabled on the network
-- you must use the official and Holistic RTB+ script templates in the insertions
+- In the RTB+ insertion, you must enable the checkbox "Activate Holistic yield mode" in the "General settings" section of the insertion.
+- RTB+ must be enabled and configured in the network global settings.
+- The Holistic+ feature must be enabled on the network.
+- You must use the official and Holistic RTB+ script templates in the insertions.
 
 For more details, read [here](https://support.smartadserver.com/s/article/Holistic-Setup#setup-ui).
 ### Step 4 - Get reporting
 Read these articles to learn more about the available header bidding reporting:
-- [Holistic Dashboard](https://support.smartadserver.com/s/article/Holistic-dashboard) - provides a fast and easy overview of basic metrics by delivery channel and RTB product
-- [Big Data Reports](https://support.smartadserver.com/s/article/Holistic-Setup#bdr) - provides full, in-depth reporting with header bidding related dimensions and metrics
+- [Holistic Dashboard](https://support.smartadserver.com/s/article/Holistic-dashboard) - provides a fast and easy overview of basic metrics by delivery channel and RTB product.
+- [Big Data Reports](https://support.smartadserver.com/s/article/Holistic-Setup#bdr) - provides full, in-depth reporting with header bidding related dimensions and metrics.
 </div>


### PR DESCRIPTION
Smart's setup documentation to be listed in http://prebid.org/adops/docs-by-ad-server.html once approved.