### PR TITLE
update outstream video url

### DIFF
--- a/dev-docs/show-outstream-video-ads.md
+++ b/dev-docs/show-outstream-video-ads.md
@@ -89,7 +89,7 @@ pbjs.addAdUnit({
         }
     },
     renderer: {
-        url: 'http://cdn.adnxs.com/renderer/video/ANOutstreamVideo.js',
+        url: 'http://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js',
         render: function (bid) {
             ANOutstreamVideo.renderAd({
                 targetId: bid.adUnitCode,


### PR DESCRIPTION
Adunit sample code [here](http://prebid.org/dev-docs/show-outstream-video-ads.html) is using the old url, **http://cdn.adnxs.com/renderer/video/ANOutstreamVideo.js**

This PR updates it to a new url, **http://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js**. 