### PR TITLE
Update video and jsfiddle examples nonversion CDN URL

### DIFF
--- a/_includes/video/head.html
+++ b/_includes/video/head.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     <script type="text/javascript" src="//services.brid.tv/player/build/brid.min.js"></script>  	
     
     <script type="text/javascript">

--- a/_includes/video/pb-cp-fp.html
+++ b/_includes/video/pb-cp-fp.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <!--<script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>-->
+    <!--<script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>-->
     
     <!--flowplayer & prebid js code-->
     <link rel="stylesheet" href="//cdn.flowplayer.com/releases/native/stable/style/flowplayer.css">

--- a/_includes/video/pb-cp-jw.html
+++ b/_includes/video/pb-cp-jw.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <!--<script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>-->
+    <!--<script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>-->
     
     <!--jwplayer & prebid js code-->
     <script type="text/javascript">

--- a/_includes/video/pb-cp-kl.html
+++ b/_includes/video/pb-cp-kl.html
@@ -64,7 +64,7 @@ function OptanonWrapper() { }
     
     
     <!--production version of prebid.js-->
-    <!--<script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>-->
+    <!--<script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>-->
     
     <!--kaltura & prebid js code-->
     <script type="text/javascript">

--- a/_includes/video/pb-cp-vjs.html
+++ b/_includes/video/pb-cp-vjs.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <!--<script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>-->
+    <!--<script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>-->
     
     <!--videojs & prebid js code-->
     <!-- use recent version of videojs to ensure proper functioning with the iOS devices -->

--- a/_includes/video/pb-cp.html
+++ b/_includes/video/pb-cp.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--brightcove & prebid js code-->
     <script>

--- a/_includes/video/pb-is-bc.html
+++ b/_includes/video/pb-is-bc.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--flowplayer & prebid js code-->
     <script>

--- a/_includes/video/pb-is-br.html
+++ b/_includes/video/pb-is-br.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--brid & prebid js code-->
     <script type="text/javascript" src="//services.brid.tv/player/build/brid.min.js"></script>  	

--- a/_includes/video/pb-is-fp.html
+++ b/_includes/video/pb-is-fp.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--pbjs and player code -->	
     

--- a/_includes/video/pb-is-jw01.html
+++ b/_includes/video/pb-is-jw01.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--pbjs and player code -->	
     

--- a/_includes/video/pb-is-jw02.html
+++ b/_includes/video/pb-is-jw02.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--pbjs and player code -->	
     <script type="text/javascript" src="http://ssl.p.jwpcdn.com/player/v/7.2.4/jwplayer.js"></script>

--- a/_includes/video/pb-is-jw03.html
+++ b/_includes/video/pb-is-jw03.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--pbjs and player code -->	
     	    

--- a/_includes/video/pb-is-kl.html
+++ b/_includes/video/pb-is-kl.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--pbjs and player code -->	
     	    

--- a/_includes/video/pb-is-ol.html
+++ b/_includes/video/pb-is-ol.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--pbjs and player code -->	
     	    

--- a/_includes/video/pb-is-rd.html
+++ b/_includes/video/pb-is-rd.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!-- Radiant Media Player core library - debug browser console mode (use rmp.min.js for production) -->
 	<script src="https://cdn.radiantmediatechs.com/rmp/5.5.6/js/rmp.debug.js"></script>

--- a/_includes/video/pb-is-vjs.html
+++ b/_includes/video/pb-is-vjs.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--pbjs and player code -->	
     	    

--- a/_includes/video/pb-lf-fw.html
+++ b/_includes/video/pb-lf-fw.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--pbjs and player code -->	
     	    

--- a/_includes/video/pb-os-dfp.html
+++ b/_includes/video/pb-os-dfp.html
@@ -64,7 +64,7 @@ function OptanonWrapper() { }
     
     <!--production version of prebid.js-->
     <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--pbjs and player code -->	
     

--- a/_includes/video/pb-os-nas.html
+++ b/_includes/video/pb-os-nas.html
@@ -64,7 +64,7 @@ function OptanonWrapper() { }
     
     <!--production version of prebid.js-->
     <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--pbjs and player code -->	
     

