### PR TITLE
Gamoshi: Add docs for new bidder adapter alias of gamoshi

### DIFF
--- a/dev-docs/bidders/adasta.md
+++ b/dev-docs/bidders/adasta.md
@@ -1,0 +1,17 @@
+---
+layout: bidder
+title: Adasta
+description: Prebid Adasta Bidder Adaptor
+hide: true
+biddercode: adasta
+aliasCode: gamoshi
+---
+
+### Bid params
+
+{: .table .table-bordered .table-striped }
+| Name              | Scope    | Description                                                   | Example              | Type     |
+|-------------------|----------|---------------------------------------------------------------|----------------------|----------|
+| `supplyPartnerId` | required | ID of the supply partner | `'12345'`            | `string` |
+
+Adasta is an aliased bidder for Gamoshi


### PR DESCRIPTION
## Type of change

- [x] New bidder adapter alias docs

## Description of change

- Add docs for `adasta` - new bidder adapter alias of gamoshi

- Maintainer contact email: `dev@gamoshi.com`