### PR TITLE
pxyz adding short biddercode

### DIFF
--- a/dev-docs/bidders/playgroundxyz.md
+++ b/dev-docs/bidders/playgroundxyz.md
@@ -4,7 +4,9 @@ title: Playground XYZ
 description: Prebid Playground XYZ Bidder Adapter
 gdpr_supported: true
 hide: true
-biddercode: playgroundxyz
+biddercode: pxyz
+prevBiddercode: playgroundxyz
+aliasCode: playgroundxyz
 ---
 
 ### Bid Params


### PR DESCRIPTION
Replaces https://github.com/prebid/prebid.github.io/pull/1203 and uses the new `prevBiddercode` attribute. It works because the PBJS adapter has both pxyz as an alias. Here's what is produces:

<img width="701" alt="Screen Shot 2019-09-07 at 6 24 36 PM" src="https://user-images.githubusercontent.com/4412838/64480832-29a10580-d19d-11e9-822a-77b7949a6b0f.png">
