### PR TITLE
update set of UC templates to use bidder keys

### DIFF
--- a/adops/send-all-bids-adops.md
+++ b/adops/send-all-bids-adops.md
@@ -95,7 +95,13 @@ Copy this creative code snippet and paste it into the **Code snippet** box.
       var ucTagData = {};
       ucTagData.adServerDomain = "";
       ucTagData.pubUrl = "%%PATTERN:url%%";
-      ucTagData.targetingMap = %%PATTERN:TARGETINGMAP%%;
+      ucTagData.adId = "%%PATTERN:hb_adid_BIDDERCODE%%";
+      ucTagData.cacheHost = "%%PATTERN:hb_cache_host%%";
+      ucTagData.cachePath = "%%PATTERN:hb_cache_path%%";
+      ucTagData.uuid = "%%PATTERN:hb_cache_id_BIDDERCODE%%";
+      ucTagData.mediaType = "%%PATTERN:hb_format_BIDDERCODE%%";
+      ucTagData.env = "%%PATTERN:hb_env%%";
+      ucTagData.size = "%%PATTERN:hb_size_BIDDERCODE%%";
 
       try {
         ucTag.renderAd(document, ucTagData);
@@ -103,6 +109,8 @@ Copy this creative code snippet and paste it into the **Code snippet** box.
         console.log(e);
       }
     </script>
+
+**NOTE** Replace the *BIDDERCODE* placeholders in the above template with the appropriate bidder your line-item is targeting.  For example, if you were targeting the bidder *appnexus*, the macro variable for `adId` would look like `ucTagData.adId = "%%PATTERN:hb_adid_appnexus%%";`
 
 ![New creative]({{ site.github.url }}/assets/images/demo-setup/new-creative.png){: .pb-lg-img :}
 
@@ -119,13 +127,21 @@ For Mopub:
       var ucTagData = {};
       ucTagData.adServerDomain = "";
       ucTagData.pubUrl = "%%KEYWORD:url%%";
-      ucTagData.targetingKeywords = "%%KEYWORDS%%";
+      ucTagData.adId = "%%KEYWORD:hb_adid_BIDDERCODE%%";
+      ucTagData.cacheHost = "%%KEYWORD:hb_cache_host%%";
+      ucTagData.cachePath = "%%KEYWORD:hb_cache_path%%";
+      ucTagData.uuid = "%%KEYWORD:hb_cache_id_BIDDERCODE%%";
+      ucTagData.mediaType = "%%KEYWORD:hb_format_BIDDERCODE%%";
+      ucTagData.env = "%%KEYWORD:hb_env%%";
+      ucTagData.size = "%%KEYWORD:hb_size_BIDDERCODE%%";
        try {
         ucTag.renderAd(document, ucTagData);
       } catch (e) {
         console.log(e);
       }
     </script>
+
+**NOTE** See earlier note above in regards to replacing *BIDDERCODE* placeholders.
 
 For other ad servers:
 
@@ -134,13 +150,13 @@ For other ad servers:
       var ucTagData = {};
       ucTagData.adServerDomain = "";
       ucTagData.pubUrl = "%%MACRO:url%%";
-      ucTagData.adId = "%%MACRO:hb_adid%%";
+      ucTagData.adId = "%%MACRO:hb_adid_BIDDERCODE%%";
       ucTagData.cacheHost = "%%MACRO:hb_cache_host%%";
       ucTagData.cachePath = "%%MACRO:hb_cache_path%%";
-      ucTagData.uuid = "%%MACRO:hb_cache_id%%";
-      ucTagData.mediaType = "%%MACRO:hb_format%%";
+      ucTagData.uuid = "%%MACRO:hb_cache_id_BIDDERCODE%%";
+      ucTagData.mediaType = "%%MACRO:hb_format_BIDDERCODE%%";
       ucTagData.env = "%%MACRO:hb_env%%";
-      ucTagData.size = "%%MACRO:hb_size%%";
+      ucTagData.size = "%%MACRO:hb_size_BIDDERCODE%%";
 
       try {
         ucTag.renderAd(document, ucTagData);
@@ -150,6 +166,8 @@ For other ad servers:
     </script>
 
 Replace `MACRO` with the appropriate macro for the ad server. (Refer to your ad server's documentation or consult with a representative for specific details regarding the proper macros and how to use them.)
+
+**NOTE** See earlier note above in regards to replacing *BIDDERCODE* placeholders.
 
 ## Step 4. Attach the Creative to the Line Item
 

--- a/adops/send-all-bids-adops.md
+++ b/adops/send-all-bids-adops.md
@@ -78,8 +78,6 @@ This line item will target the bids in the range from $0.50 to $1.00 from the bi
 
 ![Key-values]({{ site.github.url }}/assets/images/demo-setup/send-all-bids/key-values.png){: .pb-md-img :}
 
-<br>
-
 ## Step 3. Add a Creative
 
 Next, add a creative to this $0.50 line item; we will duplicate the creative later.
@@ -110,11 +108,15 @@ Copy this creative code snippet and paste it into the **Code snippet** box.
       }
     </script>
 
-**NOTE** Replace the *BIDDERCODE* placeholders in the above template with the appropriate bidder your line-item is targeting.  For example, if you were targeting the bidder *appnexus*, the macro variable for `adId` would look like `ucTagData.adId = "%%PATTERN:hb_adid_appnexus%%";`
+{% capture noteAlert %}
+Replace the *BIDDERCODE* placeholders in the above template with the appropriate bidder your line item is targeting.  For example, if you're targeting the bidder *appnexus*, the macro variable for `adId` would look like `ucTagData.adId = "%%PATTERN:hb_adid_appnexus%%";`
+{% endcapture %}
+
+{% include alerts/alert_note.html content=noteAlert %}
 
 ![New creative]({{ site.github.url }}/assets/images/demo-setup/new-creative.png){: .pb-lg-img :}
 
-Make sure the creative size is set to 1x1.  This allows us to set up size override, which allows this creative to serve on all inventory sizes.
+Make sure the creative size is set to 1x1.  This allows Prebid to set up size override, which enables this creative to serve on all inventory sizes.
 
 **Prebid universal creative code for other ad servers**
 
@@ -141,7 +143,11 @@ For Mopub:
       }
     </script>
 
