### PR TITLE
add cache url to post ad data to cache

### DIFF
--- a/examples/video/instream/brid/pb-ve-brid.html
+++ b/examples/video/instream/brid/pb-ve-brid.html
@@ -80,7 +80,10 @@ sidebarType: 4
       pbjs.addAdUnits(videoAdUnit);
 
       pbjs.setConfig({
-        usePrebidCache: true
+        usePrebidCache: true,
+        cache: {
+          url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        }
       });
 
       pbjs.requestBids({


### PR DESCRIPTION
The example did not display the ad and the reason was that it didn't send the POST request to prebid cache to save the vast xml. Hence added the cache url in setConfig().