--- a/_includes/video/pb-os-rd.html
+++ b/_includes/video/pb-os-rd.html
@@ -64,7 +64,7 @@ function OptanonWrapper() { }
     
     <!--production version of prebid.js-->
     <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--radiant code-->
 	<script src="https://cdn.radiantmediatechs.com/rmp/5.5.6/js/rmp.debug.js"></script>

--- a/_includes/video/pbs-br.html
+++ b/_includes/video/pbs-br.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--pbjs and player code -->	
     	    

--- a/_includes/video/pbs-jw01.html
+++ b/_includes/video/pbs-jw01.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     <script>
             var pbjs = pbjs || {};
             pbjs.que = pbjs.que || [];

--- a/_includes/video/pbs-jw02.html
+++ b/_includes/video/pbs-jw02.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--pbjs and player code -->	
     

--- a/_includes/video/pbs-jw03.html
+++ b/_includes/video/pbs-jw03.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--pbjs and player code -->	
     

--- a/_includes/video/pbs-jw04.html
+++ b/_includes/video/pbs-jw04.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--pbjs and player code -->	
     

--- a/_includes/video/pbs-kl.html
+++ b/_includes/video/pbs-kl.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--pbjs and player code -->	
     

--- a/_includes/video/pbs-oy.html
+++ b/_includes/video/pbs-oy.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--ooyala and player code -->	
     

--- a/_includes/video/pbs-rd.html
+++ b/_includes/video/pbs-rd.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--radiant and player code -->	
     

--- a/_includes/video/pbs-vjs.html
+++ b/_includes/video/pbs-vjs.html
@@ -63,7 +63,7 @@ function OptanonWrapper() { }
     <script type="text/javascript" src="{{site.baseurl}}/assets/js/pbjs_home.js"></script>
     
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     
     <!--pbjs and player code -->	
     

--- a/dev-docs/examples/adunit-refresh.md
+++ b/dev-docs/examples/adunit-refresh.md
@@ -8,7 +8,7 @@ sidebarType: 1
 about:
 - Ability to <strong>refresh individual ad units</strong> - useful for infinite scrolling ad slots
 
-jsfiddle_link: jsfiddle.net/prebid_org/61uzp29t/embedded/html,result
+jsfiddle_link: jsfiddle.net/Prebid_Examples/cu7tpexf/2/embedded/html,result
 
 code_height: 1540
 

--- a/dev-docs/examples/basic-example.md
+++ b/dev-docs/examples/basic-example.md
@@ -11,7 +11,7 @@ about:
 - Default keyword targeting setup (<a href="/dev-docs/publisher-api-reference.html#bidderSettingsDefault">reference</a>)
 - Default price granularity
 
-jsfiddle_link: jsfiddle.net/Prebid_Examples/5crq9cse/388/embedded/html,result
+jsfiddle_link: jsfiddle.net/Prebid_Examples/94jt62b8/7/embedded/html,result
 
 code_height: 2300
 

--- a/dev-docs/examples/custom-price-buckets.md
+++ b/dev-docs/examples/custom-price-buckets.md
@@ -9,7 +9,7 @@ about:
 - Custom price granularity buckets using <code>pbjs.setConfig()</code>
 - See the <a href="/dev-docs/publisher-api-reference.html#setConfig-Price-Granularity">the API reference</a> for more detail.
 
-jsfiddle_link: jsfiddle.net/Prebid_Examples/5eurjwu1/9/embedded/html,result
+jsfiddle_link: jsfiddle.net/Prebid_Examples/vq05dhnj/2/embedded/html,result
 
 code_height: 2152
 

--- a/dev-docs/examples/instream-banner-mix.md
+++ b/dev-docs/examples/instream-banner-mix.md
@@ -5,7 +5,7 @@ description: An example of displaying both instream video and banner ads using P
 hide: true
 sidebarType: 1
 
-jsfiddle_link: jsfiddle.net/Xandr_Prebid/7L6yj2e5/embedded/html,result/
+jsfiddle_link: jsfiddle.net/Prebid_Examples/nowfejh7/2/embedded/html,result/
 
 code_height: 3050
 

