### PR TITLE
safeframe and tcf2 fields

### DIFF
--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -995,6 +995,7 @@ registerBidder(spec);
     - If you support video and/or native mediaTypes add `media_types: video, native`. Note that display is added by default. If you don't support display, add "no-display" as the first entry, e.g. `media_types: no-display, native`
     - If you support COPPA, add `coppa_supported: true`
     - If you support SChain, add `schain_supported: true`
+    - If your bidder doesn't work well with safeframed creatives, add `safeframes_ok: false`. This will alert publishers to not use safeframed creatives when creating the ad server entries for your bidder.
     - If you're a member of Prebid.org, add `prebid_member: true`
 - Submit both the code and docs pull requests
 

--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -987,7 +987,15 @@ registerBidder(spec);
 - [Write unit tests](https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md)
 - Create a docs pull request against [prebid.github.io](https://github.com/prebid/prebid.github.io)
   - Fork the repo
-  - Copy a file in [dev-docs/bidders](https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders) and modify
+  - Copy a file in [dev-docs/bidders](https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders) and modify. Add the following metadata to the header of your .md file:
+    - If you support the GDPR consentManagement module and TCF1, add `gdpr_supported: true`
+    - If you support the GDPR consentManagement module and TCF2, add `tcf2_supported: true`
+    - If you support the US Privacy consentManagementUsp module, add `usp_supported: true`
+    - If you support one or more userId modules, add `userId: (list of supported vendors)`
+    - If you support video and/or native mediaTypes add `media_types: video, native`. Note that display is added by default. If you don't support display, add "no-display" as the first entry, e.g. `media_types: no-display, native`
+    - If you support COPPA, add `coppa_supported: true`
+    - If you support SChain, add `schain_supported: true`
+    - If you're a member of Prebid.org, add `prebid_member: true`
 - Submit both the code and docs pull requests
 
 Within a few days, the code pull request will be assigned to a developer for review.

--- a/dev-docs/bidders.md
+++ b/dev-docs/bidders.md
@@ -98,9 +98,10 @@ The following parameters in the `bidResponse` object are common across all bidde
 
 {: .table .table-bordered .table-striped }
 | **Bidder Code** | {{ page.biddercode }} | **Prebid.org Member** | {% if page.prebid_member == true %}yes{% else %}no{% endif %} |
-| **Media Types** | display{% if page.media_types contains 'video' %}, video{% endif %}{% if page.media_types contains 'native' %}, native{% endif %} | **GDPR Support** | {% if page.gdpr_supported == true %}yes{% else %}no{% endif %} |
-| **User IDs** | {% if page.userIds and page.userIds != '' %}{{page.userIds}}{% else %}none{% endif %} | **COPPA Support** | {% if page.coppa_supported == true %}yes{% else %}no{% endif %} |
-| **SChain Support** | {% if page.schain_supported  == true %}yes{% else %}no{% endif %} | **USP/CCPA Support** | {% if page.usp_supported == true %}yes{% else %}no{% endif %} |
+| **Media Types** | {% unless page.media_types contains 'no-display' %}display{% endunless %}{% if page.media_types contains 'video' %},{% endif %}{% if page.media_types contains 'video' %} video{% endif %}{% if page.media_types != "no-display, native" and page.media_types contains 'native' %}, native{% endif %}{% if page.media_types == "no-display, native" %}native{% endif %} | **GDPR TCF1 Support** | {% if page.gdpr_supported == true %}yes{% else %}no{% endif %} |
+| **User IDs** | {% if page.userIds and page.userIds != '' %}{{page.userIds}}{% else %}none{% endif %} | **GDPR TCF2 Support** | {% if page.tcf2_supported == true %}yes{% else %}no{% endif %} |
+| **SChain Support** | {% if page.schain_supported  == true %}yes{% else %}no{% endif %} | **COPPA Support** | {% if page.coppa_supported == true %}yes{% else %}no{% endif %} |
+| **Safeframes OK** | {% if page.safeframes_ok and page.safeframes_ok == false %}no{% elsif page.safeframes_ok and page.safeframes_ok == true %}yes{% else %}check with bidder{% endif %} | **USP/CCPA Support** | {% if page.usp_supported == true %}yes{% else %}no{% endif %} |
 
 
 <h3>"Send All Bids" Ad Server Keys</h3>

--- a/dev-docs/bidders/adform.md
+++ b/dev-docs/bidders/adform.md
@@ -6,6 +6,7 @@ hide: true
 biddercode: adform
 media_types: video
 gdpr_supported: true
+prebid_member: true
 ---
 
 

--- a/dev-docs/bidders/adformOpenRTB.md
+++ b/dev-docs/bidders/adformOpenRTB.md
@@ -4,8 +4,9 @@ title: AdformOpenRTB
 description: Prebid AdformOpenRTB Bidder Adaptor
 hide: true
 biddercode: adformOpenRTB
-media_types: native
+media_types: no-display, native
 gdpr_supported: true
+prebid_member: true
 ---
 
 ### Bid params

--- a/dev-docs/bidders/beachfront.md
+++ b/dev-docs/bidders/beachfront.md
@@ -8,6 +8,7 @@ media_types: video
 gdpr_supported: true
 usp_supported: true
 userIds: unifiedId
+prebid_member: true
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/connectad.md
+++ b/dev-docs/bidders/connectad.md
@@ -10,6 +10,7 @@ usp_supported: true
 coppa_supported: true
 schain_supported: true
 userIds: digitrust, id5Id, liveIntentId, parrableId, pubCommonId, unifiedId
+prebid_member: true
 ---
 
 

--- a/dev-docs/bidders/conversant.md
+++ b/dev-docs/bidders/conversant.md
@@ -7,6 +7,7 @@ biddercode: conversant
 media_types: video
 gdpr_supported: true
 userIds: criteo, digitrust, id5Id, identityLink, liveIntentId, parrableId, pubCommonId, unifiedId
+prebid_member: true
 ---
 
 

--- a/dev-docs/bidders/medianet.md
+++ b/dev-docs/bidders/medianet.md
@@ -8,6 +8,7 @@ gdpr_supported: true
 media_types: banner,native
 usp_supported: true
 userIds: britepoolId, criteo, digitrust, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
+prebid_member: true
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/rakuten.md
+++ b/dev-docs/bidders/rakuten.md
@@ -4,6 +4,7 @@ title: Rakuten
 description: Prebid Rakuten Bidder Adaptor
 hide: true
 biddercode: rakuten
+prebid_member: true
 ---
 
 

--- a/dev-docs/bidders/rubicon.md
+++ b/dev-docs/bidders/rubicon.md
@@ -12,6 +12,7 @@ schain_supported: true
 media_types: video
 userIds: digitrust, identityLink, liveIntentId, pubCommonId, unifiedId
 prebid_member: true
+safeframes_ok: true
 ---
 
 ### Note:

--- a/dev-docs/bidders/sovrn.md
+++ b/dev-docs/bidders/sovrn.md
@@ -7,6 +7,7 @@ biddercode: sovrn
 gdpr_supported: true
 usp_supported: true
 userIds: digitrust
+prebid_member: true
 ---
 
 


### PR DESCRIPTION
For https://github.com/prebid/prebid.github.io/issues/2014 - added 'safeframes_ok' field. Next step is to figure out how to surface this info on the AdOps pages.

For https://github.com/prebid/prebid.github.io/issues/1659 - added support for a "no-display" value for media_types

Also updated the prebid_member values for a number of adapters.