### PR TITLE
DistrictmDMX to support user id sub modules

### DIFF
--- a/dev-docs/bidders/districtmdmx.md
+++ b/dev-docs/bidders/districtmdmx.md
@@ -7,6 +7,7 @@ biddercode: districtmDMX
 gdpr_supported: true
 schain_supported: true
 usp_supported: true
+userIds: digitrust, id5Id, identityLink, pubCommonId, unifiedId
 ---
 
 


### PR DESCRIPTION
updating docs to reflect support of digitrust, id5Id, identityLink, pubCommonId, and unifiedId submodules