### PR TITLE
Quantcast: Added flags for TCF v2 and COPPA support.

### DIFF
--- a/dev-docs/bidders/quantcast.md
+++ b/dev-docs/bidders/quantcast.md
@@ -7,6 +7,8 @@ biddercode: quantcast
 media_types: video
 gdpr_supported: true
 usp_supported: true
+tcf2_supported: true
+coppa_supported: true
 ---
 
 ### Bid Params


### PR DESCRIPTION
Added flags for TCF v2 and COPPA support to the Quantcast adapter documentation.