### PR TITLE
Fix bidder docs support for userid module

### DIFF
--- a/dev-docs/bidders/9MediaOnline.md
+++ b/dev-docs/bidders/9MediaOnline.md
@@ -8,7 +8,7 @@ media_types: banner, video
 gdpr_supported: true
 schain_supported: true
 usp_supported: true
-userIds: unifiedId/tradedesk, id5Id
+userIds: id5Id, unifiedId
 aliasCode: gamoshi
 ---
 

--- a/dev-docs/bidders/aardvark.md
+++ b/dev-docs/bidders/aardvark.md
@@ -7,7 +7,7 @@ biddercode: aardvark
 gdpr_supported: true
 usp_supported: true
 schain_supported: true
-userIds: unifiedId/tradedesk
+userIds: unifiedId
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/adtarget.md
+++ b/dev-docs/bidders/adtarget.md
@@ -8,7 +8,7 @@ media_types: banner, video
 gdpr_supported: true
 schain_supported: true
 usp_supported: true
-userIds: unifiedId/tradedesk, id5Id
+userIds: id5Id, unifiedId
 aliasCode: gamoshi
 ---
 

--- a/dev-docs/bidders/adxcg.md
+++ b/dev-docs/bidders/adxcg.md
@@ -6,7 +6,7 @@ hide: true
 biddercode: adxcg
 media_types: native, video
 gdpr_supported: true
-userIds: pubCommon, unifiedId/tradedesk
+userIds: id5Id, identityLink, pubCommonId, unifiedId
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/beachfront.md
+++ b/dev-docs/bidders/beachfront.md
@@ -7,7 +7,7 @@ biddercode: beachfront
 media_types: video
 gdpr_supported: true
 usp_supported: true
-userIds: unifiedId/tradedesk
+userIds: unifiedId
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/cleanmedia.md
+++ b/dev-docs/bidders/cleanmedia.md
@@ -8,7 +8,7 @@ media_types: banner, video
 gdpr_supported: true
 schain_supported: true
 usp_supported: true
-userIds: unifiedId/tradedesk, id5Id
+userIds: id5Id, unifiedId
 aliasCode: gamoshi
 ---
 

--- a/dev-docs/bidders/conversant.md
+++ b/dev-docs/bidders/conversant.md
@@ -6,7 +6,7 @@ hide: true
 biddercode: conversant
 media_types: video
 gdpr_supported: true
-userIds: pubCommon
+userIds: criteo, digitrust, id5Id, identityLink, liveIntentId, parrableId, unifiedId
 ---
 
 

--- a/dev-docs/bidders/emoteev.md
+++ b/dev-docs/bidders/emoteev.md
@@ -5,7 +5,7 @@ description: Prebid Emoteev Bidder Adaptor
 hide: true
 biddercode: emoteev
 gdpr_supported: true
-userIds: pubCommon
+userIds: pubCommonId
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/gambid.md
+++ b/dev-docs/bidders/gambid.md
@@ -10,7 +10,7 @@ hide: true
 media_types: banner, video
 biddercode: gambid
 aliasCode: gamoshi
-
+userIds: id5Id, unifiedId
 ---
 
 ### Bid params

--- a/dev-docs/bidders/gamoshi.md
+++ b/dev-docs/bidders/gamoshi.md
@@ -8,7 +8,7 @@ media_types: banner, video
 gdpr_supported: true
 schain_supported: true
 usp_supported: true
-userIds: unifiedId/tradedesk, id5Id
+userIds: id5Id, unifiedId
 ---
 
 ### Bid params

--- a/dev-docs/bidders/gumgum.md
+++ b/dev-docs/bidders/gumgum.md
@@ -6,7 +6,7 @@ hide: true
 biddercode: gumgum
 media_types: banner, video
 schain_supported: true
-userIds: unifiedId/tradedesk, digitrustId
+userIds: digitrust, unifiedId
 gdpr_supported: true
 usp_supported: true
 ---

--- a/dev-docs/bidders/justpremium.md
+++ b/dev-docs/bidders/justpremium.md
@@ -6,6 +6,7 @@ hide: true
 biddercode: justpremium
 gdpr_supported: true
 usp_supported: true
+userIds: britepoolId, criteo, digitrust, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
 ---
 
 

--- a/dev-docs/bidders/kargo.md
+++ b/dev-docs/bidders/kargo.md
@@ -4,7 +4,7 @@ title: Kargo
 description: Prebid Kargo Bidder Adaptor
 hide: true
 biddercode: kargo
-userIds: unifiedId/tradedesk
+userIds: unifiedId
 usp_supported: true
 ---
 

--- a/dev-docs/bidders/livewrapped.md
+++ b/dev-docs/bidders/livewrapped.md
@@ -6,7 +6,7 @@ biddercode: livewrapped
 hide: true
 media_types: banner
 gdpr_supported: true
