### PR TITLE
fix adsparc adapter parameters in documentation

### DIFF
--- a/dev-docs/bidders/adsparc.md
+++ b/dev-docs/bidders/adsparc.md
@@ -1,17 +1,16 @@
 ---
 layout: bidder
 title: AdSparc
-description: Prebid Serverbid Bidder Adaptor
+description: Prebid Adsparc Bidder Adaptor
 hide: true
 biddercode: adsparc
-aliasCode: serverbid
+aliasCode: aardvark
 ---
 
-
-### Bid Params
+### bid params
 
 {: .table .table-bordered .table-striped }
-| Name        | Scope    | Description                  | Example | Type      |
-|-------------|----------|------------------------------|---------|-----------|
-| `siteId`    | required | The site ID from AdSparc.    | `12345` | `integer` |
-| `networkId` | required | The network ID from AdSparc. | `9969`  | `integer` |
+| Name | Scope    | Description        | Example  | Type     |
+|------|----------|--------------------|----------|----------|
+| `ai` | required | The auction ID     | `'XBC1'` | `string` |
+| `sc` | required | The adshortcode    | `'AF2g'` | `string` |


### PR DESCRIPTION
Hi there, this PR addresses this issue https://github.com/prebid/Prebid.js/issues/4113 

Adsparc is an alias for Aardvark. Previous Adsparc documentation contained wrong parameter definitions.  With this PR we set the parameters to be the same of Aardvark. 