### PR TITLE
Update docs for Triplelift tdid support

### DIFF
--- a/dev-docs/bidders/triplelift.md
+++ b/dev-docs/bidders/triplelift.md
@@ -5,6 +5,7 @@ description: Prebid TripleLift Bidder Adapter
 hide: true
 gdpr_supported: true
 biddercode: triplelift
+userIds: unifiedId/tradedesk
 ---
 
 ### Bid Params


### PR DESCRIPTION
**Context**
Updating bidder doc to include new `userIds: unifiedId/tradedesk` support. Looking to include triplelift in list here: [http://prebid.org/dev-docs/modules/userId.html#adapters-supporting-the-user-id-sub-modules](http://prebid.org/dev-docs/modules/userId.html#adapters-supporting-the-user-id-sub-modules)

Prebid.js PR = [Triplelift adapter tdid support #3983](https://github.com/prebid/Prebid.js/pull/3983)