### PR TITLE
Update adastamedia.md

### DIFF
--- a/dev-docs/bidders/adastaMedia.md
+++ b/dev-docs/bidders/adastaMedia.md
@@ -3,14 +3,15 @@ layout: bidder
 title: Adasta Media
 description: Prebid Adasta Media Bidder Adaptor
 hide: true
-biddercode: adastaMedia
-media_types: banner, video
-aliasCode: gamoshi
+biddercode: adasta
+aliasCode : appnexus
 ---
 
-### Bid params
+### Bid Params
 
 {: .table .table-bordered .table-striped }
-| Name              | Scope    | Description                                                   | Example              | Type     |
-|-------------------|----------|---------------------------------------------------------------|----------------------|----------|
-| `supplyPartnerId` | required | ID of the supply partner | `'12345'`            | `string` |
+| Name          | Scope    | Description | Example | Type     |
+|---------------|----------|-------------|---------|----------|
+| `placementId` | required |             |         | `string` |
+
+Adasta Media is an aliased bidder for AppNexus


### PR DESCRIPTION
Adasta Media is an aliased bidder for AppNexus.
Adasta Media no longer relies on Gamoshi for publication in Prebid. This new one replaces the existing one in your listings.