--- a/dev-docs/examples/multi-format-example.md
+++ b/dev-docs/examples/multi-format-example.md
@@ -12,7 +12,7 @@ about:
 - For ad ops setup instructions, see <a href="/adops/setting-up-prebid-multi-format-in-dfp.html">Setting up Prebid Multi-Format in Google Ad Manager</a>
 - Try the Prebid.org-hosted <a href="/examples/multi_format_example.html">Multi-Format Example</a> to see multi-format slots including outstream video as well.
 
-jsfiddle_link: jsfiddle.net/Prebid_Examples/u999cwtL/36/embedded/html,result
+jsfiddle_link: jsfiddle.net/Prebid_Examples/yxsgcj71/2/embedded/html,result
 
 code_height: 3050
 

--- a/dev-docs/examples/native-ad-example.md
+++ b/dev-docs/examples/native-ad-example.md
@@ -10,7 +10,7 @@ about:
 - For engineering setup instructions, see <a href="/dev-docs/show-native-ads.html">Show Native Ads</a>
 - For ad ops setup instructions, see <a href="/adops/setting-up-prebid-native-in-dfp.html">Setting up Prebid Native in Google Ad Manager (Alpha)</a>
 
-jsfiddle_link: jsfiddle.net/Xandr_Prebid/96wj73n2/embedded/html,result/
+jsfiddle_link: jsfiddle.net/Prebid_Examples/s5L7p3yd/2/embedded/html,result/
 
 code_height: 3050
 

--- a/dev-docs/examples/postbid.md
+++ b/dev-docs/examples/postbid.md
@@ -14,7 +14,7 @@ about:
 - There is no need to create line items for each price bucket as the postbid creative is served after the ad server has chosen the line item. 
 - This postbid creative <strong>supports passback</strong>. See how this works below.
 
-jsfiddle_link: jsfiddle.net/prebid_org/ob1kn504/embedded/html,result
+jsfiddle_link: jsfiddle.net/Prebid_Examples/mtuq7kz0/2/embedded/html,result
 
 code_height: 1450
 ---

--- a/dev-docs/examples/size-mapping.md
+++ b/dev-docs/examples/size-mapping.md
@@ -10,7 +10,7 @@ about:
 - Dynamic filtering on ad unit sizes
 - Ad unit labels applied based on CSS media queries
 
-jsfiddle_link: jsfiddle.net/Prebid_Examples/cjzezwk9/77/embedded/html,result
+jsfiddle_link: jsfiddle.net/Prebid_Examples/qourvse1/3/embedded/html,result
 
 code_height: 2400
 

--- a/dev-docs/examples/use-prebid-with-appnexus-ad-server.md
+++ b/dev-docs/examples/use-prebid-with-appnexus-ad-server.md
@@ -10,6 +10,6 @@ about:
 - See the <a href="https://wiki.appnexus.com/x/PgOXBQ">AppNexus Seller Tag documentation</a> for more information
 - To configure the AppNexus Seller Tag to use SafeFrames, refer to the <a href="https://wiki.appnexus.com/x/QgOXBQ">SafeFrame API Reference</a>.
 
-jsfiddle_link: jsfiddle.net/prebid_org/7hc1gm8h/embedded/html,result
+jsfiddle_link: jsfiddle.net/Prebid_Examples/tr1djf9e/3/embedded/html,result
 code_height: 2404
 ---

--- a/dev-docs/getting-started.md
+++ b/dev-docs/getting-started.md
@@ -25,7 +25,7 @@ The easiest way to get started with Prebid.js is to use the example code below.
 </div>
 
 <script type="text/javascript">
-Optanon.InsertHtml('<iframe width="100%" height="1600" src="//jsfiddle.net/Prebid_Examples/bryzc7g6/1/embedded/html,result/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>', 'jsfiddle', null, {deleteSelectorContent: true}, 3);
+Optanon.InsertHtml('<iframe width="100%" height="1600" src="//jsfiddle.net/Prebid_Examples/bryzc7g6/3/embedded/html,result/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>', 'jsfiddle', null, {deleteSelectorContent: true}, 3);
 </script>
 
 ### Next Steps

