### PR TITLE
Add External Id to the Yieldlab Bidder Doc

### DIFF
--- a/dev-docs/bidders/yieldlab.md
+++ b/dev-docs/bidders/yieldlab.md
@@ -20,3 +20,4 @@ gdpr_supported: true
 | `supplyId`  | required | Yieldlab Supply ID. Please reach out to your account management for more information. | `'12345'`                                | `string` |
 | `adSize`    | required | Override the default prebid size                                                      | `'970x250'`                              | `string` |
 | `targeting` | optional | Key-Value Targeting                                                                   | `{ 'key1': 'value1', 'key2': 'value2' }` | `object` |
+| `extId`     | optional | External Id                                                                           | `'abc'`                                  | `string` |


### PR DESCRIPTION
The External Id is a dynamic reporting dimension, that can be passed through Yieldlab's adtag via the "id"-parameter. E.g. https://ad.yieldlab.net/d/1111/2222/728x90?ts=123456789&id=abc