### PR TITLE
AOL: Document CCPA support

### DIFF
--- a/dev-docs/bidders/aol.md
+++ b/dev-docs/bidders/aol.md
@@ -5,6 +5,7 @@ description: Prebid AOL Bidder Adaptor
 hide: true
 biddercode: aol
 gdpr_supported: true
+usp_supported: true
 ---
 
 ### Note:


### PR DESCRIPTION
Documentation update for CCPA support for AOL bidder.

Ref:
https://github.com/prebid/Prebid.js/pull/4536