--- a/dev-docs/plugins/bc/bc-prebid-plugin-prebid-options.md
+++ b/dev-docs/plugins/bc/bc-prebid-plugin-prebid-options.md
@@ -56,7 +56,7 @@ Not required but recommended.
 
 **Default Value:**
 
-https://acdn.adnxs.com/prebid/not-for-prod/3/prebid.js
+https://acdn.adnxs.com/prebid/not-for-prod/prebid.js
 
 **Example:**
 

--- a/dev-docs/plugins/cross-player-prebid-component/cross-player-config.md
+++ b/dev-docs/plugins/cross-player-prebid-component/cross-player-config.md
@@ -45,7 +45,7 @@ Not required but recommended.
 
 **Default Value:**
 
-https://acdn.adnxs.com/prebid/not-for-prod/3/prebid.js
+https://acdn.adnxs.com/prebid/not-for-prod/prebid.js
 
 **Example:**
 
@@ -297,7 +297,7 @@ Here is a sample Prebid configuration JSON object returned via URL:
 
 ```
 {
-    "prebidPath" : "//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js",
+    "prebidPath" : "//acdn.adnxs.com/prebid/not-for-prod/prebid.js",
     "biddersSpec" : {
         "code" : "my-video-tag",
         "sizes" : [640, 480],

--- a/examples/legacy/multi-format/multi_format_example.html
+++ b/examples/legacy/multi-format/multi_format_example.html
@@ -4,7 +4,7 @@
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
         <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <meta charset="utf-8">
         <style>
             body {

--- a/examples/legacy/native/native-demo.html
+++ b/examples/legacy/native/native-demo.html
@@ -3,7 +3,7 @@
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
         <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
 
         <script>
             var googletag = googletag || {};

--- a/examples/legacy/pbjs_demo.html
+++ b/examples/legacy/pbjs_demo.html
@@ -90,7 +90,7 @@
                 eventLogger.logEventTime('loadPBJS', 'start');
                 var d = document, pbs = d.createElement("script");
                 pbs.type = "text/javascript";
-                pbs.src = 'https://acdn.adnxs.com/prebid/not-for-prod/3/prebid.js';
+                pbs.src = 'https://acdn.adnxs.com/prebid/not-for-prod/prebid.js';
                 var target = document.getElementsByTagName("head")[0];
                 target.insertBefore(pbs, target.firstChild);
                 eventLogger.logEventTime('loadPBJS', 'end');

--- a/examples/legacy/simple.html
+++ b/examples/legacy/simple.html
@@ -3,7 +3,7 @@
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
         <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <script>
             var sizes = [
                 [300, 250]

--- a/examples/video/crossplayer/flowplayer/pb-cp-flowplayer.html
+++ b/examples/video/crossplayer/flowplayer/pb-cp-flowplayer.html
@@ -46,7 +46,7 @@ sidebarType: 4
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 			<p style="color:#a94443">
-			To allow the Cross-Player plugin to load your custom build of Prebid.js ensure that the option key `prebidPath` is set to the custom build's location. If `prebidPath` is not set, the plugin will point to `//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js`.</p>
+			To allow the Cross-Player plugin to load your custom build of Prebid.js ensure that the option key `prebidPath` is set to the custom build's location. If `prebidPath` is not set, the plugin will point to `//acdn.adnxs.com/prebid/not-for-prod/prebid.js`.</p>
 		</div>
 
 		<div style="width:60vw;">

--- a/examples/video/crossplayer/jwplayer/pb-cp-jwplayer.html
+++ b/examples/video/crossplayer/jwplayer/pb-cp-jwplayer.html
@@ -32,7 +32,7 @@ sidebarType: 4
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 			<p style="color:#a94443">
-			To allow the Cross-Player plugin to load your custom build of Prebid.js ensure that the option key `prebidPath` is set to the custom build's location. If `prebidPath` is not set, the plugin will point to `//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js`.</p>
+			To allow the Cross-Player plugin to load your custom build of Prebid.js ensure that the option key `prebidPath` is set to the custom build's location. If `prebidPath` is not set, the plugin will point to `//acdn.adnxs.com/prebid/not-for-prod/prebid.js`.</p>
 		</div>
 
 		<div style="width:60vw;">