-**NOTE** See earlier note above in regards to replacing *BIDDERCODE* placeholders.
+{% capture noteAlert %}
+See note above in regards to replacing *BIDDERCODE* placeholders.
+{% endcapture %}
+
+{% include alerts/alert_note.html content=noteAlert %}
 
 For other ad servers:
 
@@ -167,7 +173,11 @@ For other ad servers:
 
 Replace `MACRO` with the appropriate macro for the ad server. (Refer to your ad server's documentation or consult with a representative for specific details regarding the proper macros and how to use them.)
 
-**NOTE** See earlier note above in regards to replacing *BIDDERCODE* placeholders.
+{% capture noteAlert %}
+See note above in regards to replacing *BIDDERCODE* placeholders.
+{% endcapture %}
+
+{% include alerts/alert_note.html content=noteAlert %}
 
 ## Step 4. Attach the Creative to the Line Item
 
@@ -187,8 +197,6 @@ Then, in the creative's **Settings** tab, override all sizes in the **Size overr
 
 Save the creative and go back to the line item.
 
-<br>
-
 ## Step 5. Duplicate Creatives
 
 DFP has a constraint that one creative can be served to at most one ad unit in a page under GPT's single request mode.
@@ -198,8 +206,6 @@ Let's say your page has 4 ad units.  We need to have at least 4 creatives attach
 Therefore, we need to duplicate our Prebid creative 4 times.
 
 Once that's done, we have a fully functioning line item with 4 creatives attached.
-
-<br>
 
 ## Step 6. Duplicate Line Items
 
@@ -230,5 +236,3 @@ Repeat for your other line items until you have the pricing granularity level yo
 ## Step 7. Create Orders for your other bidder partners
 
 Once you've created line items for `BIDDERCODE` targeting all the price buckets you want, start creating orders for each of your remaining bidder partners using the steps above.
-
-

--- a/adops/send-all-bids-adops.md
+++ b/adops/send-all-bids-adops.md
@@ -96,8 +96,8 @@ Copy this creative code snippet and paste it into the **Code snippet** box.
       ucTagData.adServerDomain = "";
       ucTagData.pubUrl = "%%PATTERN:url%%";
       ucTagData.adId = "%%PATTERN:hb_adid_BIDDERCODE%%";
-      ucTagData.cacheHost = "%%PATTERN:hb_cache_host%%";
-      ucTagData.cachePath = "%%PATTERN:hb_cache_path%%";
+      ucTagData.cacheHost = "%%PATTERN:hb_cache_host_BIDDERCODE%%";
+      ucTagData.cachePath = "%%PATTERN:hb_cache_path_BIDDERCODE%%";
       ucTagData.uuid = "%%PATTERN:hb_cache_id_BIDDERCODE%%";
       ucTagData.mediaType = "%%PATTERN:hb_format_BIDDERCODE%%";
       ucTagData.env = "%%PATTERN:hb_env%%";
@@ -128,8 +128,8 @@ For Mopub:
       ucTagData.adServerDomain = "";
       ucTagData.pubUrl = "%%KEYWORD:url%%";
       ucTagData.adId = "%%KEYWORD:hb_adid_BIDDERCODE%%";
-      ucTagData.cacheHost = "%%KEYWORD:hb_cache_host%%";
-      ucTagData.cachePath = "%%KEYWORD:hb_cache_path%%";
+      ucTagData.cacheHost = "%%KEYWORD:hb_cache_host_BIDDERCODE%%";
+      ucTagData.cachePath = "%%KEYWORD:hb_cache_path_BIDDERCODE%%";
       ucTagData.uuid = "%%KEYWORD:hb_cache_id_BIDDERCODE%%";
       ucTagData.mediaType = "%%KEYWORD:hb_format_BIDDERCODE%%";
       ucTagData.env = "%%KEYWORD:hb_env%%";
@@ -151,8 +151,8 @@ For other ad servers:
       ucTagData.adServerDomain = "";
       ucTagData.pubUrl = "%%MACRO:url%%";
       ucTagData.adId = "%%MACRO:hb_adid_BIDDERCODE%%";
-      ucTagData.cacheHost = "%%MACRO:hb_cache_host%%";
-      ucTagData.cachePath = "%%MACRO:hb_cache_path%%";
+      ucTagData.cacheHost = "%%MACRO:hb_cache_host_BIDDERCODE%%";
+      ucTagData.cachePath = "%%MACRO:hb_cache_path_BIDDERCODE%%";
       ucTagData.uuid = "%%MACRO:hb_cache_id_BIDDERCODE%%";
       ucTagData.mediaType = "%%MACRO:hb_format_BIDDERCODE%%";
       ucTagData.env = "%%MACRO:hb_env%%";


### PR DESCRIPTION
This PR modifies the UC creative templates on http://prebid.org/adops/send-all-bids-adops.html to demonstrate how to use bidder specific targeting keys instead of the generic targeting keys.

While it may not be common, these alternate setups would allow publishers to be able to support certain use-cases where they specifically want to show the bid of a particular bidder (even if they didn't win the auction).

Beyond this - it would also give publishers assurance that the ads rendered from a bidder targeted line-item are actually from that bidder.