### PR TITLE
Prebid SDK iOS: Added Store URL field and itunesID heading

### DIFF
--- a/prebid-mobile/pbm-api/ios/pbm-targeting-ios.md
+++ b/prebid-mobile/pbm-api/ios/pbm-targeting-ios.md
@@ -88,6 +88,18 @@ Targeting.shared.domain = domain
 Retrieve and set the domain of your store URL with the following commands: 
 
 ```
+Targeting.shared.storeURL
+```
+
+```
+Targeting.shared.storeURL = "itunes store URL string"
+```
+
+### iTunesID
+
+Retrieve and set the domain of your store URL with the following commands: 
+
+```
 Targeting.shared.itunesID
 ```
 


### PR DESCRIPTION
For the Prebid Mobile iOS page, added the following:

- New storeURL field
- Added heading for itunesID