### PR TITLE
Add Tercept Analytics adapter to download page and analytics page

### DIFF
--- a/download.md
+++ b/download.md
@@ -428,6 +428,14 @@ Note: If you receive an error during download you most likely selected a configu
 <div class="col-md-4">
   <div class="checkbox">
     <label>
+      <input type="checkbox" analyticscode="tercept" class="analytics-check-box" /> Tercept Analytics
+    </label>
+  </div>
+</div>
+
+<div class="col-md-4">
+  <div class="checkbox">
+    <label>
       <input type="checkbox" analyticscode="ucfunnel" class="analytics-check-box" /> ucfunnel Analytics
     </label>
   </div>

--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -38,6 +38,7 @@ There are several analytics adapter plugins available to track header bidding pe
 | Sortable | Contact vendor | [Website](https://www.sortable.com) |
 | Sovrn | <a href="https://www.sovrn.com/contact/">Contact vendor</a> | [Website](https://www.sovrn.com/analytics/)|
 | STAQ | <a href="https://www.staq.com/contact">Contact vendor</a> | [Website](https://www.staq.com/)|
+| Tercept Analytics | <a href="https://www.tercept.com/contact">Contact vendor</a> | [Website](https://www.tercept.com/)|
 | ucfunnel | Contact vendor | [Website](https://www.ucfunnel.com/)|
 | Vuble | Contact vendor | [Website](https://vuble.tv/us/prebid/) |
 | Yieldone | Contact vendor | [Website](https://www.platform-one.co.jp/) |

--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -38,7 +38,7 @@ There are several analytics adapter plugins available to track header bidding pe
 | Sortable | Contact vendor | [Website](https://www.sortable.com) |
 | Sovrn | <a href="https://www.sovrn.com/contact/">Contact vendor</a> | [Website](https://www.sovrn.com/analytics/)|
 | STAQ | <a href="https://www.staq.com/contact">Contact vendor</a> | [Website](https://www.staq.com/)|
-| Tercept Analytics | <a href="https://www.tercept.com/contact">Contact vendor</a> | [Website](https://www.tercept.com/)|
+| Tercept Analytics | <a href="https://www.tercept.com/unified-analytics/">Contact vendor</a> | [Website](https://www.tercept.com/)|
 | ucfunnel | Contact vendor | [Website](https://www.ucfunnel.com/)|
 | Vuble | Contact vendor | [Website](https://vuble.tv/us/prebid/) |
 | Yieldone | Contact vendor | [Website](https://www.platform-one.co.jp/) |


### PR DESCRIPTION
Tercept's Analytics adapter went live with the 3.17 release of Prebid.js.