--- a/examples/video/crossplayer/kaltura/pb-cp-kaltura.html
+++ b/examples/video/crossplayer/kaltura/pb-cp-kaltura.html
@@ -32,7 +32,7 @@ sidebarType: 4
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 			<p style="color:#a94443">
-			To allow the Cross-Player plugin to load your custom build of Prebid.js ensure that the option key `prebidPath` is set to the custom build's location. If `prebidPath` is not set, the plugin will point to `//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js`.</p>
+			To allow the Cross-Player plugin to load your custom build of Prebid.js ensure that the option key `prebidPath` is set to the custom build's location. If `prebidPath` is not set, the plugin will point to `//acdn.adnxs.com/prebid/not-for-prod/prebid.js`.</p>
 		</div>
 
 		<div style="width:60vw;">

--- a/examples/video/crossplayer/videojs/pb-cp-videojs.html
+++ b/examples/video/crossplayer/videojs/pb-cp-videojs.html
@@ -37,7 +37,7 @@ sidebarType: 4
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 			<p style="color:#a94443">
-			To allow the Cross-Player plugin to load your custom build of Prebid.js ensure that the option key `prebidPath` is set to the custom build's location. If `prebidPath` is not set, the plugin will point to `//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js`.</p>
+			To allow the Cross-Player plugin to load your custom build of Prebid.js ensure that the option key `prebidPath` is set to the custom build's location. If `prebidPath` is not set, the plugin will point to `//acdn.adnxs.com/prebid/not-for-prod/prebid.js`.</p>
 		</div>
 
 		<div style="width:60vw;">

--- a/examples/video/instream/brid/pb-ve-brid.html
+++ b/examples/video/instream/brid/pb-ve-brid.html
@@ -37,7 +37,7 @@ sidebarType: 4
 			<h4>Place this code in the page header.</h4>
 <pre class="pb-code-hl" style="width:60vw;">
 <!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"&gt;&lt;/script&gt;<br>
+&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;<br>
 &lt;script type="text/javascript" src="//services.brid.tv/player/build/brid.min.js"&gt;&lt;/script&gt;
 &lt;script&gt;
     var pbjs = pbjs || {};

--- a/examples/video/instream/brightcove/pb-ve-brightcove.html
+++ b/examples/video/instream/brightcove/pb-ve-brightcove.html
@@ -39,7 +39,7 @@ sidebarType: 4
 			<h4>Place this code in the page header.</h4>
 <pre class="pb-code-hl" style="width:60vw;">
 <!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"&gt;&lt;/script&gt;<br>
+&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;<br>
 &lt;!--brightcove & prebid js code--&gt;
 &lt;script&gt;
 	var pbjs = pbjs || {};

--- a/examples/video/instream/flowplayer/pb-ve-flowplayer.html
+++ b/examples/video/instream/flowplayer/pb-ve-flowplayer.html
@@ -52,7 +52,7 @@ sidebarType: 4
 			<h4>Place this code in the page header.</h4>
 <pre class="pb-code-hl" style="width:60vw;">
 <!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 &lt;link rel="stylesheet" href="//cdn.flowplayer.com/releases/native/stable/style/flowplayer.css"&gt;
 &lt;script src="//cdn.flowplayer.com/releases/native/stable/flowplayer.min.js"&gt;&lt;/script&gt;
 &lt;script src="//cdn.flowplayer.com/releases/native/stable/plugins/ads.min.js"&gt;&lt;/script&gt;

--- a/examples/video/instream/jwplayer/pb-ve-jwplayer-hosted.html
+++ b/examples/video/instream/jwplayer/pb-ve-jwplayer-hosted.html
@@ -39,7 +39,7 @@ sidebarType: 4
 <pre class="pb-code-hl" style="width:60vw;">
 
 <!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 &lt;script type="text/javascript" src="http://ssl.p.jwpcdn.com/player/v/7.2.4/jwplayer.js"&gt;&lt;/script&gt;
 &lt;script type="text/javascript"&gt;
 	jwplayer.key = "YEUwUA9wRFeDcydr"; //Test Key - replace this with your own valid JWPlayer license key<br>

