### PR TITLE
PubCommonId - Add support for local storage

### DIFF
--- a/dev-docs/modules/pubCommonId.md
+++ b/dev-docs/modules/pubCommonId.md
@@ -28,7 +28,8 @@ Add a pubcid object in the setConfig() call.
 | Param | Type | Description | Example |
 | --- | --- | --- | --- |
 | enable | `boolean` | Enable or disable the module. Setting it to false will disable the module without having to remove it from the bundle.  Default is true. | true |
-| expInterval | `decimal` | Expiration interval of the cookie in minutes.  Default is 2628000, or 5 years.  | 525600 |
+| expInterval | `decimal` | Expiration interval of the id in minutes.  Default is 525600, or 1 years.  | 525600 |
+| type | `string` | Type of storage.  By default, the id is stored both as a cookie and in localStorage.  It's possible to choose just one or the other by setting either 'cookie' or 'html5'.  | 'cookie' |
 
 Example: Changing ID expiration to 1 year
 
@@ -43,10 +44,10 @@ Example: Changing ID expiration to 1 year
 
 ### User Opt-Out
 
-Users must be allowed to opt out of targeted advertising. When implementing this module, you are required to place a link in your privacy policy or elsewhere on your website which allows the user to implement this opt-out. User opt-out is supported by setting the `_pubcid_optout` cookie in the publisher’s domain. When this cookie is set, then Publisher Common ID is neither read nor updated, and it will not be made available to any adapters. The opt-out must also delete the Publisher Common ID cookie (shown in [example](../../examples/modules/pub_common_id_optout.html)).
+Users must be allowed to opt out of targeted advertising. When implementing this module, you are required to place a link in your privacy policy or elsewhere on your website which allows the user to implement this opt-out. User opt-out is supported by setting the `_pubcid_optout` as a cookie in the publisher’s domain, or in local storage. When this flag is set, then Publisher Common ID is neither read nor updated, and it will not be made available to any adapters. The opt-out must also delete the Publisher Common ID value (shown in [example](../../examples/modules/pub_common_id_optout.html)).
 
-* Opt-In - `_pubcid_optout` cookie is not present or set to 0
-* Opt-Out - `_pubcid_optout` cookie is set to 1
+* Opt-In - `_pubcid_optout` flag is not present or set to 0
+* Opt-Out - `_pubcid_optout` flag is set to 1
 
 
 ### Build the package
@@ -92,8 +93,9 @@ Adapters should look for `bid.crumbs.pubcid` in buildRequests() method.
 
 ## Technical Details
 
-- The ID is UUID v4 and stored as a cookie called `_pubcid` in the page's domain.
-- This module hooks into the pbjs.requestBids() method.  When invoked, it retrieves the cookie, updates the expiration time, and decorates the adUnits objects.  A new cookie will be created if one doesn't exist already.
+- The ID is UUID v4 and stored as a cookie and a local storage item called `_pubcid` in the page's domain.
+- This module hooks into the pbjs.requestBids() method.  When invoked, it retrieves the id from cookie and local storage, updates the expiration time, and decorates the adUnits objects.  A new id will be created if one doesn't exist already.  
+- The id stored as cookie takes precedence over local storage.
 - Beware that if prebid.js is included in an ad server frame, then the ID would have ad server domain instead.
 
 


### PR DESCRIPTION
Add support for localStorage in PubCommondId module.  This is for publishers who have not yet made the switch to the new user id module.