### PR TITLE
Add appier analytics adapter doc info to analytics page

### DIFF
--- a/download.md
+++ b/download.md
@@ -204,6 +204,14 @@ Note: If you receive an error during download you most likely selected a configu
 <div class="col-md-4">
   <div class="checkbox">
     <label>
+      <input type="checkbox" analyticscode="appier" class="analytics-check-box"> Appier Analytics
+    </label>
+  </div>
+</div>
+
+<div class="col-md-4">
+  <div class="checkbox">
+    <label>
       <input type="checkbox" analyticscode="adagio" class="analytics-check-box"> Adagio Analytics
     </label>
   </div>

--- a/download.md
+++ b/download.md
@@ -204,14 +204,6 @@ Note: If you receive an error during download you most likely selected a configu
 <div class="col-md-4">
   <div class="checkbox">
     <label>
-      <input type="checkbox" analyticscode="appier" class="analytics-check-box"> Appier Analytics
-    </label>
-  </div>
-</div>
-
-<div class="col-md-4">
-  <div class="checkbox">
-    <label>
       <input type="checkbox" analyticscode="adagio" class="analytics-check-box"> Adagio Analytics
     </label>
   </div>
@@ -237,6 +229,14 @@ Note: If you receive an error during download you most likely selected a configu
   <div class="checkbox">
     <label>
       <input type="checkbox" analyticscode="adxcg" class="analytics-check-box"> Adxcg Analytics
+    </label>
+  </div>
+</div>
+
+<div class="col-md-4">
+  <div class="checkbox">
+    <label>
+      <input type="checkbox" analyticscode="appier" class="analytics-check-box"> Appier Analytics
     </label>
   </div>
 </div>

--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -14,6 +14,7 @@ There are several analytics adapter plugins available to track header bidding pe
 {: .table .table-bordered .table-striped }
 | Analytics Adapter                                                | Cost | Contact |
 | -------------                                                    | ------------- | ----------- |
+| Appier                                                           | Contact vendor | [Website](https://www.appier.com) |
 | Adagio                                                           | Contact vendor| [Website](https://adagio.io)|
 | Assertive Yield (contact for adapter) | Free to try (Large accounts $0.002 CPM or sampled < 10mm/m imp.) | [Website](https://yield.assertcom.de) |
 | Finteza Analytics | <a href="mailto: support@finteza.com">Contact vendor</a> | [Website](https://www.finteza.com/) |


### PR DESCRIPTION
PR for the docs repo to add appier analytics adapter:

https://github.com/prebid/Prebid.js/pull/3871

Thank you :)