### PR TITLE
Add a conversant parameter to override the destination URL

### DIFF
--- a/dev-docs/bidders/conversant.md
+++ b/dev-docs/bidders/conversant.md
@@ -26,6 +26,7 @@ userIds: criteo, digitrust, id5Id, identityLink, liveIntentId, parrableId, unifi
 | `maxduration` | optional                    | Maximum duration in seconds for this video as an integer.                                                                 | `30`              | `integer`        |
 | `api`         | optional                    | Array of supported API frameworks. See details below.                                                                     | `[2]`             | `Array<integer>` |
 | `protocols`   | optional                    | Array of supported video protocols. See details below.                                                                    | `[2]`             | `Array<integer>` |
+| `white_label_url`| optional                  | Override the destination URL the request is sent to.                                                                       | `https://mydomain.com/hbendpoint`  | `string` |
 | `pubcid_name` | optional                    | Name of the pub common id. Conversant adapter can read the id directly if the UserID module is absent. Default is _pubcid.| `_pubcid`         | `string`         |
 
 

--- a/dev-docs/bidders/conversant.md
+++ b/dev-docs/bidders/conversant.md
@@ -26,7 +26,7 @@ userIds: criteo, digitrust, id5Id, identityLink, liveIntentId, parrableId, unifi
 | `maxduration` | optional                    | Maximum duration in seconds for this video as an integer.                                                                 | `30`              | `integer`        |
 | `api`         | optional                    | Array of supported API frameworks. See details below.                                                                     | `[2]`             | `Array<integer>` |
 | `protocols`   | optional                    | Array of supported video protocols. See details below.                                                                    | `[2]`             | `Array<integer>` |
-| `white_label_url`| optional                  | Override the destination URL the request is sent to.                                                                       | `https://mydomain.com/hbendpoint`  | `string` |
+| `white_label_url`| optional                  | Override the destination URL the request is sent to.                                                                       | `'https://mydomain.com/hbendpoint'`  | `string` |
 | `pubcid_name` | optional                    | Name of the pub common id. Conversant adapter can read the id directly if the UserID module is absent. Default is _pubcid.| `_pubcid`         | `string`         |
 
 


### PR DESCRIPTION
Override the destination URL in the Conversant adapter with the white_label_url parameter