### PR TITLE
Fix horizontal scroll on Prebid.org homepage

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -9,7 +9,7 @@
 			<p><div>{% include footer.html %}</div></p>
 		</div>
 		
-		<div class="pb-homepage-container pb-homepage-content">
+		<div class="pb-homepage-container pb-homepage-content container">
 			
 			<div class="row">
 				<div class="col-lg-12 pb-top-text">


### PR DESCRIPTION
The homepage is missing a container for the layout, this causes a small horizontal scroll to be present (due to the -15px margins of .row without .container)