### PR TITLE
Sharethrough: Schain bidfloor adapter docs update

### DIFF
--- a/dev-docs/bidders/sharethrough.md
+++ b/dev-docs/bidders/sharethrough.md
@@ -21,4 +21,4 @@ The Sharethrough bidder adapter requires additional setup and approval from the 
 | `pkey` | required | The placement key | `'DfFKxpkRGPMS7A9f71CquBgZ'` | `string`
 | `iframe` | optional | If `true`, the ad will render in an iframe. Defaults to `false`. | `true` | `boolean`
 | `iframeSize` | optional | `[width, height]` If provided, use this size for the iframe size. Only applicable if `iframe` is `true`. If omitted, the largest size from the ad unit sizes array will be used. | `[300, 250]` | `[integer]`
-| `bidfloor` | optional | The floor price, or minimum amount, a publisher will accept for an impression, given in CPM in USD. | `"1.00"` or `1.00` | `string` or `float`
+| `bidfloor` | optional | The floor price, or minimum amount, a publisher will accept for an impression, given in CPM in USD. | `1.00` | `float`

--- a/dev-docs/bidders/sharethrough.md
+++ b/dev-docs/bidders/sharethrough.md
@@ -16,8 +16,9 @@ The Sharethrough bidder adapter requires additional setup and approval from the 
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
-| Name         | Scope    | Description                                                                                                                                                                                                                                                           | Example                      | Type             |
-|--------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|------------------|
-| `pkey`       | required | The placement key                                                                                                                                                                                                                                                     | `'DfFKxpkRGPMS7A9f71CquBgZ'` | `string`         |
-| `iframe`     | optional | If `true`, the ad will render in an iframe. Defaults to `false`.                                                                                                                                                                                                      | `true`                       | `boolean`        |
-| `iframeSize` | optional | `[width, height]` If provided, use this size for the iframe size. Only applicable if `iframe` is `true`. If omitted, the largest size from the ad unit sizes array will be used.                                                                                      | `[300, 250]`                 | `Array<integer>` |
+| Name | Scope | Description | Example | Type
+| ---- | ----- | ----------- | ------- | ----
+| `pkey` | required | The placement key | `'DfFKxpkRGPMS7A9f71CquBgZ'` | `string`
+| `iframe` | optional | If `true`, the ad will render in an iframe. Defaults to `false`. | `true` | `boolean`
+| `iframeSize` | optional | `[width, height]` If provided, use this size for the iframe size. Only applicable if `iframe` is `true`. If omitted, the largest size from the ad unit sizes array will be used. | `[300, 250]` | `[integer]`
+| `bidfloor` | optional | The floor price, or minimum amount, a publisher will accept for an impression, given in CPM in USD. | `"1.00"` or `1.00` | `string` or `float`

--- a/dev-docs/bidders/sharethrough.md
+++ b/dev-docs/bidders/sharethrough.md
@@ -7,6 +7,7 @@ biddercode: sharethrough
 media_types: native
 gdpr_supported: true
 userIds: unifiedId/tradedesk
+schain_supported: true
 ---
 
 ### Note:


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on https://prebid.org?

## Description of change
- Documentation change to indicate that Sharethrough's bid adapter has been updated to support the schain module and to check for and send the `bidfloor` parameter when building bid requests.
- pubgrowth.engineering@sharethrough.com
- See related prebid.js PR: https://github.com/prebid/Prebid.js/pull/4271