### PR TITLE
menu tweaks

### DIFF
--- a/_data/dropdown_v2.yml
+++ b/_data/dropdown_v2.yml
@@ -104,8 +104,18 @@
   - subsectionId: 0
     sectionId: 1
     sectionName: Product   
-    title: Plugins
-    link: /dev-docs/plugins/index.html
+    title: Publisher API
+    link: /dev-docs/publisher-api-reference.html
+    needsDivider: 0
+    isHeader: 0
+    isSubHeader: 0
+    isSubSectionStart: 0
+    
+  - subsectionId: 0
+    sectionId: 1
+    sectionName: Product   
+    title: Bidder Params
+    link: /dev-docs/bidders.html
     needsDivider: 1
     isHeader: 0
     isSubHeader: 0
@@ -147,15 +157,6 @@
     isHeader: 0
     isSubSectionStart: 0
     
-  - subsectionId: 3
-    sectionId: 1
-    sectionName: Product
-    title: Debugging Extension
-    link: /debugging/debugging.html
-    needsDivider: 1
-    isHeader: 0
-    isSubSectionStart: 1
-
   - subsectionId: 4
     sectionId: 1
     sectionName: Product
@@ -260,10 +261,19 @@
     sectionName: Support
     title: Training Videos
     link: /videos/index.html
+    needsDivider: 0
+    isHeader: 0
+    isSubSectionStart: 0
+
+  - subsectionId: 2
+    sectionId: 2
+    sectionName: Support
+    title: Debugging Extension
+    link: /debugging/debugging.html
     needsDivider: 1
     isHeader: 0
     isSubSectionStart: 0
-    
+
   - subsectionId: 3
     sectionId: 2
     sectionName: Support

--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -379,7 +379,7 @@
   subgroup: 3
 
 - sbSecId: 1
-  title: Adapters
+  title: Adding an Adapter
   link:
   isLastSubSectionItem: 0
   isHeader: 1


### PR DESCRIPTION
proposal for updating the top and side menus as a result of https://github.com/prebid/Prebid.js/issues/3538

1) rename the 'Prebid.js/Adapter' left menu to 'Adding an Adapter'
2) with the philosophy that the top menu should have the most commonly used documents, I propose that we remove "plugins" from the Product menu and add "Publisher API" and "Bidder Params". Our new GA metrics prove these are the two most popular pages besides Download.
3) Move the "Debugging Extension" from the Product menu to the Support menu