### PR TITLE
ATS-fix download link

### DIFF
--- a/download.md
+++ b/download.md
@@ -261,7 +261,7 @@ Prebid only supports the most recent major version. Within a month or so after a
 <div class="col-md-4">
   <div class="checkbox">
     <label>
-      <input type="checkbox" analyticscode="atsAnalytics" class="analytics-check-box"> ATS Analytics
+      <input type="checkbox" analyticscode="ats" class="analytics-check-box"> ATS Analytics
     </label>
   </div>
 </div>


### PR DESCRIPTION
ATS bug fix.

When try to check ATS Analytics and download:

- The downloaded file does not contain the built JavaScript, but rather {"error":"Prebid file not built properly","requestId":"2f7a1640-9762-433a-8af8-97749c3918e4"}. Look at the network request; the POST contains: modules[]: atsAnalyticsAnalyticsAdapter.

Name of the module is not correct, there is two 'Analytics' in name.

@bretg 