--- a/examples/video/instream/jwplayer/pb-ve-jwplayer-platform.html
+++ b/examples/video/instream/jwplayer/pb-ve-jwplayer-platform.html
@@ -39,7 +39,7 @@ sidebarType: 4
 <pre class="pb-code-hl" style="width:60vw;">
 <!--put javascript code here-->
 &lt;!--Prebid.js and video player code--&gt;
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 &lt;script&gt;
     var pbjs = pbjs || {};
     pbjs.que = pbjs.que || [];

--- a/examples/video/instream/jwplayer/pb-ve-jwplayer-playlist.html
+++ b/examples/video/instream/jwplayer/pb-ve-jwplayer-playlist.html
@@ -37,7 +37,7 @@ sidebarType: 4
 			<h4>Place this code in the page header.</h4>
 <pre class="pb-code-hl" style="width:60vw;">
 <!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 &lt;script&gt;
     var pbjs = pbjs || {};
     pbjs.que = pbjs.que || [];

--- a/examples/video/instream/ooyala/pb-ve-ooyala.html
+++ b/examples/video/instream/ooyala/pb-ve-ooyala.html
@@ -39,7 +39,7 @@ sidebarType: 4
 		
 <pre class="pb-code-hl" style="width:60vw; display:block; overflow:normal; overflow-x:auto;"><code>
 <!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 &lt;!-- LOAD OOYALA PLUGINS
 
  Load the Ooyala player scripts you plan to use.

--- a/examples/video/instream/radiant/pb-ve-radiant.html
+++ b/examples/video/instream/radiant/pb-ve-radiant.html
@@ -38,7 +38,7 @@ sidebarType: 4
 <pre class="pb-code-hl" style="width:60vw; display:block; overflow:normal; overflow-x:auto;"><code>
 <!--put javascript code here-->
 &lt;!--production version of prebid.js--&gt;
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 
 &lt;!-- Radiant Media Player core library - debug browser console mode (use rmp.min.js for production) --&gt;
 &lt;script src="https://cdn.radiantmediatechs.com/rmp/5.5.6/js/rmp.debug.js"&gt;&lt;/script&gt;

--- a/examples/video/instream/videojs/pb-ve-videojs.html
+++ b/examples/video/instream/videojs/pb-ve-videojs.html
@@ -42,7 +42,7 @@ sidebarType: 4
 			<h4>Place this code in the page header.</h4>
 <pre class="pb-code-hl" style="width:60vw;">
 <!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 &lt;!-- use recent version of videojs to ensure proper functioning with the iOS devices --&gt;
 &lt;link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/video.js/6.4.0/video-js.css"&gt;
 &lt;script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/video.js/6.4.0/video.js"&gt;&lt;/script&gt;

--- a/examples/video/legacy/bc-demo.html
+++ b/examples/video/legacy/bc-demo.html
@@ -3,7 +3,7 @@
 
 	<head>
 		<link rel="icon" type="image/png" href="/favicon.png">
-		<script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+		<script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
 		<link href="//players.brightcove.net/videojs-ima3/2/videojs.ima3.min.css" rel="stylesheet">
 		<title>Prebid Video -- Brightcove Player</title>
 		<script>

--- a/examples/video/legacy/bc-pbserver-demo.html
+++ b/examples/video/legacy/bc-pbserver-demo.html
@@ -4,7 +4,7 @@
     <head>
 
         <link href="//players.brightcove.net/videojs-ima3/2/videojs.ima3.min.css" rel="stylesheet">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <title>Prebid Server Video -- Brightcove</title>
         <script>
             var pbjs = pbjs || {};

--- a/examples/video/legacy/brid-player-demo.html
+++ b/examples/video/legacy/brid-player-demo.html
@@ -3,7 +3,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <meta charset="utf-8" />
         <title>Prebid.js Cloud-Hosted Brid Player Example</title>
         <script type="text/javascript" src="//services.brid.tv/player/build/brid.min.js"></script>

--- a/examples/video/legacy/bridplayer-pbserver-demo.html
+++ b/examples/video/legacy/bridplayer-pbserver-demo.html
@@ -3,7 +3,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <meta charset="utf-8" />
         <title>Prebid Server Video - Cloud-Hosted Brid Player</title>
         <script type="text/javascript" src="//services.brid.tv/player/build/brid.min.js"></script>

