### PR TITLE
Fix broken Analytics Adapter table rendering

### DIFF
--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -30,6 +30,7 @@ There are several analytics adapter plugins available to track header bidding pe
 | Rivr Analytics                                                   | Contact vendor                                                                      | [website](https://www.rivr.ai/)                                        | |
 | OpenX | Contact vendor | [website](https://www.openx.com/publishers/header-bidding/) | |
 | LiveYield | Contact vendor | [website](https://www.pubocean.com/liveyield) | |
+
 None of these analytics options are endorsed or supported by Prebid.org.
 
 ## How it works


### PR DESCRIPTION
The analytics adapter table is currently not rendering as a table.  This PR fixes it.
http://prebid.org/overview/analytics.html