### PR TITLE
Turning text on download page

### DIFF
--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -4,7 +4,7 @@ page_type: module
 title: Module - User ID
 description: Supports multiple cross-vendor user IDs
 module_code : userId
-display_name : User ID
+display_name : User ID (including UnifiedID and PubCommonID)
 enable_download : true
 sidebarType : 1
 ---


### PR DESCRIPTION
Making it clear that downloading the base module pulls in Unified and PubCommon