--- a/examples/video/legacy/flowplayer-demo.html
+++ b/examples/video/legacy/flowplayer-demo.html
@@ -3,7 +3,7 @@
 
 <head>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     <meta charset="utf-8" />
     <title>Prebid.js Cloud-Hosted Flowplayer Example</title>
     <link rel="stylesheet" href="//cdn.flowplayer.com/releases/native/stable/style/flowplayer.css">

--- a/examples/video/legacy/jwPlatformPrebidDemo.html
+++ b/examples/video/legacy/jwPlatformPrebidDemo.html
@@ -3,7 +3,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <meta charset="utf-8" />
         <title>Prebid.js JW Platform Example</title>
         <script>

--- a/examples/video/legacy/jwPlayerPrebid.html
+++ b/examples/video/legacy/jwPlayerPrebid.html
@@ -3,7 +3,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <meta charset="utf-8" />
         <title>Prebid.js Self-Hosted JW Player Example</title>
         <script type="text/javascript" src="http://ssl.p.jwpcdn.com/player/v/7.2.4/jwplayer.js"></script>

--- a/examples/video/legacy/jwPlaylistUniqueAds.html
+++ b/examples/video/legacy/jwPlaylistUniqueAds.html
@@ -3,7 +3,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <meta charset="utf-8" />
         <title>Prebid.js JWPlayer Example</title>
         <script>

--- a/examples/video/legacy/jwplatform-pbserver-demo.html
+++ b/examples/video/legacy/jwplatform-pbserver-demo.html
@@ -3,7 +3,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <meta charset="utf-8" />
         <title>Prebid Server Video -- JW Platform</title>
         <script>

--- a/examples/video/legacy/jwplayer-pbserver-demo.html
+++ b/examples/video/legacy/jwplayer-pbserver-demo.html
@@ -3,7 +3,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <meta charset="utf-8" />
         <title>Prebid Server Video -- Self-Hosted JW V8 Player</title>
         <script type="text/javascript" src="http://ssl.p.jwpcdn.com/player/v/8.0.5/jwplayer.js"></script>

--- a/examples/video/legacy/jwplayer7-pbserver-demo.html
+++ b/examples/video/legacy/jwplayer7-pbserver-demo.html
@@ -3,7 +3,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <meta charset="utf-8" />
         <title>Prebid Server Video -- Self-Hosted JW V7 Player</title>
         <script type="text/javascript" src="http://ssl.p.jwpcdn.com/player/v/7.2.4/jwplayer.js"></script>

--- a/examples/video/legacy/jwplaylist-pbserver-demo.html
+++ b/examples/video/legacy/jwplaylist-pbserver-demo.html
@@ -3,7 +3,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <meta charset="utf-8" />
         <title>Prebid Server Video -- JW Player with Playlist</title>
         <script>

--- a/examples/video/legacy/kaltura-pbserver-demo.html
+++ b/examples/video/legacy/kaltura-pbserver-demo.html
@@ -3,7 +3,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <title>Prebid Server Video Example - Kaltura Player</title>
         <script>

--- a/examples/video/legacy/klt-demo.html
+++ b/examples/video/legacy/klt-demo.html
@@ -3,7 +3,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <title>Prebid Video Example - Kaltura Player</title>
 

--- a/examples/video/legacy/ooyala-demo.html
+++ b/examples/video/legacy/ooyala-demo.html
@@ -3,7 +3,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <title>Ooyala Prebid Demo</title>
 
         <!-- LOAD OOYALA PLUGINS

--- a/examples/video/legacy/ooyala-pbserver-demo.html
+++ b/examples/video/legacy/ooyala-pbserver-demo.html
@@ -3,7 +3,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <title>Prebid Server Video -- Ooyala Player</title>
 
         <!-- LOAD OOYALA PLUGINS

--- a/examples/video/legacy/outstream-dfp.html
+++ b/examples/video/legacy/outstream-dfp.html
@@ -4,7 +4,7 @@
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
         <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <meta charset="utf-8" />
         <title>Prebid.js Outstream DFP Demo</title>
         <script>

