### PR TITLE
Removing stray suraniewiki reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ In alphabetical order:
 + Mordhak <adrien.desmoules@gmail.com>
 + Nate Guisinger <ncozi@appnexus.com>
 + Niksok <belnamtar@mail.ru>
-+ Paul <heranyang@gmail.com>
 + Paul Yang <heranyang@gmail.com>
 + Paul Young <heranyang+prebid@gmail.com>
 + Pavlos Kalogiannidis <pkalogiannidis@wideorbit.com>
@@ -184,4 +183,4 @@ In alphabetical order:
 + ronenst <stern.ronen@gmail.com>
 + sberry <sberry@appnexus.com>
 + studnicky <astudnicky@sonobi.com>
-# SuranieWiki
+


### PR DESCRIPTION
also removed an extra reference to PaulY. Do we really need this list. While we really do appreciate the community's input to Prebid products, this list is a pain to keep up-to-date. :-/