### PR TITLE
fix sizes in multi-format docs to match native examples

### DIFF
--- a/dev-docs/show-multi-format-ads.md
+++ b/dev-docs/show-multi-format-ads.md
@@ -73,10 +73,7 @@ The ad unit below supports the banner, native, and video media types.
             },
             native: {
                 image: {
-                    sizes: [
-                        [300, 250],
-                        [300, 50]
-                    ]
+                    sizes: [300, 250]
                 }
             },
             video: {


### PR DESCRIPTION
Example was incorrect as pointed out in comment here: https://github.com/prebid/Prebid.js/pull/3145#issuecomment-536332809