-userIds: pubcommon
+userIds: id5Id, pubCommonId
 ---
 
 ### Note:

--- a/dev-docs/bidders/medianet.md
+++ b/dev-docs/bidders/medianet.md
@@ -7,7 +7,7 @@ hide: true
 gdpr_supported: true
 media_types: banner,native
 usp_supported: true
-userIds: criteo,digitrust,pubCommonId
+userIds: britepoolId, criteo, digitrust, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/mobsmart.md
+++ b/dev-docs/bidders/mobsmart.md
@@ -5,7 +5,7 @@ description: Prebid Mobsmart SSP Bidder Adaptor
 hide: true
 biddercode: mobsmart
 media_types: banner
-userIds: pubCommon
+userIds: pubCommonId
 ---
 
 ### Note:

--- a/dev-docs/bidders/onetag.md
+++ b/dev-docs/bidders/onetag.md
@@ -7,6 +7,7 @@ biddercode: onetag
 media_types: banner
 gdpr_supported: true
 usp_supported: true
+userIds: britepoolId, criteo, digitrust, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
 ---
 
 

--- a/dev-docs/bidders/openx.md
+++ b/dev-docs/bidders/openx.md
@@ -9,7 +9,7 @@ schain_supported: true
 gdpr_supported: true
 usp_supported: true
 coppa_supported: true
-userIds: criteo, identityLink, pubCommonId, unifiedId
+userIds: britepoolId, criteo, digitrust, id5Id, identityLink, liveIntentId, parrableId, pubCommonId, unifiedId
 prebid_member: true
 ---
 

--- a/dev-docs/bidders/openx.md
+++ b/dev-docs/bidders/openx.md
@@ -9,7 +9,7 @@ schain_supported: true
 gdpr_supported: true
 usp_supported: true
 coppa_supported: true
-userIds: pubCommon, unifiedId, identityLink
+userIds: criteo, identityLink, pubCommonId, unifiedId
 prebid_member: true
 ---
 

--- a/dev-docs/bidders/ozone.md
+++ b/dev-docs/bidders/ozone.md
@@ -6,6 +6,7 @@ biddercode: ozone
 hide: true
 media_types: banner
 gdpr_supported: true
+userIds: criteo, id5Id, identityLink, liveIntentId, parrableId, pubCommonId
 ---
 
 #### Bid Params

--- a/dev-docs/bidders/pubmatic.md
+++ b/dev-docs/bidders/pubmatic.md
@@ -9,7 +9,7 @@ gdpr_supported: true
 usp_supported: true
 coppa_supported: true
 schain_supported: true
-userIds: pubcommonId, unifiedId/tradedesk, digitrustId, id5Id, criteo, identityLink, liveIntent, parrable, britepoolId, NetId
+userIds: britepoolId, criteo, digitrust, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
 prebid_member: true
 ---
 

--- a/dev-docs/bidders/pulsepoint.md
+++ b/dev-docs/bidders/pulsepoint.md
@@ -8,7 +8,7 @@ gdpr_supported: true
 usp_supported: true
 schain_supported: true
 media_types: banner, video, native
-userIds: pubcommonId, unifiedId, digitrustId, id5Id, britepoolId, criteo, identityLink, parrable, liveIntent
+userIds: britepoolId, criteo, digitrust, id5Id, identityLink, liveIntentId, parrableId, pubCommonId, unifiedId
 ---
 
 

--- a/dev-docs/bidders/richaudience.md
+++ b/dev-docs/bidders/richaudience.md
@@ -4,7 +4,7 @@ title: Rich Audience
 description: Prebid Rich Audience Bidder Adapter
 hide: true
 biddercode: richaudience
-userIds: pubcommonId, unifiedId/tradedesk, id5Id, criteo, identityLink, liveIntent
+userIds: criteo, id5Id, identityLink, liveIntentId, pubCommonId, unifiedId
 media_types: banner, video
 gdpr_supported: true
 ---

--- a/dev-docs/bidders/rubicon.md
+++ b/dev-docs/bidders/rubicon.md
@@ -9,7 +9,7 @@ usp_supported: true
 coppa_supported: true
 schain_supported: true
 media_types: video
-userIds: unifiedId/tradedesk, digitrust, liveIntent
+userIds: identityLink, liveIntentId, pubCommonId, unifiedId
 prebid_member: true
 ---
 

--- a/dev-docs/bidders/sharethrough.md
+++ b/dev-docs/bidders/sharethrough.md
@@ -7,7 +7,7 @@ biddercode: sharethrough
 media_types: native
 gdpr_supported: true
 usp_supported: true
-userIds: unifiedId/tradedesk
+userIds: unifiedId
 schain_supported: true
 ---
 

--- a/dev-docs/bidders/smartrtb.md
+++ b/dev-docs/bidders/smartrtb.md
@@ -6,7 +6,7 @@ hide: true
 biddercode: smartrtb
 gdpr_supported: true
 media_types: banner, video
