### PR TITLE
refining the load-cookie docs

### DIFF
--- a/dev-docs/show-prebid-ads-on-amp-pages.md
+++ b/dev-docs/show-prebid-ads-on-amp-pages.md
@@ -208,21 +208,33 @@ Replace `MACRO` in the preceding example with the appropriate macro for the ad s
 To properly sync user IDs with Prebid Server, the `amp-iframe` pixel below should be added to your AMP pages. As of now, only image pixels (those returned with "type": "redirect") are supported.
 
 {% capture tipNote %}
-The following example includes a transparent image as a placeholder which will allow you to place this at the top within the `body`. If this is not included the iFrame must be either 600px away from the top or not within the first 75% of the viewport when scrolled to the top – whichever is smaller. For more information on this, see [amp-iframe](https://ampbyexample.com/components/amp-iframe/)
+The following examples include a transparent image as a placeholder which will allow you to place this at the top within the HTML body. If this is not included the iFrame must be either 600px away from the top or not within the first 75% of the viewport when scrolled to the top – whichever is smaller. For more information on this, see [amp-iframe](https://ampbyexample.com/components/amp-iframe/)
 {% endcapture %}
 
-{% include alerts/alert_warning.html content=tipNote %}
+{% include alerts/alert_tip.html content=tipNote %}
 
+If you're using AppNexus' Prebid Server cluster:
 ```html
-
 <amp-iframe width="1" title="User Sync"
   height="1"
   sandbox="allow-scripts"
   frameborder="0"
-  src="https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/load-cookie.html">
+  src="https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/load-cookie.html?endpoint=appnexus">
   <amp-img layout="fill" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" placeholder></amp-img>
 </amp-iframe>
+```
 
+Else if you're utilizing Rubicon Project's Prebid Server cluster, you'll need an extra 'args'
+param on the call to load-cookie.html and will need to replace _RUBICON_ACCOUNT_ID_ with
+the ID provided by your Rubicon Project account team.
+```html
+<amp-iframe width="1" title="User Sync"
+  height="1"
+  sandbox="allow-scripts"
+  frameborder="0"
+  src="https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/load-cookie.html?endpoint=rubicon&args=account:RUBICON_ACCOUNT_ID">
+  <amp-img layout="fill" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" placeholder></amp-img>
+</amp-iframe>
 ```
 
 ## Debugging Tips
@@ -230,7 +242,7 @@ To review that Prebid on AMP is working properly the following aspects can be lo
 + Include `#development=1` to the URL to review AMP specifc debug messages in the browser console.
 + Look for the Prebid server call in the network panel. You can open this URL in a new tab to view additional debugging information relating to the Prebid Server Stored Bid Request. If working properly, Prebid server will display the targeting JSON for AMP to use.
 + Look for the network call from the Ad Server to ensure that key values are being passed. (For DFP these are in the `scp` query string parameter in the network request)
-+ Most of the debugging information is omitted from the Prebid Server response unless the `debug=1` parameter is present. It will sometimes be useful to manually edit the query string of the Prebid Server request to add this parameter.
++ Most of the debugging information is omitted from the Prebid Server response unless the `debug=1` parameter is present in the Prebid Server query string. AMP won't add this parameter, so you'll need to grab the Prebid Server URL and manually add it to see the additional information provided.
 
 ## Related Topics
 

--- a/dev-docs/show-prebid-ads-on-amp-pages.md
+++ b/dev-docs/show-prebid-ads-on-amp-pages.md
@@ -244,7 +244,7 @@ Available arguments for the `load-cookie.html` query string:
 | --- | --- | --- | --- |
 | endpoint | recommended | appnexus or rubicon | Determines which cluster of prebid servers to load from. Default, for legacy reasons, is appnexus. |
 | max_sync_count | optional | integer | How many sync pixels should be returned from Prebid Server |
-| args | optional | attr1:val1,attr2:val2 | These attribute value pairs will be passed to Prebid Server in the /cookie-sync call. Both attr and val will be quoted. |
+| args | optional | attr1:val1,attr2:val2 | These attribute value pairs will be passed to Prebid Server in the /cookie-sync call. The attribute and value will be quoted by the system when appropriate. |
 | gdpr | optional | 0 or 1 | Defines whether GDPR processing is in scope for this request. 0=no, 1=yes. Leave unknown if not sure. |
 | gdpr_consent | optional | String | IAB CMP-formatted consent string | 
 

--- a/dev-docs/show-prebid-ads-on-amp-pages.md
+++ b/dev-docs/show-prebid-ads-on-amp-pages.md
@@ -219,7 +219,7 @@ If you're using AppNexus' Prebid Server cluster:
   height="1"
   sandbox="allow-scripts"
   frameborder="0"
-  src="https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/load-cookie.html?endpoint=appnexus">
+  src="https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/load-cookie.html?endpoint=appnexus&max_sync_count=5">
   <amp-img layout="fill" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" placeholder></amp-img>
 </amp-iframe>
 ```
@@ -232,10 +232,21 @@ the ID provided by your Rubicon Project account team.
   height="1"
   sandbox="allow-scripts"
   frameborder="0"
-  src="https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/load-cookie.html?endpoint=rubicon&args=account:RUBICON_ACCOUNT_ID">
+  src="https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/load-cookie.html?endpoint=rubicon&max_sync_count=6&args=account:RUBICON_ACCOUNT_ID">
   <amp-img layout="fill" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" placeholder></amp-img>
 </amp-iframe>
 ```
+
+Available arguments for the `load-cookie.html` query string:
+
+{: .table .table-bordered .table-striped }
+| Param | Scope | Values | Description |
+| --- | --- | --- | --- |
+| endpoint | recommended | appnexus or rubicon | Determines which cluster of prebid servers to load from. Default, for legacy reasons, is appnexus. |
+| max_sync_count | optional | integer | How many sync pixels should be returned from Prebid Server |
+| args | optional | attr1:val1,attr2:val2 | These attribute value pairs will be passed to Prebid Server in the /cookie-sync call. Both attr and val will be quoted. |
+| gdpr | optional | 0 or 1 | Defines whether GDPR processing is in scope for this request. 0=no, 1=yes. Leave unknown if not sure. |
+| gdpr_consent | optional | String | IAB CMP-formatted consent string | 
 
 ## Debugging Tips
 To review that Prebid on AMP is working properly the following aspects can be looked at:


### PR DESCRIPTION
Related to https://github.com/prebid/prebid-universal-creative/pull/58 -- we've expanded the Prebid Universal Creative load-cookie.html to support multiple bidders.

So this doc change outlines how to set up load-cookie.html for appnexus and rubicon. Other bidders can be added in the future.

Also made a few other minor tweaks for wording and formatting.