### PR TITLE
playgroundxyz adapter documentation update

### DIFF
--- a/dev-docs/bidders/playgroundxyz.md
+++ b/dev-docs/bidders/playgroundxyz.md
@@ -4,15 +4,13 @@ title: Playground XYZ
 description: Prebid Playground XYZ Bidder Adapter
 gdpr_supported: true
 hide: true
-biddercode: playgroundxyz
-biddercode_longer_than_12: true
+biddercode: pxyz
+biddercode_longer_than_12: false
 ---
 
 #### Send All Bids Ad Server Keys
 
-(Truncated to 20 chars due to [DFP limit](https://support.google.com/dfp_premium/answer/1628457?hl=en#Key-values))
-
-`hb_adid_playgroundxy`
+`hb_adid_pxyz`
 
 ### bid params
 


### PR DESCRIPTION
This change informs users of the playgroundxyz adapter to use the aliased name pxyz, avoiding complications with DFP character limits