### PR TITLE
Remove media_types video when not supported by code

### DIFF
--- a/dev-docs/bidders/aol.md
+++ b/dev-docs/bidders/aol.md
@@ -5,7 +5,6 @@ description: Prebid AOL Bidder Adaptor
 hide: true
 biddercode: aol
 biddercode_longer_than_12: false
-media_types: video
 gdpr_supported: true
 ---
 

--- a/dev-docs/bidders/rubicon.md
+++ b/dev-docs/bidders/rubicon.md
@@ -6,7 +6,6 @@ hide: true
 biddercode: rubicon
 biddercode_longer_than_12: false
 gdpr_supported: true
-media_types: video
 userIds: unifiedId/tradedesk
 ---
 

--- a/dev-docs/bidders/smartadserver.md
+++ b/dev-docs/bidders/smartadserver.md
@@ -5,7 +5,6 @@ description: Prebid Smart Bidder Adaptor
 hide: true
 biddercode: smartadserver
 biddercode_longer_than_12: true
-media_types: video
 gdpr_supported: true
 ---
 ### "Send All Bids" Ad Server Keys:


### PR DESCRIPTION
The documentation states that smartadserver and rubicon are ready for video media types, but the spec in [smartadserverBidAdapter.js](https://github.com/prebid/Prebid.js/blob/master/modules/smartadserverBidAdapter.js) and [rubiconBidAdapter.js](https://github.com/prebid/Prebid.js/blob/master/modules/rubiconBidAdapter.js) does not exports video as a valid media type.