### PR TITLE
Add note for change in getHighestCpmBids's behaviour in prebid-3.0

### DIFF
--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -429,6 +429,9 @@ Use this method to retrieve an array of winning bids.
 + `pbjs.getHighestCpmBids()`: with no argument, returns an array of winning bid objects for each ad unit on page
 + `pbjs.getHighestCpmBids(adUnitCode)`: when passed an ad unit code, returns an array with the winning bid object for that ad unit
 
+{: .alert.alert-warning :}
+Note that from **Prebid 3.0** onwards, `pbjs.getHighestCpmBids` will not return rendered bids.
+
 <hr class="full-rule">
 
 <a name="module_pbjs.getAllWinningBids"></a>


### PR DESCRIPTION
`getHighestCpmBids` no longer returns rendered bids from **prebid-3.0** onwards. If this function is integrated into some publisher's workflow who rely on the old way of returning the winning bid, even if, it's from an old auction, (rendered bid), this note might come in handy if they wish to update to prebid version 3.

Link to the original PR that fixes this issue: https://github.com/prebid/Prebid.js/pull/4247