-userIds: unifiedId,pubCommonId,id5id,digitrust
+userIds: britepoolId, criteo, digitrust, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
 ---
 
 ### bid params

--- a/dev-docs/bidders/sonobi.md
+++ b/dev-docs/bidders/sonobi.md
@@ -6,7 +6,7 @@ hide: true
 biddercode: sonobi
 media_types: video
 gdpr_supported: true
-userIds: pubCommon, unifiedId/tradedesk
+userIds: britepoolId, criteo, digitrust, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
 ---
 
 ### Note:

--- a/dev-docs/bidders/sovrn.md
+++ b/dev-docs/bidders/sovrn.md
@@ -6,6 +6,7 @@ hide: true
 biddercode: sovrn
 gdpr_supported: true
 usp_supported: true
+userIds: digitrust
 ---
 
 

--- a/dev-docs/bidders/spotx.md
+++ b/dev-docs/bidders/spotx.md
@@ -6,7 +6,7 @@ hide: true
 biddercode: spotx
 media_types: video
 gdpr_supported: true
-userIds: unifiedId/tradedesk, id5Id
+userIds: id5Id, pubCommonId, unifiedId
 prebid_member: true
 schain_supported: true
 usp_supported: true

--- a/dev-docs/bidders/triplelift.md
+++ b/dev-docs/bidders/triplelift.md
@@ -8,7 +8,7 @@ usp_supported: true
 schain_supported: true
 coppa_supported: true
 biddercode: triplelift
-userIds: unifiedId/tradedesk, identityLink
+userIds: criteo, identityLink, unifiedId
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/ucfunnel.md
+++ b/dev-docs/bidders/ucfunnel.md
@@ -7,6 +7,7 @@ biddercode: ucfunnel
 media_types: video, native
 gdpr_supported: true
 usp_supported: true
+userIds: unifiedId
 ---
 
 ### Bid params

--- a/dev-docs/bidders/undertone.md
+++ b/dev-docs/bidders/undertone.md
@@ -6,6 +6,7 @@ hide: true
 biddercode: undertone
 gdpr_supported: true
 usp_supported: true
+userIds: britepoolId, criteo, digitrust, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
 ---
 
 

--- a/dev-docs/bidders/visx.md
+++ b/dev-docs/bidders/visx.md
@@ -6,7 +6,7 @@ hide: true
 biddercode: visx
 gdpr_supported: true
 schain_supported: true
-userIds: unifiedId, digitrust, id5
+userIds: digitrust, id5Id, unifiedId
 ---
 
 ### Note

--- a/dev-docs/bidders/yieldlab.md
+++ b/dev-docs/bidders/yieldlab.md
@@ -6,6 +6,7 @@ hide: true
 biddercode: yieldlab
 media_types: video
 gdpr_supported: true
+userIds: britepoolId, criteo, digitrust, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
 ---
 
 

--- a/dev-docs/bidders/yieldmo.md
+++ b/dev-docs/bidders/yieldmo.md
@@ -5,7 +5,7 @@ description: Prebid Yieldmo Bidder Adaptor
 hide: true
 biddercode: yieldmo
 media_types: native
-userIds: pubCommon
+userIds: pubCommonId, unifiedId
 ---
 
 

--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -96,7 +96,7 @@ The BritePool privacy policy is at [https://britepool.com/services-privacy-notic
 #### BritePool Configuration
 
 {: .table .table-bordered .table-striped }
-| Param under usersync.userIds[] | Scope | Type | Description | Example |
+| Param under userSync.userIds[] | Scope | Type | Description | Example |
 | --- | --- | --- | --- | --- |
 | name | Required | String | `"britepoolId"` | `"britepoolId"` |
 | params | Required | Object | Details for britepool initialization. | |
@@ -110,7 +110,7 @@ The BritePool privacy policy is at [https://britepool.com/services-privacy-notic
 
 {% highlight javascript %}
    pbjs.setConfig({
-       usersync: {
+       userSync: {
            userIds: [{
                name: "britepoolId",
                storage: {
@@ -706,7 +706,7 @@ The EnID is a non-profit organization which is open to any contributing party on
 
 {% highlight javascript %}
 pbjs.setConfig({
-    usersync: {
+    userSync: {
         userIds: [{
             name: "netId",
             value: {


### PR DESCRIPTION
Many of the bid adapters' documentation did not properly list the userId submodules that they listen to in their adapter code. 

This PR is to update each adapter's docs that are clearly listening to one or more userId submodules in their adapter code. Bid adapters can listen to providers via a whitelist of ID providers that are clearly called out in the code, or by grabbing the entire `userIds` or `userIdAsEids` array and adding them to their ad request payload.

ID providers are listen in alphabetical order, just like in the userId documentation.