### PR TITLE
remove stray HTML tags, fixes #1852

### DIFF
--- a/_includes/adops/adops-gam-setup.html
+++ b/_includes/adops/adops-gam-setup.html
@@ -170,15 +170,4 @@ order), the creative and targeting will be different from the example shown here
 
 <p>Repeat for your other line items until you have the pricing granularity level you want.</p>
 
-			
-			
-			
-			</div>
-				
-		</div>
-		<!--end wrapper-->
-	</div>	
-	<!--end row-->	
 </div>
-
-<p></p>

--- a/_includes/adops/adops-gam-video-setup.html
+++ b/_includes/adops/adops-gam-video-setup.html
@@ -86,15 +86,4 @@ or
   <li><a href="https://support.google.com/admanager/answer/2376981">Google Ad Manager Macros</a> (Google Ad Manager)</li>
 </ul>
 
-			
-			
-			
-			</div>
-				
-		</div>
-		<!--end wrapper-->
-	</div>	
-	<!--end row-->	
 </div>
-
-<p></p>


### PR DESCRIPTION
Remove stray HTML tags. You can see the problem at the bottom of these two pages:
http://prebid.org/adops/step-by-step.html
http://prebid.org/adops/setting-up-prebid-video-in-dfp.html