### PR TITLE
changed bidder param in docs to match what is in the jcmbidAdapter

### DIFF
--- a/dev-docs/bidders/jcartermarketing.md
+++ b/dev-docs/bidders/jcartermarketing.md
@@ -13,6 +13,6 @@ biddercode_longer_than_12: false
 | Name          | Scope    | Description | Example | Type     |
 |---------------|----------|-------------|---------|----------|
 | `id`          | required |             |         | `string` |
-| `siteID`      | required |             |         | `string` |
+| `siteId`      | required |             |         | `string` |
 | `tier2SiteID` | optional |             |         | `string` |
 | `tier3SiteID` | optional |             |         | `string` |


### PR DESCRIPTION
There appears to be a typo in the docs for jcm bidder params. I changed the docs to match what is in the adapter.