### PR TITLE
YIELDONE docs - add media_types

### DIFF
--- a/dev-docs/bidders/yieldone.md
+++ b/dev-docs/bidders/yieldone.md
@@ -2,22 +2,23 @@
 layout: bidder
 title: YIELDONE
 description: Prebid YIELDONE Bidder Adaptor
-
 top_nav_section: dev_docs
 nav_section: reference
-
 hide: true
-
 biddercode: yieldone
-
 biddercode_longer_than_12: false
 prebid_1_0_supported : true
+media_types: banner, video
 ---
 
+### Note:
+
+THE YIELDONE adapter requires setup and approval from the YIELDONE team.
+Please reach out to your account team or y1s@platform-one.co.jp for more information.
 
 ### bid params
 
 {: .table .table-bordered .table-striped }
 | Name          | Scope    | Description      | Example | Type     |
 |---------------|----------|------------------|---------|----------|
-| `placementId` | required | The placement ID |         | `string` |
+| `placementId` | required | The placement ID | `36891` | `string` |

--- a/dev-docs/bidders/yieldone.md
+++ b/dev-docs/bidders/yieldone.md
@@ -21,4 +21,4 @@ Please reach out to your account team or y1s@platform-one.co.jp for more informa
 {: .table .table-bordered .table-striped }
 | Name          | Scope    | Description      | Example | Type     |
 |---------------|----------|------------------|---------|----------|
-| `placementId` | required | The placement ID | `36891` | `string` |
+| `placementId` | required | The placement ID | `'36891'` | `string` |


### PR DESCRIPTION
We would like to add media_types to YIELDONE docs.
This is the code: prebid/Prebid.js#3227