### PR TITLE
fix typo in userSync wildcard example

### DIFF
--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -1504,7 +1504,7 @@ pbjs.setConfig({
     userSync: {
         filterSettings: {
             iframe: {
-                bidders: ['*'],   // '*' means all bidders
+                bidders: '*',   // '*' means all bidders
                 filter: 'include'
             }
         }


### PR DESCRIPTION
There was a typo in the userSync example for using a wildcard value for the `bidders` field.  This PR fixes the typo to match how the feature actually works.