### PR TITLE
Aardvark: add schain support

### DIFF
--- a/dev-docs/bidders/aardvark.md
+++ b/dev-docs/bidders/aardvark.md
@@ -5,6 +5,7 @@ description: Prebid Aardvark Bidder Adaptor
 hide: true
 biddercode: aardvark
 gdpr_supported: true
+schain_supported: true
 ---
 
 ### Bid Params


### PR DESCRIPTION
Add support for schain in aardvark bid adapter.

Here is pull request on prebid.js repository:
https://github.com/prebid/Prebid.js/pull/4636 