### PR TITLE
New Adapter VMG

### DIFF
--- a/dev-docs/bidders/vmg.md
+++ b/dev-docs/bidders/vmg.md
@@ -2,12 +2,9 @@
 layout: bidder
 title: VMG
 description: Connects DFP to the VMG Predict engine.
-top_nav_section: dev_docs
-nav_section: reference
 hide: true
 biddercode: vmg
 biddercode_longer_than_12: false
-prebid_1_0_supported: true
 ---
 
 ### bid params

--- a/dev-docs/bidders/vmg.md
+++ b/dev-docs/bidders/vmg.md
@@ -1,0 +1,11 @@
+---
+layout: bidder
+title: VMG
+description: Connects DFP to the VMG Predict engine.
+top_nav_section: dev_docs
+nav_section: reference
+hide: true
+biddercode: vmg
+biddercode_longer_than_12: false
+
+---

--- a/dev-docs/bidders/vmg.md
+++ b/dev-docs/bidders/vmg.md
@@ -7,5 +7,12 @@ nav_section: reference
 hide: true
 biddercode: vmg
 biddercode_longer_than_12: false
-
+prebid_1_0_supported: true
 ---
+
+### bid params
+
+{: .table .table-bordered .table-striped }
+| Name       | Scope    | Description            | Example | Type     |
+|------------|----------|------------------------|---------|----------|
+| ``         | optional | no params required     | `''`    | ``       |


### PR DESCRIPTION
Adapter that allows VMG's publisher partners to connect DFP to the 'VMG Predict' Engine.