### PR TITLE
Added new setConfig option for pbs adapterOptions

### DIFF
--- a/dev-docs/bidders/prebidServer.md
+++ b/dev-docs/bidders/prebidServer.md
@@ -46,4 +46,4 @@ Configuration options
 | `syncEndpoint` | String     |           | Configures the user-sync endpoint. Highly recommended.                    |
 | `adapter`    | String        |           | Adapter code; default: `"prebidServer"`.                                  |
 | `secure`     | Integer       |           | Override Prebid Server's determination of whether the request needs secure assets. Set to `1` to force secure assets on the response, or `0` for non-secure assets. |
-| `adapterOptions` | Object       |           | adds arguments to resulting OpenRTB payload to Prebid Server. |
+| `adapterOptions` | Object       |           | Arguments will be added to resulting OpenRTB payload to Prebid Server. |

--- a/dev-docs/bidders/prebidServer.md
+++ b/dev-docs/bidders/prebidServer.md
@@ -46,3 +46,4 @@ Configuration options
 | `syncEndpoint` | String     |           | Configures the user-sync endpoint. Highly recommended.                    |
 | `adapter`    | String        |           | Adapter code; default: `"prebidServer"`.                                  |
 | `secure`     | Integer       |           | Override Prebid Server's determination of whether the request needs secure assets. Set to `1` to force secure assets on the response, or `0` for non-secure assets. |
+| `adapterOptions` | Object       |           | adds arguments to resulting OpenRTB payload to Prebid Server. |

--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -1454,6 +1454,7 @@ Additional information of these properties:
 | `endpoint` | Required | URL | Defines the auction endpoint for the Prebid Server cluster |
 | `syncEndpoint` | Required | URL | Defines the cookie_sync endpoint for the Prebid Server cluster |
 | `userSyncLimit` | Optional | Integer | Max number of userSync URLs that can be executed by Prebid Server cookie_sync per request.  If not defined, PBS will execute all userSync URLs included in the request. |
+| `adapterOptions` | Optional | Object | Arguments will be added to resulting OpenRTB payload to Prebid Server. |
 
 **Additional Notes on s2sConfig properties**
 

--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -1431,7 +1431,11 @@ pbjs.setConfig({
         timeout: 1000,
         adapter: 'prebidServer',
         endpoint: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction',
-        syncEndpoint: 'https://prebid.adnxs.com/pbs/v1/cookie_sync'
+        syncEndpoint: 'https://prebid.adnxs.com/pbs/v1/cookie_sync',
+        adapterOptions: {
+            rubicon: { key: 'value' },
+            appnexus: { key: 'value' }
+        }
     }
 })
 {% endhighlight %}


### PR DESCRIPTION
## Associated Prebid.js PR
[Prebid.js PR-3394](https://github.com/prebid/Prebid.js/pull/3394)

Documentation for new `setConfig` pbs option `adapterOptions`
```
setConfig({
  adapterOptions: {
    rubicon: { key: 'value' },
    appnexus: { key: 'value' }
  }
})
```