### PR TITLE
only show bidders with native or video demand

### DIFF
--- a/dev-docs/bidders.md
+++ b/dev-docs/bidders.md
@@ -84,7 +84,7 @@ The following parameters in the `bidResponse` object are common across all bidde
 </tr></thead>
 <tbody>
 {% for page in bidder_pages %}
-{% if page.media_types and page.prebid_1_0_supported%}
+{% if page.media_types and page.prebid_1_0_supported and (page.media_types contains "video") or page.media_types contains "native")) %}
 <tr><td> {{page.biddercode}} </td><td> {% if page.media_types contains 'video' and page.media_types contains 'native' %} video, native {% elsif page.media_types contains 'native' %} native {% elsif page.media_types contains 'video' %} video {% endif %} </td></tr>
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
"Bidders with Native and Video Demand" table was showing bidders for all media types, then listing native, video, or blank. Removed all those that were blank (not native or video).