### PR TITLE
update wording on setting up creatives in a DFP line item

### DIFF
--- a/adops/send-all-bids-adops.md
+++ b/adops/send-all-bids-adops.md
@@ -193,19 +193,19 @@ In the pop-up dialog that appears, click **Show All** to remove the default size
 
 Back in the line item, go into the **Creatives** tab again, and click into the creative you just added.
 
-Then, in the creative's **Settings** tab, override all sizes in the **Size overrides** field.
+Then, in the creative's **Settings** tab, enable the **Size overrides** field and set all your line item's potential sizes.
 
 Save the creative and go back to the line item.
 
 ## Step 5. Duplicate Creatives
 
-DFP has a constraint that one creative can be served to at most one ad unit in a page under GPT's single request mode.
+DFP has a constraint that one creative can be served to at most one ad slot in a single pageview (see [here](https://support.google.com/admanager/answer/183281?hl=en) for more details).
 
-Let's say your page has 4 ad units.  We need to have at least 4 creatives attached to the line item in case more than 2 bids are within the $0.50 range.
+Let's say your page has 4 ad slots.  We need to have at least 4 creatives attached to the line item in case more than 2 bids are within the $0.50 range.
 
 Therefore, we need to duplicate our Prebid creative 4 times.
 
-Once that's done, we have a fully functioning line item with 4 creatives attached.
+Once that's done, we have a fully functioning line item with 4 creatives attached that can potentially fill 4 ad slots of varying sizes during a single pageview.
 
 ## Step 6. Duplicate Line Items
 

--- a/adops/step-by-step.md
+++ b/adops/step-by-step.md
@@ -116,7 +116,7 @@ In the pop-up dialog that appears, click **Show All** to remove the default size
 
 Back in the line item, go into the **Creatives** tab again, and click into the creative you just added.
 
-Then, in the creative's **Settings** tab, override all sizes in the **Size overrides** field.
+Then, in the creative's **Settings** tab, enable the **Size overrides** field and set all your line item's potential sizes.
 
 Save the creative and go back to the line item.
 
@@ -124,13 +124,13 @@ Save the creative and go back to the line item.
 
 ## Step 4. Duplicate Creatives
 
-DFP has a constraint that one creative can be served to at most one ad unit in a page under GPT's single request mode.
+DFP has a constraint that one creative can be served to at most one ad slot in a single pageview (see [here](https://support.google.com/admanager/answer/183281?hl=en) for more details).
 
-Let's say your page has 4 ad units.  We need to have at least 4 creatives attached to the line item in case more than 2 bids are within the $0.50 range.
+Let's say your page has 4 ad slots.  We need to have at least 4 creatives attached to the line item in case more than 2 bids are within the $0.50 range.
 
 Therefore, we need to duplicate our Prebid creative 4 times.
 
-Once that's done, we have a fully functioning line item with 4 creatives attached.
+Once that's done, we have a fully functioning line item with 4 creatives attached that can potentially fill 4 ad slots of varying sizes during a single pageview.
 
 <br>
 


### PR DESCRIPTION
This PR updates some of the wording when setting up creatives in DFP.

Specifically it's meant to illustrate that adops traffickers need to have a copy of the Prebid creative for each potential ad slot they use on a page.  They can multiple sizes available on each creative (so they can resize given the request's context) but having a physical creative for each slot is the key.

**Context for the wording update**
There were some questions raised internally about how the pagview logic from the linked article affects the number of creatives that need to be setup in a line-item given the slot/size combinations.  For example, if they used 5 sizes and 3 ad slots - did they need to make 15 creatives?  

The answer is they need to make enough creatives to fill the ad slots.  The sizes will handle themselves assuming they assign all sizes to each creative using the **sizeOverride** feature in DFP.

**Some context on the ad server functionality**
When a page loads with DFP tags, DFP sees the request(s) as part of the same pageview.  

When DFP goes to fill the ad slots present in that pageview, it will use a creative from a line-item only once to fill one of the ad slots.  Even if there were multiple requests loaded together, because they're still in the same pageview - a creative can only be used once.  

By using multiple creatives, DFP could have one line-item fill all the slots that were present in the request(s).