### PR TITLE
Update triplelift.md to show tcf2 support

### DIFF
--- a/dev-docs/bidders/triplelift.md
+++ b/dev-docs/bidders/triplelift.md
@@ -4,9 +4,11 @@ title: TripleLift
 description: Prebid TripleLift Bidder Adapter
 
 gdpr_supported: true
+tcf2_supported: true
 usp_supported: true
 schain_supported: true
 coppa_supported: true
+
 biddercode: triplelift
 userIds: criteo, identityLink, unifiedId
 ---


### PR DESCRIPTION
Triplelift now supports TCFv2 so we would like to add it to our bidder md file