### PR TITLE
Fix for bidder layout and anchors tags

### DIFF
--- a/_layouts/bidder.html
+++ b/_layouts/bidder.html
@@ -9,7 +9,11 @@
 
         <div class="row">
 
-            {% include left_nav.html %}
+            <div class="col-md-3">
+                <div class="docs-sidebar">
+                    {% include left_nav.html %}
+                </div>
+            </div>
 
             <div class="col-md-9" role="main">
                 <div class="bs-docs-section">

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -412,3 +412,10 @@ div.pl-doc-entry{
 .prebid-mobile-notice {
     margin-top: 2em;
 }
+
+:target:before {
+  content: "";
+  display: block;
+  height: 60px;
+  margin: -60px 0 0;
+}


### PR DESCRIPTION
The bidder layout is missing a wrapping column for the left nav which causes them to render incorrectly, like here: http://prebid.org/dev-docs/bidders/rubicon.html 
Adding the `col-md-3` around the left nav fixes the problem.

Also added fix for anchor links.  Currently, clicking an anchor link to a fragment causes the target to fall underneath the fixed header.  The css fix in this pull-request causes the targets to be positioned so they're not underneath the fixed header when navigated to.