### PR TITLE
Criteo - Updated doc regarding bidder parameters

### DIFF
--- a/dev-docs/bidders/criteo.md
+++ b/dev-docs/bidders/criteo.md
@@ -15,8 +15,7 @@ prebid_member: true
 {: .table .table-bordered .table-striped }
 | Name              | Scope    | Description                                                                                                          | Example                                       | Type       |
 |-------------------|----------|----------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|------------|
-| `zoneId`          | required | The zone ID from Criteo. Can be replaced by `networkId` when using zone matching.                                    | `234234`                                      | `integer`  |
-| `networkId`       | optional | The network ID from Criteo.Please reach out your Criteo representative for more details.                             | `456456`                                      | `integer`  |
+| `networkId`       | required | The network ID from Criteo.Please reach out your Criteo representative for more details.                             | `456456`                                      | `integer`  |
 | `nativeCallback`  | optional | Callback to perform render in native integrations. Please reach out your Criteo representative for more details.     | `function(payload) { console.log(payload); }` | `function` |
 | `integrationMode` | optional | Integration mode to use for ad render (none or 'AMP'). Please reach out your Criteo representative for more details. | `'AMP'`                                       | `string`   |
 


### PR DESCRIPTION
Remove mention of zoneId.
Updated networkId is now a required parameter.