### PR TITLE
aardvark - declare ccpa support

### DIFF
--- a/dev-docs/bidders/aardvark.md
+++ b/dev-docs/bidders/aardvark.md
@@ -5,7 +5,9 @@ description: Prebid Aardvark Bidder Adaptor
 hide: true
 biddercode: aardvark
 gdpr_supported: true
+usp_supported: true
 schain_supported: true
+userIds: unifiedId/tradedesk
 ---
 
 ### Bid Params


### PR DESCRIPTION
Declare CCPA support for aardvark adapter.  
Declare utilization of unifiedId.