--- a/examples/video/legacy/outstream-no-adserver.html
+++ b/examples/video/legacy/outstream-no-adserver.html
@@ -3,7 +3,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <meta charset="utf-8" />
         <title>Prebid.js Outstream without Ad Server Demo</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/video/legacy/videojs-demo.html
+++ b/examples/video/legacy/videojs-demo.html
@@ -3,7 +3,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <meta charset="utf-8" />
         <title>Prebid Video -- video.js</title>
         <!-- videojs -->

--- a/examples/video/legacy/videojs-pbserver-demo.html
+++ b/examples/video/legacy/videojs-pbserver-demo.html
@@ -3,7 +3,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
         <meta charset="utf-8" />
         <title>Prebid Server Video -- Video.js</title>
         <!-- videojs -->

--- a/examples/video/long-form/long-form-video-with-freewheel.html
+++ b/examples/video/long-form/long-form-video-with-freewheel.html
@@ -3,7 +3,7 @@
   <head>
     <title>Prebid Freewheel Integration Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <script async src="http://acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"></script>
+    <script async src="http://acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script><link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">

--- a/examples/video/pb-video-template.html
+++ b/examples/video/pb-video-template.html
@@ -176,7 +176,7 @@ sidebarType: 4
 <pre class="pb-code-hl">
 	<!--put javascript code here-->
 	&lt;script async src="//www.googletagservices.com/tag/js/gpt.js"&gt;&lt;/script&gt;
-		&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"&gt;&lt;/script&gt;
+		&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 		&lt;script type="text/javascript" src="http://ssl.p.jwpcdn.com/player/v/8.0.5/jwplayer.js"&gt;&lt;/script&gt;
         &lt;script type="text/javascript"&gt;
             jwplayer.key = "F4+phNkFZ4+I3UhfSN6h8JPbxdnsto3caVMq+A=="; //Test Key - replace this with your own valid JWPlayer license key

--- a/examples/video/server/brid/pbs-ve-brid.html
+++ b/examples/video/server/brid/pbs-ve-brid.html
@@ -37,7 +37,7 @@ sidebarType: 4
 			<h4>Place this code in the page header.</h4>
 <pre class="pb-code-hl">
 <!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 
 &lt;script type="text/javascript" src="//services.brid.tv/player/build/brid.min.js"&gt;&lt;/script&gt;
 &lt;script&gt;

--- a/examples/video/server/jwplayer/pbs-ve-jwplayer-hosted.html
+++ b/examples/video/server/jwplayer/pbs-ve-jwplayer-hosted.html
@@ -36,7 +36,7 @@ sidebarType: 4
 			<h4>Place this code in the page header.</h4>
 <pre class="pb-code-hl">
 	<!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 &lt;script type="text/javascript" src="http://ssl.p.jwpcdn.com/player/v/8.0.5/jwplayer.js"&gt;&lt;/script&gt;
 &lt;script type="text/javascript"&gt;
     jwplayer.key = "F4+phNkFZ4+I3UhfSN6h8JPbxdnsto3caVMq+A=="; //Test Key - replace this with your own valid JWPlayer license key<br>

--- a/examples/video/server/radiant/pbs-ve-radiant.html
+++ b/examples/video/server/radiant/pbs-ve-radiant.html
@@ -38,7 +38,7 @@ sidebarType: 4
 <pre class="pb-code-hl" style="width:60vw; display:block; overflow:normal; overflow-x:auto;"><code>
 <!--put javascript code here-->
 &lt;!--production version of prebid.js--&gt;
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/3/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 
 &lt;!-- Radiant Media Player core library - debug browser console mode (use rmp.min.js for production) --&gt;
 &lt;script src="https://cdn.radiantmediatechs.com/rmp/5.5.6/js/rmp.debug.js"&gt;&lt;/script&gt;


### PR DESCRIPTION
A semi follow-up to https://github.com/prebid/prebid.github.io/pull/1745

In this PR, I updated the CDN URLs to a non-version specific variant so that they should continue to work even when we do the next major release for Prebid.js.  This includes the jsfiddle examples, which were also updated to exist under a single jsfiddle account (instead of multiple accounts).

