### PR TITLE
Revert "Gamoshi: Remove unsupported aliases"

### DIFF
--- a/dev-docs/bidders/adastaMedia.md
+++ b/dev-docs/bidders/adastaMedia.md
@@ -1,0 +1,17 @@
+---
+layout: bidder
+title: Adasta Media
+description: Prebid Adasta Media Bidder Adaptor
+hide: true
+biddercode: adasta
+aliasCode : appnexus
+---
+
+### Bid Params
+
+{: .table .table-bordered .table-striped }
+| Name          | Scope    | Description | Example | Type     |
+|---------------|----------|-------------|---------|----------|
+| `placementId` | required |             |         | `string` |
+
+Adasta Media is an aliased bidder for AppNexus

--- a/dev-docs/bidders/viewdeos.md
+++ b/dev-docs/bidders/viewdeos.md
@@ -1,0 +1,16 @@
+---
+layout: bidder
+title: Viewdeos
+description: Prebid Viewdeos Bidder Adaptor
+hide: true
+biddercode: viewdeos
+media_types: banner, video
+aliasCode: gamoshi
+---
+
+### Bid params
+
+{: .table .table-bordered .table-striped }
+| Name              | Scope    | Description                                                   | Example              | Type     |
+|-------------------|----------|---------------------------------------------------------------|----------------------|----------|
+| `supplyPartnerId` | required | ID of the supply partner | `'12345'`            | `string` |

--- a/dev-docs/bidders/viewdeos.md
+++ b/dev-docs/bidders/viewdeos.md
@@ -3,9 +3,8 @@ layout: bidder
 title: Viewdeos
 description: Prebid Viewdeos Bidder Adaptor
 hide: true
-biddercode: viewdeos
+biddercode: viewdeosDX
 media_types: banner, video
-aliasCode: gamoshi
 ---
 
 ### Bid params


### PR DESCRIPTION
Reverts prebid/prebid.github.io#1563

Deleting these files wasn't the proper approach for either. Adasta is now an alias of AppNexus, and viewdeos has their own adapter.