### PR TITLE
Add Finteza Analytics Adapter to download and overview pages

### DIFF
--- a/download.md
+++ b/download.md
@@ -345,6 +345,14 @@ Note: If you receive an error during download you most likely selected a configu
   </div>
 </div>
 
+<div class="col-md-4">
+  <div class="checkbox">
+    <label>
+      <input type="checkbox" analyticscode="finteza" class="analytics-check-box" /> Finteza Analytics
+    </label>
+  </div>
+</div>
+
 </div>
 <br/>
 <div class="row">

--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -30,6 +30,7 @@ There are several analytics adapter plugins available to track header bidding pe
 | OpenX | Contact vendor | [Website](https://www.openx.com/publishers/header-bidding/) | |
 | LiveYield | Contact vendor | [Website](https://www.pubocean.com/liveyield) | |
 | Rubicon Project | <a href="mailto: sales@rubiconproject.com">Contact vendor</a> | [Website](https://rubiconproject.com/header-bidding-for-publishers/) | |
+| Finteza Analytics | <a href="mailto: support@finteza.com">Contact vendor</a> | [Website](https://www.finteza.com/) | |
 
 None of these analytics options are endorsed or supported by Prebid.org.
 


### PR DESCRIPTION
[Finteza Analytics Adapter](https://github.com/prebid/Prebid.js/blob/master/modules/fintezaAnalyticsAdapter.md)
Because analytics adapters should be added manually
