### PR TITLE
Troubleshooting: fixing prebid server debug

### DIFF
--- a/troubleshooting/troubleshooting.md
+++ b/troubleshooting/troubleshooting.md
@@ -21,8 +21,30 @@ Enable javascript console trace messages by adding ```?pbjs_debug=true``` to the
 
 ## Prebid Server
 
-To return debug data for Prebid Server add `&debug=1` to the end of the URL. A 'url_override' parameter is also available to help further isolate issues.
+There are several ways to get more debug info from Prebid Server:
+
+### Direct Prebid Server Invocation
+
+One of these parameters needs to be added to the OpenRTB:
+- `"test":1` -- this will inform the bidders that this should be treated as a test (non-billable) request, and also provide additional debug info in the OpenRTB response.
+- `"debug":1` -- this just adds the additional debug info.
 
 {% highlight bash %}
-https://prebid-server.rubiconproject.com/auction?url_override=rubiconproject.com&debug=1
+POST https://prebid-server.rubiconproject.com/openrtb2/auction
+{
+    ...
+    "test":1
+}
+{% endhighlight %}
+
+### Invoked from Prebid.js
+
+There are two ways to turn on the OpenRTB `test` flag from Prebid.js:
+
+1) Add ?pbjs_debug=true to the URL of the page.
+
+2) Add the following `setConfig` to the page:
+
+{% highlight bash %}
+    pbjs.setConfig({"debug":true});
 {% endhighlight %}


### PR DESCRIPTION
It was still referring to the legacy endpoint.