### PR TITLE
module rules

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -76,7 +76,7 @@
   subgroup: 1
 
 - sbSecId: 0
-  title: '&nbsp;&nbsp;Header Bidding Wrapper'
+  title: '&nbsp;&nbsp;Header Bidding'
   link: /wrapper_code_of_conduct.html
   isHeader: 0
   isSectionHeader: 0
@@ -86,6 +86,13 @@
 - sbSecId: 0
   title: '&nbsp;&nbsp;Community'
   link: /overview/community-code-of-conduct.html
+  isHeader: 0
+  isSectionHeader: 0
+  subgroup: 0
+
+- sbSecId: 0
+  title: '&nbsp;&nbsp;Module Rules'
+  link: /dev-docs/module-rules.html
   isHeader: 0
   isSectionHeader: 0
   subgroup: 0

--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -38,6 +38,8 @@ In order to provide a fast and safe header bidding environment for publishers, t
 * **All user-sync activity must be registered via the provided functions**: The platform will place all registered syncs in the page after the auction is complete, subject to publisher configuration.
 * **Adapters may not create or trigger any network requests or pixels** outside of the requests that wrapper creates on behalf of the adapter from the return values of `buildRequests()` and `getUserSyncs()` or are included in a winning and rendered creative.
 * **Adapters may not modify ad slots directly**: e.g. Accessing `googletag.pubads().getSlots()` to modify or set targeting directly on slots is not permitted.
+* **All parameter conventions must be followed**:
+    * Video params must be read from AdUnit.mediaTypes.video when available; however bidder config can override the ad unit.
 
 {: .alert.alert-danger :}
 What's listed above is **not** the full list of requirements. Failure to follow any of the required conventions defined in the [Module Rules](/dev-docs/module-rules.html) could lead to delays in approving your adapter for inclusion in Prebid.js. If you'd like to apply for an exception to one of the rules, make your case in a new [Prebid.js issue](https://github.com/prebid/Prebid.js/issues).
@@ -276,19 +278,25 @@ Notes on parameters in the bidderRequest object:
 - **gdprConsent** is the object containing data from the [GDPR ConsentManagement](/dev-docs/modules/consentManagement.html) module
 - **uspConsent** is the object containing data from the [US Privacy ConsentManagement](/dev-docs/modules/consentManagementUsp.html) module
 
-#### Prebid Config
+<a name="std-param-location"></a>
 
-There are a number of important values that a publisher can set in the page that your bid adapter may need to take
-into account:
+#### Prebid Standard Parameter Locations
+
+There are a number of important values that a publisher expects to handled in a standard way across
+all Prebid.js adapters:
 
 {: .table .table-bordered .table-striped }
-| Value | Description                                   | Example               |
+| Parameter | Description                                   | Example               |
 | ----- | ------------ | ---------- |
 | Ad Server Currency | If your endpoint supports responding in different currencies, read this value. | config.getConfig('currency.adServerCurrency') |
-| Publisher Domain | The page may declare its domain, useful in cross-iframe scenarios. | config.getConfig('publisherDomain') |
 | Bidder Timeout | Use if your endpoint needs to know how long the page is allowing the auction to run. | config.getConfig('bidderTimeout'); |
 | COPPA | If your endpoint supports the Child Online Privacy Protection Act, you should read this value. | config.getConfig('coppa'); |
-| First Party Data | The publisher may provide first party data (e.g. page type). | config.getConfig('fpd'); |
+| First Party Data | The publisher may provide [first party data](/dev-docs/publisher-api-reference.html#setConfig-fpd) (e.g. page type). | config.getConfig('fpd'); |
+| Floors | Adapters that accept a floor parameter must also support the [floors module](https://docs.prebid.org/dev-docs/modules/floors.html) | [`getFloor()`](/dev-docs/modules/floors.html#bid-adapter-interface) |
+| Page Referrer | Intead of building your own function to find the page referrer, look in the standard bidRequest location. | bidderRequest.refererInfo.referer |
+| Publisher Domain | The page may declare its domain, useful in cross-iframe scenarios. | config.getConfig('publisherDomain') |
+| [Supply Chain](/dev-docs/modules/schain.html) | Adapters cannot accept an schain parameter. Rather, they must look for the schain parameter at bidRequest.schain. | bidRequest.schain |
+| Video Parameters | Video params must be read from AdUnit.mediaTypes.video when available; however bidder config can override the ad unit. | AdUnit.mediaType.video |
 
 #### Referrers
 

--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -32,17 +32,16 @@ This page has instructions for writing your own bidder adapter.  The instruction
 
 ### Required Adapter Rules
 
-In order to provide a fast and safe header bidding environment for publishers, the Prebid.org team reviews all adapters for the required conventions laid out for bid adapters in the [Module Rules](/dev-docs/module-rules.html). Here are additional Prebid.js-specific details:
+In order to provide a fast and safe header bidding environment for publishers, the Prebid.org team reviews all adapters for the required bid adapter conventions laid out in the [Module Rules](/dev-docs/module-rules.html). Here are additional details specific to Prebid.js:
 
 * **No loading of external code**: All code must be present in the adapter, not loaded at runtime. Exceptions are possible -- see [the full policy](https://github.com/prebid/prebid-js-external-js-template#policy).
 * **All user-sync activity must be registered via the provided functions**: The platform will place all registered syncs in the page after the auction is complete, subject to publisher configuration.
-* **Adapters may not create or trigger any network requests or pixels** outside of the requests that wrapper creates on behalf of the adapter from the return values of `buildRequests()` and `getUserSyncs()` or are included in a winning and rendered creative.
-* **Adapters may not modify ad slots directly**: e.g. Accessing `googletag.pubads().getSlots()` to modify or set targeting directly on slots is not permitted.
-* **All parameter conventions must be followed**:
-    * Video params must be read from AdUnit.mediaTypes.video when available; however bidder config can override the ad unit.
+* **Adapters may not create or trigger any network requests or pixels** outside of the requests the wrapper creates on behalf of the adapter (from the return values of `buildRequests()` and `getUserSyncs()`) or that are included in a winning and rendered creative.
+* **Adapters may not modify ad slots directly**: For example, accessing `googletag.pubads().getSlots()` to modify or set targeting directly on slots is not permitted.
+* **All parameter conventions must be followed**: Video params must be read from AdUnit.mediaTypes.video when available; however, bidder config can override the ad unit.
 
 {: .alert.alert-danger :}
-What's listed above is **not** the full list of requirements. Failure to follow any of the required conventions defined in the [Module Rules](/dev-docs/module-rules.html) could lead to delays in approving your adapter for inclusion in Prebid.js. If you'd like to apply for an exception to one of the rules, make your case in a new [Prebid.js issue](https://github.com/prebid/Prebid.js/issues).
+The above list is **not** the full list of requirements. Failure to follow any of the required conventions defined in the [Module Rules](/dev-docs/module-rules.html) could lead to delays in approving your adapter for inclusion in Prebid.js. If you'd like to apply for an exception to one of the rules, make your request in a new [Prebid.js issue](https://github.com/prebid/Prebid.js/issues).
 
 <a name="bidder-adaptor-Required-Files" />
 
@@ -282,8 +281,7 @@ Notes on parameters in the bidderRequest object:
 
 #### Prebid Standard Parameter Locations
 
-There are a number of important values that a publisher expects to handled in a standard way across
-all Prebid.js adapters:
+There are a number of important values that a publisher expects to be handled in a standard way across all Prebid.js adapters:
 
 {: .table .table-bordered .table-striped }
 | Parameter | Description                                   | Example               |
@@ -296,7 +294,7 @@ all Prebid.js adapters:
 | Page Referrer | Intead of building your own function to find the page referrer, look in the standard bidRequest location. | bidderRequest.refererInfo.referer |
 | Publisher Domain | The page may declare its domain, useful in cross-iframe scenarios. | config.getConfig('publisherDomain') |
 | [Supply Chain](/dev-docs/modules/schain.html) | Adapters cannot accept an schain parameter. Rather, they must look for the schain parameter at bidRequest.schain. | bidRequest.schain |
-| Video Parameters | Video params must be read from AdUnit.mediaTypes.video when available; however bidder config can override the ad unit. | AdUnit.mediaType.video |
+| Video Parameters | Video params must be read from AdUnit.mediaType.video when available; however bidder config can override the ad unit. | AdUnit.mediaType.video |
 
 #### Referrers
 
@@ -786,7 +784,7 @@ function createBid(status, reqBid, response) {
 ### Deals in Ad Pods
 
 To do deals for long-form video (`adpod` ad unit) just add the `dielTier` integer value to `bid.video.dealTier`. For more details on conducting deals in ad pods see our [ad pod module documentation](/dev-docs/modules/adpod.html).
- 
+
 ## Supporting Native
 
 In order for your bidder to support the native media type:
@@ -1053,5 +1051,5 @@ The Prebid.org [download page](/download.html) will automatically be updated wit
 
 ## Further Reading
 
-+ [The bidder adapter sources in the repo](https://github.com/prebid/Prebid.js/tree/master/modules)
++ [Prebid.js Repo - Bidder Adapter Sources](https://github.com/prebid/Prebid.js/tree/master/modules)
 + [Module Rules](/dev-docs/module-rules.html)

--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -1,7 +1,7 @@
 ---
 layout: page_v2
-title: How to Add a New Bidder Adapter
-description: Documentation on how to add a new bidder adapter
+title: How to Add a New Prebid.js Bidder Adapter
+description: Documentation on how to add a Prebid.js new bidder adapter
 top_nav_section: dev_docs
 nav_section: adapters
 sidebarType: 1
@@ -9,7 +9,7 @@ sidebarType: 1
 
 
 
-# How to Add a New Bidder Adapter
+# How to Add a New Prebid.js Bidder Adapter
 {:.no_toc}
 
 At a high level, a bidder adapter is responsible for:
@@ -24,35 +24,23 @@ This page has instructions for writing your own bidder adapter.  The instruction
 
 ## Planning your Adapter
 
-+ [Required Adapter Conventions](#bidder-adaptor-Required-Adapter-Conventions)
++ [Required Adapter Rules](#bidder-adaptor-Required-Adapter-Conventions)
 + [Required Files](#bidder-adaptor-Required-Files)
 + [Designing your Bid Params](#bidder-adaptor-Designing-your-Bid-Params)
 
 <a name="bidder-adaptor-Required-Adapter-Conventions" />
 
-### Required Adapter Conventions
+### Required Adapter Rules
 
-In order to provide a fast and safe header bidding environment for publishers, the Prebid.org team reviews all adapters for the following required conventions:
+In order to provide a fast and safe header bidding environment for publishers, the Prebid.org team reviews all adapters for the required conventions laid out for bid adapters in the [Module Rules](/dev-docs/module-rules.html). Here are additional Prebid.js-specific details:
 
-* *Support multiple instances*: All adapters must support the creation of multiple concurrent instances. This means, for example, that adapters cannot rely on mutable global variables.
-* *No loading of external libraries*: All code must be present in the adapter, not loaded at runtime. Exceptions are possible -- see [the full policy](https://github.com/prebid/prebid-js-external-js-template#policy).
-* *Must support HTTPS*: Within a secure page context, the request to the bidder's server must also be secure.
-* *Compressed responses*: All bid responses from the bidder's server must be gzipped.
-* *Bid responses may not use JSONP*: All requests must be AJAX with JSON responses.
-* *All user-sync activity must be registered via the provided functions*: The platform will place all registered syncs in the page after the auction is complete, subject to publisher configuration.
-* *Adapters may not create or trigger any network requests or pixels* outside of the requests that wrapper creates on behalf of the adapter from the return values of `buildRequests()` and `getUserSyncs()` or are included in a winning and rendered creative.
-* *Adapters may not use the `$$PREBID_GLOBAL$$` variable*: Instead, they must load any necessary functions and call them directly.
-* *Adapters may not modify ad slots directly*: e.g. Accessing `googletag.pubads().getSlots()` to modify or set targeting directly on slots is not permitted.
-* *Adapters may not override standard ad server targeting*: Do not override, or set default values for any of the standard targeting variables: hb_adid, hb_bidder, hb_pb, hb_deal, or hb_size, hb_source, hb_format.
+* **No loading of external code**: All code must be present in the adapter, not loaded at runtime. Exceptions are possible -- see [the full policy](https://github.com/prebid/prebid-js-external-js-template#policy).
+* **All user-sync activity must be registered via the provided functions**: The platform will place all registered syncs in the page after the auction is complete, subject to publisher configuration.
+* **Adapters may not create or trigger any network requests or pixels** outside of the requests that wrapper creates on behalf of the adapter from the return values of `buildRequests()` and `getUserSyncs()` or are included in a winning and rendered creative.
+* **Adapters may not modify ad slots directly**: e.g. Accessing `googletag.pubads().getSlots()` to modify or set targeting directly on slots is not permitted.
 
 {: .alert.alert-danger :}
-Failure to follow any of the above conventions could lead to delays in approving your adapter for inclusion in Prebid.js.
-
-{: .alert.alert-danger :}
-Pull requests for non-1.0 compatible adapters will not be reviewed or accepted on the legacy branch.
-
-{: .alert.alert-danger :}
-Prebid.org does not support any version of Prebid.js prior to version 1.0.
+What's listed above is **not** the full list of requirements. Failure to follow any of the required conventions defined in the [Module Rules](/dev-docs/module-rules.html) could lead to delays in approving your adapter for inclusion in Prebid.js. If you'd like to apply for an exception to one of the rules, make your case in a new [Prebid.js issue](https://github.com/prebid/Prebid.js/issues).
 
 <a name="bidder-adaptor-Required-Files" />
 
@@ -1058,3 +1046,4 @@ The Prebid.org [download page](/download.html) will automatically be updated wit
 ## Further Reading
 
 + [The bidder adapter sources in the repo](https://github.com/prebid/Prebid.js/tree/master/modules)
++ [Module Rules](/dev-docs/module-rules.html)

--- a/dev-docs/integrate-with-the-prebid-analytics-api.md
+++ b/dev-docs/integrate-with-the-prebid-analytics-api.md
@@ -1,7 +1,7 @@
 ---
 layout: page_v2
-title: How to Add an Analytics Adapter
-description: How to add an analytics adapter
+title: How to Add a Prebid.js Analytics Adapter
+description: How to add a Prebid.js analytics adapter
 pid: 28
 top_nav_section: dev_docs
 nav_section: adapters
@@ -11,7 +11,7 @@ sidebarType: 1
 
 
 
-# How to Add an Analytics Adapter
+# How to Add Prebid.js Analytics Adapter
 {:.no_toc}
 
 The Prebid Analytics API provides a way to get analytics data from `Prebid.js` and send it to the analytics provider of your choice, such as Google Analytics.  Because it's an open source API, you can write an adapter to send analytics data to any provider you like.  Integrating with the Prebid Analytics API has the following benefits:
@@ -44,6 +44,10 @@ Working with any Prebid project requires using Github. In general, we recommend 
 3. Build and test your feature/bug fix in the branch.
 4. Open a [pull request](https://help.github.com/en/desktop/contributing-to-projects/creating-a-pull-request) to the appropriate repository's master branch with a good description of the feature/bug fix.
 5. If there's something that needs to change on the prebid.org website, follow the above steps for the [website repo](https://github.com/prebid/prebid.github.io).
+
+{: .alert.alert-warning :}
+Analytics adapters are subject to a number of specific technical rules. Please become familiar
+with the [module rules](/dev-docs/module-rules.html) that apply globally and to analytics adapters in particular.
 
 ### Step 1: Add a markdown file describing the module
 
@@ -165,7 +169,5 @@ We sometimes get pretty busy, so it can take a couple of weeks for the review pr
 
 ## Further Reading
 
-- [Analytics for Prebid]({{site.baseurl}}/overview/analytics.html) (Overview and list of analytics providers)
-- [Integrate with the Prebid Analytics API]({{site.baseurl}}/dev-docs/integrate-with-the-prebid-analytics-api.html) (For developers)
-
-
+- [Analytics for Prebid](/overview/analytics.html) (Overview and list of analytics providers)
+- [Module Rules](/dev-docs/modules-rules.html)

--- a/dev-docs/integrate-with-the-prebid-analytics-api.md
+++ b/dev-docs/integrate-with-the-prebid-analytics-api.md
@@ -11,7 +11,7 @@ sidebarType: 1
 
 
 
-# How to Add Prebid.js Analytics Adapter
+# How to Add a Prebid.js Analytics Adapter
 {:.no_toc}
 
 The Prebid Analytics API provides a way to get analytics data from `Prebid.js` and send it to the analytics provider of your choice, such as Google Analytics.  Because it's an open source API, you can write an adapter to send analytics data to any provider you like.  Integrating with the Prebid Analytics API has the following benefits:
@@ -51,7 +51,7 @@ with the [module rules](/dev-docs/module-rules.html) that apply globally and to 
 
 ### Step 1: Add a markdown file describing the module
 
-1. Create a markdown file under `modules` with the name of the bidder suffixed with 'AnalyticsAdapter', e.g., `exAnalyticsAdapter.md`
+Create a markdown file under `modules` with the name of the bidder suffixed with 'AnalyticsAdapter', e.g., `exAnalyticsAdapter.md`
 
 Example markdown file:
 {% highlight text %}
@@ -152,7 +152,7 @@ Once everything looks good, submit the code, tests, and markdown as a pull reque
 
 ### Step 5: Website pull request
 
-There are two files that need to be updated to list your new analytics adapter. 
+There are two files that need to be updated to list your new analytics adapter.
 
 1. Create a fork of the [website repo](https://github.com/prebid/prebid.github.io) and a branch for your new adapter. (e.g. feature/exAnalyticsAdapter)
 
@@ -170,4 +170,4 @@ We sometimes get pretty busy, so it can take a couple of weeks for the review pr
 ## Further Reading
 
 - [Analytics for Prebid](/overview/analytics.html) (Overview and list of analytics providers)
-- [Module Rules](/dev-docs/modules-rules.html)
+- [Module Rules](/dev-docs/module-rules.html)

--- a/dev-docs/module-rules.md
+++ b/dev-docs/module-rules.md
@@ -1,0 +1,143 @@
+---
+layout: page_v2
+title: Module Rules
+description: Technical Module Rules for Prebid.js and Prebid Server
+sidebarType: 0
+---
+
+# Prebid.js and Prebid Server Module Rules
+{:.no_toc}
+
+* TOC
+{:toc}
+
+"Modules" are optional features that extend Prebid's functionality. There are
+several kinds of modules built by the community to enhance header bidding:
+
+{: .table .table-bordered .table-striped }
+| Module Type | Description | Scope |
+|-------------|-------------|-------|
+| Bid Adapter | Obtains Open Market or Private Market bids for the current ad request. | Prebid.js, Prebid Server |
+| Analytics Adapter | Listen to auction events and report to an analytics system. | Prebid.js, Prebid Server |
+| User ID Sub-Module | Obtain an ID for this user and make it available for other types of modules. | Prebid.js |
+| Real Time Data Sub-Module | Obtain data for the current user's context that may be of interest to advertisers. | Prebid.js |
+| Other | Modules that don't fall into one of the other categories | Prebid.js |
+
+Specific technical rules are needed to govern the development and review of modules in order to assure that they
+conform to Prebid's Core Values.
+
+## Prebid.org Core Values
+
+The main objective of Prebid.org is to make great header bidding technology available for web publishers and mobile app developers. We believe great technology is:
+
+- **Efficient** - Products offered by Prebid.org should not burden a user device, the network, or a company server.
+Secure - Prebid.org software should not open doors to security risks, including electronic attack, denial of service, fraud, or data leakage.
+- **Transparent** - Our products are built in the open with community review. Changes to Prebid software and modules must be open to inspection before and after release.
+- **Fair** - The Prebid.org platform doesn’t favor any one entity over another. No entity can be favored over another in technical ordering or status as a default value. No entity can gain information about another entity without approval.
+- **Collaborative** - Human interactions in Prebid.org forums and events must be courteous. 
+- **Privacy Sensitive** - Our products are built for publishers to support users’ privacy concerns and comply with industry standards.
+
+## Module Rules
+
+Bid adapters, user ID adapters, analytics adapters, and other modules will be reviewed for conformity to the core values of Prebid.org to be sure they are efficient, secure, transparent, and fair.
+
+Prebid.js and Prebid Server will follow the same rules.
+
+These rules don’t necessarily apply to tools or SDK. Those committees should review this list and build their own guidelines as required.
+
+The use of the terms ‘must’ and ‘should’ is deliberate.  However, some of the rules are ‘aspirational’, in that we know there are existing exceptions to the rule that will need to get sorted out over time. These are marked with ‘(*)’. The goal is:
+
+- Every new module adheres to all required rules
+- Even grandfathered modules must adhere to all required rules by Prebid.js 5.0
+
+### Global Module Rules
+
+1. Modules must(*) not load outside code files unless those libraries are approved and open source.
+    1. External modules may be used at build-time at the discretion of the relevant Prebid committee. Build-time modules must be locked to a particular version so that any upgrades must be done via Prebid pull request.
+    1. Exceptions may be made if:
+        - The publisher has control over whether the file is loaded and which version. The base module should be able to work without the auxiliary file.
+        - If run-time code is not needed for the auction, it should support a deferred load. E.g. User ID modules.
+        - The file loaded must be locked to a particular version so that any upgrades must be done via Prebid pull request.
+        - A prominent disclosure must be made about the loading of the file, why they need the file, and a size warning if it’s greater than 10KB.
+    1. If a functionality is supported by Prebid core or an existing module, Prebid modules must prefer the Prebid version of that functionality rather than an externally coded version.
+    1. The build-time or run-time loading of required or optional external files must be disclosed. (See the disclosure section below.)
+    1. Modules must not import other Prebid modules at build time.
+1. Modules must not(*)  add any pixel, iframe, cookie or local storage directly onto the page. Rather, they must use wrapper-provided mechanisms for usersyncs, cookies, and local storage.
+1. Modules must use the communication functions provided by the Prebid core (both Prebid.js and Prebid Server) for external communication.
+1. Prebid.js modules must not use the $$PREBID_GLOBAL$$ variable nor otherwise obtain a pointer to the global PBJS object. This preserves data integrity.
+1. All modules must support the creation of multiple concurrent instances. This means, for example, they cannot rely on mutable global variables.
+    1. Writing to the global window object must be non-intrusive, disclosed, and done in a way that supports multiple instances.
+1. All modules and any external code references must disclose their support of privacy regulations such as GDPR, CCPA, COPPA, etc. (See the disclosure section below.)
+1. Responses to auction or data requests should be compressed as long as the client supports that functionality. (e.g. gzip, compress, deflate)
+1. Prebid.js requests and responses must be secure HTTPS. Prebid Server requests should be HTTPS.
+1. Endpoints should use HTTP2 with keepalives so that connections don’t need to be re-created.
+1. In order to be listed on the Prebid.org website, a module must be in a Prebid open source repository.
+1. Each module must include maintainer information with a group email address for Prebid.org to contact for support or maintenance.
+1. Modules must not include polyfills or override standard or Prebid javascript functions.
+
+### Bidder Adapter Rules
+
+1. All global rules
+1. Bid adapters must(*) be able to bid. If they cannot return an auction bid, they should consider integration as a Real-Time Data or other module type.
+1. Creative rendering scripts must(*) load from the creative frame and not directly in the page. In other words, creative rendering javascript cannot be used to bypass the “no external code” rule.
+1. Bidder modules must not(*) make requests to endpoints for functionality other than auctions without:
+    1. Disclosure
+    1. Ability for the publisher to control the additional functionality.
+    1. If the publisher turns off the additional functionality, their auctions must still be operable. i.e. bid adapters may log certain analytics events, but if a publisher turns it off, the auction should still happen.
+    1. If a bidder would like to incorporate an external data fetch that would influence the auction, they must(*) build a Real-Time Data sub-module that obtains data in a way that can be utilized by other bidders as well.
+1. Bidder modules must not obtain bid information from or about any other party in the auction. E.g. They cannot listen to ad server events and forward information naming other bidders back to their endpoint - that is the job of an analytics module.
+1. Bidder modules must not(*) cache bids from previous auctions. That functionality is reserved for Prebid core.
+1. Bidders must(*) accept the following global parameters in preference to bidder-specific parameters: first party data, floors, schain, video params, page referrer, and COPPA. 
+1. Bidders must not override the standard ad server targeting values: hb_adid, hb_bidder, hb_pb, hb_deal, or hb_size, hb_source, hb_format.
+1. If bid adapters are reporting multiple media types in the hb_format as ‘banner’, they must(*) indicate the actual mediatype in the metadata object. One use case for this is that it allows publishers to manage which creatives support safeframes.
+1. Bidder modules should supply buyer metadata - including advertiser, advertiser domain, network, actual mediatype, and others defined in the Prebid documentation.
+1. Creatives returned must be fully HTTPS.
+
+### Analytics Adapter Rules
+
+1. All global rules
+1. Analytics adapters must not bid or supply any parameters to the auction.
+1. Analytics adapters must be neutral to the bid adapters -- not favoring any particular bidder in any way.
+1. Analytics adapters should minimize the number of times they call their endpoints by batching auction and event data.
+
+### User ID Sub-Module Rules
+
+1. All global rules
+1. ID sub-modules must not gather any information from the page except for publisher-approved ID data for this user.
+1. ID sub-modules must not report analytics information back to their endpoints, including use of other user IDs, auction information, bidders, bids won, etc. This is the job of an analytics module.
+1. ID sub-modules must be neutral to the bid adapters -- each bidder must have the same opportunity to utilize each user ID.
+
+### Real Time Data Module Rules
+
+1. All global rules
+1. RTD modules must not bid. That functionality is reserved for bid adapters.
+1. RTD modules must not supply privacy-sensitive user information (including IDs) into the auction. That functionality is reserved for User ID modules.
+1. RTD modules should make data available in a cross-bidder way when possible. For example, passing data through existing mechanisms like First Party Data.
+1. RTD modules may cache bid metadata for analytics and optimization purposes. They may use those bids to optimize future auctions for which bidders and adunits take place. They must not re-use specific past bids in an auction -- that functionality is restricted to Prebid core.
+
+### Other modules
+
+1. Any other type of module will be evaluated on a case-by-case basis. E.g. Currency, Video ad serving, Consent management, etc. They must all follow the ‘global rules’.
+
+## Disclosure
+
+There are already exceptions to these rules, and we recognize there will likely be more. Any module doing something that needs to be disclosed will receive a label on their prebid.org documentation like:
+
+- Disclosure: this bidder adapter loads external javascript to render creatives.
+- Disclosure: this bidder records win and loss events with a pixel call.
+- Disclosure: this bidder listens directly to Google Ad Manager events.
+- Disclosure: this bidder reports timeout events.
+
+Ideally, the disclosures should be of a limited number of standard types so they can be managed.
+
+To manage this, we will:
+
+1. Document a distinct set of disclosures with guidance for reviewers on how to determine which disclosures are needed. 
+1. Create a process for generating new types of disclosures and which modules received a given disclosure/exception on which date.
+1. Make sure that disclosures are applied to all existing and new adapter aliases.
+
+
+# Further Reading
+
+- Adding a bid adapter: [Prebid.js](/dev-docs/bidder-adaptor.html), [Prebid Server](/prebid-server/developers/add-new-bidder-go.html)
+- Adding an analytics adapter: [Prebid.js](/dev-docs/integrate-with-the-prebid-analytics-api.html), [Prebid Server](/prebid-server/developers/pbs-build-an-analytics-adapter.html)

--- a/dev-docs/module-rules.md
+++ b/dev-docs/module-rules.md
@@ -18,47 +18,44 @@ several kinds of modules built by the community to enhance header bidding:
 | Module Type | Description | Scope |
 |-------------|-------------|-------|
 | Bid Adapter | Obtains Open Market or Private Market bids for the current ad request. | Prebid.js, Prebid Server |
-| Analytics Adapter | Listen to auction events and report to an analytics system. | Prebid.js, Prebid Server |
-| User ID Sub-Module | Obtain an ID for this user and make it available for other types of modules. | Prebid.js |
-| Real Time Data Sub-Module | Obtain data for the current user's context that may be of interest to advertisers. | Prebid.js |
-| Other | Modules that don't fall into one of the other categories | Prebid.js |
-
-Specific technical rules are needed to govern the development and review of modules in order to assure that they
-conform to Prebid's Core Values.
+| Analytics Adapter | Listens to auction events and reports to an analytics system. | Prebid.js, Prebid Server |
+| User ID Sub-Module | Obtains an ID for this user and makes that ID available to other types of modules. | Prebid.js |
+| Real Time Data Sub-Module | Obtains data for the current user's context that may be of interest to advertisers. | Prebid.js |
+| Other | Modules that don't fall into one of the other categories. | Prebid.js |
 
 ## Prebid.org Core Values
 
-The main objective of Prebid.org is to make great header bidding technology available for web publishers and mobile app developers. We believe great technology is:
+Specific technical rules are needed to govern the development and review of modules in order to assure that they conform to Prebid's Core Values. The main objective of Prebid.org is to make great header bidding technology available for web publishers and mobile app developers. We believe great technology is:
 
 - **Efficient** - Products offered by Prebid.org should not burden a user device, the network, or a company server.
-Secure - Prebid.org software should not open doors to security risks, including electronic attack, denial of service, fraud, or data leakage.
+- **Secure** - Prebid.org software should not open doors to security risks, including electronic attack, denial of service, fraud, or data leakage.
 - **Transparent** - Our products are built in the open with community review. Changes to Prebid software and modules must be open to inspection before and after release.
 - **Fair** - The Prebid.org platform doesn’t favor any one entity over another. No entity can be favored over another in technical ordering or status as a default value. No entity can gain information about another entity without approval.
-- **Collaborative** - Human interactions in Prebid.org forums and events must be courteous. 
+- **Collaborative** - Human interactions in Prebid.org forums and events must be courteous.
 - **Privacy Sensitive** - Our products are built for publishers to support users’ privacy concerns and comply with industry standards.
 
 ## Module Rules
 
-Bid adapters, user ID adapters, analytics adapters, and other modules will be reviewed for conformity to the core values of Prebid.org to be sure they are efficient, secure, transparent, and fair.
+Bid adapters, user ID adapters, analytics adapters, and other modules will be reviewed for conformity to the Core Values of Prebid.org.
 
-Prebid.js and Prebid Server will follow the same rules.
+This set of module rules applies to both Prebid.js and Prebid Server.
 
-These rules don’t necessarily apply to tools or SDK. Those committees should review this list and build their own guidelines as required.
+These rules don’t necessarily apply to tools or the Prebid Mobile SDK. Rules and guidelines for those products will be determined by their respective committees as required.
 
-The use of the terms ‘must’ and ‘should’ is deliberate.  However, some of the rules are ‘aspirational’, in that we know there are existing exceptions to the rule that will need to get sorted out over time. These are marked with ‘(*)’. The goal is:
+The use of the terms "must" and "should" in this document is deliberate.  However, some of the rules are "aspirational," in that we know there are existing exceptions to the rule that will need to get sorted out over time. These are marked with an asterisk (*). The goal is:
 
-- Every new module adheres to all required rules
-- Even grandfathered modules must adhere to all required rules by Prebid.js 5.0
+- Every new module adheres to all required rules.
+- Even grandfathered modules must adhere to all required rules by Prebid.js 5.0.
 
 ### Global Module Rules
 
 1. Modules must(*) not load outside code files unless those libraries are approved and open source.
     1. External modules may be used at build-time at the discretion of the relevant Prebid committee. Build-time modules must be locked to a particular version so that any upgrades must be done via Prebid pull request.
-    1. Exceptions may be made if:
-        - The publisher has control over whether the file is loaded and which version. The base module should be able to work without the auxiliary file.
+    1. Exceptions may be made in the following cases:
+        - When the publisher has control over whether the file is loaded and which version, the base module should be able to work without the auxiliary file.
         - If run-time code is not needed for the auction, it should support a deferred load. E.g. User ID modules.
         - The file loaded must be locked to a particular version so that any upgrades must be done via Prebid pull request.
-        - A prominent disclosure must be made about the loading of the file, why they need the file, and a size warning if it’s greater than 10KB.
+        - A prominent disclosure must be made about the loading of the file and why they need the file, and a size warning provided if it’s greater than 10KB.
     1. If a functionality is supported by Prebid core or an existing module, Prebid modules must prefer the Prebid version of that functionality rather than an externally coded version.
     1. The build-time or run-time loading of required or optional external files must be disclosed. (See the disclosure section below.)
     1. Modules must not import other Prebid modules at build time.
@@ -66,28 +63,28 @@ The use of the terms ‘must’ and ‘should’ is deliberate.  However, some o
 1. Modules must use the communication functions provided by the Prebid core (both Prebid.js and Prebid Server) for external communication.
 1. Prebid.js modules must not use the $$PREBID_GLOBAL$$ variable nor otherwise obtain a pointer to the global PBJS object. This preserves data integrity.
 1. All modules must support the creation of multiple concurrent instances. This means, for example, they cannot rely on mutable global variables.
-    1. Writing to the global window object must be non-intrusive, disclosed, and done in a way that supports multiple instances.
+    - Writing to the global window object must be non-intrusive, disclosed, and done in a way that supports multiple instances.
 1. All modules and any external code references must disclose their support of privacy regulations such as GDPR, CCPA, COPPA, etc. (See the disclosure section below.)
-1. Responses to auction or data requests should be compressed as long as the client supports that functionality. (e.g. gzip, compress, deflate)
+1. Responses to auction or data requests should be compressed as long as the client supports that functionality (e.g. gzip, compress, deflate).
 1. Prebid.js requests and responses must be secure HTTPS. Prebid Server requests should be HTTPS.
-1. Endpoints should use HTTP2 with keepalives so that connections don’t need to be re-created.
+1. Endpoints should use HTTP/2 with keepalives so that connections don’t need to be re-created.
 1. In order to be listed on the Prebid.org website, a module must be in a Prebid open source repository.
 1. Each module must include maintainer information with a group email address for Prebid.org to contact for support or maintenance.
-1. Modules must not include polyfills or override standard or Prebid javascript functions.
+1. Modules must not include polyfills or override standard or Prebid JavaScript functions.
 
 ### Bidder Adapter Rules
 
-1. All global rules
+1. All global rules apply.
 1. Bid adapters must(*) be able to bid. If they cannot return an auction bid, they should consider integration as a Real-Time Data or other module type.
-1. Creative rendering scripts must(*) load from the creative frame and not directly in the page. In other words, creative rendering javascript cannot be used to bypass the “no external code” rule.
+1. Creative rendering scripts must(*) load from the creative frame and not directly in the page. In other words, creative rendering JavaScript cannot be used to bypass the “no external code” rule.
 1. Bidder modules must not(*) make requests to endpoints for functionality other than auctions without:
     1. Disclosure
     1. Ability for the publisher to control the additional functionality.
-    1. If the publisher turns off the additional functionality, their auctions must still be operable. i.e. bid adapters may log certain analytics events, but if a publisher turns it off, the auction should still happen.
-    1. If a bidder would like to incorporate an external data fetch that would influence the auction, they must(*) build a Real-Time Data sub-module that obtains data in a way that can be utilized by other bidders as well.
-1. Bidder modules must not obtain bid information from or about any other party in the auction. E.g. They cannot listen to ad server events and forward information naming other bidders back to their endpoint - that is the job of an analytics module.
+    1. Ensuring auctions are still operable if the publisher turns off the additional functionality; i.e., bid adapters may log certain analytics events, but if a publisher turns it off, the auction should still happen.
+    1. Building a Real-Time Data sub-module that obtains data in a way that can be utilized by other bidders as well if a bidder would like to incorporate an external data fetch that would influence the auction.
+1. Bidder modules must not obtain bid information from or about any other party in the auction. E.g., they cannot listen to ad server events and forward information naming other bidders back to their endpoint - that is the job of an analytics module.
 1. Bidder modules must not(*) cache bids from previous auctions. That functionality is reserved for Prebid core.
-1. Bidders must(*) accept parameters in the conventional location in preference to bidder-specific parameters. The list of these parameters is in [the bidder adapter documentation](/dev-docs/bidder-adaptor.html#std-param-location).
+1. Bidders must(*) accept parameters in the conventional location in preference to bidder-specific parameters. The list of these parameters is in the [bidder adapter documentation](/dev-docs/bidder-adaptor.html#std-param-location).
 1. Bidders must not override the standard ad server targeting values: hb_adid, hb_bidder, hb_pb, hb_deal, or hb_size, hb_source, hb_format.
 1. If bid adapters are reporting multiple media types in the hb_format as ‘banner’, they must(*) indicate the actual mediatype in the metadata object. One use case for this is that it allows publishers to manage which creatives support safeframes.
 1. Bidder modules should supply buyer metadata - including advertiser, advertiser domain, network, actual mediatype, and others defined in the Prebid documentation.
@@ -95,44 +92,44 @@ The use of the terms ‘must’ and ‘should’ is deliberate.  However, some o
 
 ### Analytics Adapter Rules
 
-1. All global rules
+1. All global rules apply.
 1. Analytics adapters must not bid or supply any parameters to the auction.
 1. Analytics adapters must be neutral to the bid adapters -- not favoring any particular bidder in any way.
 1. Analytics adapters should minimize the number of times they call their endpoints by batching auction and event data.
 
 ### User ID Sub-Module Rules
 
-1. All global rules
+1. All global rules apply.
 1. ID sub-modules must not gather any information from the page except for publisher-approved ID data for this user.
 1. ID sub-modules must not report analytics information back to their endpoints, including use of other user IDs, auction information, bidders, bids won, etc. This is the job of an analytics module.
 1. ID sub-modules must be neutral to the bid adapters -- each bidder must have the same opportunity to utilize each user ID.
 
 ### Real Time Data Module Rules
 
-1. All global rules
-1. RTD modules must not bid. That functionality is reserved for bid adapters.
+1. All global rules apply.
+1. Real Time Data (RTD) modules must not bid. That functionality is reserved for bid adapters.
 1. RTD modules must not supply privacy-sensitive user information (including IDs) into the auction. That functionality is reserved for User ID modules.
 1. RTD modules should make data available in a cross-bidder way when possible. For example, passing data through existing mechanisms like First Party Data.
 1. RTD modules may cache bid metadata for analytics and optimization purposes. They may use those bids to optimize future auctions for which bidders and adunits take place. They must not re-use specific past bids in an auction -- that functionality is restricted to Prebid core.
 
 ### Other modules
 
-1. Any other type of module will be evaluated on a case-by-case basis. E.g. Currency, Video ad serving, Consent management, etc. They must all follow the ‘global rules’.
+Any other type of module will be evaluated on a case-by-case basis. Examples of other modules include Currency, Video ad serving, Consent management, etc. These modules must all follow the global rules.
 
 ## Disclosure
 
 There are already exceptions to these rules, and we recognize there will likely be more. Any module doing something that needs to be disclosed will receive a label on their prebid.org documentation like:
 
-- Disclosure: this bidder adapter loads external javascript to render creatives.
+- Disclosure: this bidder adapter loads external JavaScript to render creatives.
 - Disclosure: this bidder records win and loss events with a pixel call.
 - Disclosure: this bidder listens directly to Google Ad Manager events.
 - Disclosure: this bidder reports timeout events.
 
 Ideally, the disclosures should be of a limited number of standard types so they can be managed.
 
-To manage this, we will:
+To manage this, we plan to:
 
-1. Document a distinct set of disclosures with guidance for reviewers on how to determine which disclosures are needed. 
+1. Document a distinct set of disclosures with guidance for reviewers on how to determine which disclosures are needed.
 1. Create a process for generating new types of disclosures and which modules received a given disclosure/exception on which date.
 1. Make sure that disclosures are applied to all existing and new adapter aliases.
 

--- a/dev-docs/module-rules.md
+++ b/dev-docs/module-rules.md
@@ -87,7 +87,7 @@ The use of the terms ‘must’ and ‘should’ is deliberate.  However, some o
     1. If a bidder would like to incorporate an external data fetch that would influence the auction, they must(*) build a Real-Time Data sub-module that obtains data in a way that can be utilized by other bidders as well.
 1. Bidder modules must not obtain bid information from or about any other party in the auction. E.g. They cannot listen to ad server events and forward information naming other bidders back to their endpoint - that is the job of an analytics module.
 1. Bidder modules must not(*) cache bids from previous auctions. That functionality is reserved for Prebid core.
-1. Bidders must(*) accept the following global parameters in preference to bidder-specific parameters: first party data, floors, schain, video params, page referrer, and COPPA. 
+1. Bidders must(*) accept parameters in the conventional location in preference to bidder-specific parameters. The list of these parameters is in [the bidder adapter documentation](/dev-docs/bidder-adaptor.html#std-param-location).
 1. Bidders must not override the standard ad server targeting values: hb_adid, hb_bidder, hb_pb, hb_deal, or hb_size, hb_source, hb_format.
 1. If bid adapters are reporting multiple media types in the hb_format as ‘banner’, they must(*) indicate the actual mediatype in the metadata object. One use case for this is that it allows publishers to manage which creatives support safeframes.
 1. Bidder modules should supply buyer metadata - including advertiser, advertiser domain, network, actual mediatype, and others defined in the Prebid documentation.

--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -51,6 +51,7 @@ This page has documentation for the public API methods of Prebid.js.
     * [enableSendAllBids](#setConfig-Send-All-Bids)
     * [sendBidsControl](#setConfig-Send-Bids-Control)
     * [useBidCache](#setConfig-Use-Bid-Cache)
+    * [pageUrl](#setConfig-Page-URL)
     * [publisherDomain](#setConfig-Publisher-Domain)
     * [priceGranularity](#setConfig-Price-Granularity)
     * [mediaTypePriceGranularity](#setConfig-MediaType-Price-Granularity)
@@ -1312,6 +1313,7 @@ Core config:
 + [Configure send bids control](#setConfig-Send-Bids-Control)
 + [Bid cache](#setConfig-Use-Bid-Cache)
 + [Set the order in which bidders are called](#setConfig-Bidder-Order)
++ [Set the page URL](#setConfig-Page-URL)
 + [Set the publisher's domain](#setConfig-Publisher-Domain)
 + [Set a delay before requesting cookie sync](#setConfig-Cookie-Sync-Delay)
 + [Set price granularity](#setConfig-Price-Granularity)
@@ -1542,6 +1544,16 @@ Set the order in which bidders are called:
 
 {% highlight js %}
 pbjs.setConfig({ bidderSequence: "fixed" })   /* default is "random" */
+{% endhighlight %}
+
+<a name="setConfig-Page-URL" />
+
+#### Page URL
+
+Override Prebid.js' page referer algorithm.
+
+a{% highlight js %}
+pbjs.setConfig({ pageUrl: "https://example.com/index.html" )
 {% endhighlight %}
 
 <a name="setConfig-Publisher-Domain" />

--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -1550,7 +1550,7 @@ pbjs.setConfig({ bidderSequence: "fixed" })   /* default is "random" */
 
 #### Page URL
 
-Override Prebid.js' page referer algorithm.
+Override the Prebid.js page referrer algorithm.
 
 a{% highlight js %}
 pbjs.setConfig({ pageUrl: "https://example.com/index.html" )

--- a/prebid-server/developers/add-new-bidder-go.md
+++ b/prebid-server/developers/add-new-bidder-go.md
@@ -46,6 +46,9 @@ Bidder implementations are scattered throughout several files.
 
 Bidder implementations may assume that any params have already been validated against the defined json-schema.
 
+{: .alert.alert-warning :}
+Prebid Server bid adapters must follow all required conventions defined in the [Module Rules](/dev-docs/module-rules.html). Not doing so could lead to delays in approving your adapter for inclusion in Prebid Server. If you'd like to apply for an exception to one of the rules, make your case in a new [Prebid Server issue](https://github.com/prebid/prebid-server/issues).
+
 ### Bid Response Metadata
 
 In addition to the standard OpenRTB2.5 response fields, Prebid encourages bidders to

--- a/prebid-server/developers/add-new-bidder-go.md
+++ b/prebid-server/developers/add-new-bidder-go.md
@@ -47,7 +47,7 @@ Bidder implementations are scattered throughout several files.
 Bidder implementations may assume that any params have already been validated against the defined json-schema.
 
 {: .alert.alert-warning :}
-Prebid Server bid adapters must follow all required conventions defined in the [Module Rules](/dev-docs/module-rules.html). Not doing so could lead to delays in approving your adapter for inclusion in Prebid Server. If you'd like to apply for an exception to one of the rules, make your case in a new [Prebid Server issue](https://github.com/prebid/prebid-server/issues).
+Prebid Server bid adapters must follow all required conventions defined in the [Module Rules](/dev-docs/module-rules.html). Not doing so could lead to delays in approving your adapter for inclusion in Prebid Server. If you'd like to apply for an exception to one of the rules, make your request in a new [Prebid Server issue](https://github.com/prebid/prebid-server/issues).
 
 ### Bid Response Metadata
 

--- a/prebid-server/developers/add-new-bidder-java.md
+++ b/prebid-server/developers/add-new-bidder-java.md
@@ -45,7 +45,7 @@ Bidder implementations are scattered throughout several files:
 Bidder implementations may assume that any params have already been validated against the defined json-schema.
 
 {: .alert.alert-warning :}
-Prebid Server bid adapters must follow all required conventions defined in the [Module Rules](/dev-docs/module-rules.html). Not doing so could lead to delays in approving your adapter for inclusion in Prebid Server. If you'd like to apply for an exception to one of the rules, make your case in a new [Prebid Server issue](https://github.com/prebid/prebid-server/issues).
+Prebid Server bid adapters must follow all required conventions defined in the [Module Rules](/dev-docs/module-rules.html). Not doing so could lead to delays in approving your adapter for inclusion in Prebid Server. If you'd like to apply for an exception to one of the rules, make your request in a new [Prebid Server issue](https://github.com/prebid/prebid-server/issues).
 
 ### Generic OpenRTB Bidder
 

--- a/prebid-server/developers/add-new-bidder-java.md
+++ b/prebid-server/developers/add-new-bidder-java.md
@@ -44,6 +44,9 @@ Bidder implementations are scattered throughout several files:
 
 Bidder implementations may assume that any params have already been validated against the defined json-schema.
 
+{: .alert.alert-warning :}
+Prebid Server bid adapters must follow all required conventions defined in the [Module Rules](/dev-docs/module-rules.html). Not doing so could lead to delays in approving your adapter for inclusion in Prebid Server. If you'd like to apply for an exception to one of the rules, make your case in a new [Prebid Server issue](https://github.com/prebid/prebid-server/issues).
+
 ### Generic OpenRTB Bidder
 
 There's an option to implement a bidder by using a pre-existing template.

--- a/prebid-server/developers/pbs-build-an-analytics-adapter.md
+++ b/prebid-server/developers/pbs-build-an-analytics-adapter.md
@@ -12,7 +12,11 @@ There aren't any open sourced analytics adapters for Prebid Server,
 but there is an internal interface that host companies can use to
 integrate their own modules.
 
-Here's an outline of how it's done for both versions of the server.
+Below is an outline of how it's done for both versions of the server.
+
+{: .alert.alert-warning :}
+Analytics adapters are subject to a number of specific technical rules. Please become familiar
+with the [module rules](/dev-docs/module-rules.html) that apply globally and to analytics adapters in particular.
 
 * TOC
 {:toc }
@@ -30,7 +34,9 @@ Your new module belongs in the analytics/{moduleName} package. It should impleme
 3. Connect your Config to the Implementation
 The `NewPBSAnalytics()` function inside analytics/config/config.go instantiates Analytics modules using the app config. You'll need to update this to recognize your new module.
 
-Example
+### Example
+{:.no_toc}
+
 A simple [filesystem](https://github.com/prebid/prebid-server/tree/master/analytics/filesystem) analytics module is provided as an example. This module will log dummy messages to a file.
 
 It can be configured with:
@@ -53,7 +59,9 @@ Your new module org.prebid.server.analytics.{module}AnalyticsReporter needs to i
 3. Add your implementation to Spring Context
 In order to make Prebid Server aware of the new analytics module it needs to be added to the Spring Context in org.prebid.server.spring.config.AnalyticsConfiguration as a bean.
 
-Example
+### Example
+{:.no_toc}
+
 The [log module](https://github.com/rubicon-project/prebid-server-java/blob/master/src/main/java/org/prebid/server/analytics/LogAnalyticsReporter.java) is provided as an example. This module will write dummy messages to a log.
 
 It can be configured with:


### PR DESCRIPTION
We're finally ready to publish the module rules to the website. Original doc was https://docs.google.com/document/d/1kK0ifXV-vzyV7VchPKoyGuz375H7fzbTJFt_oWeCiRo/edit# -- this PR converts the GDoc to Markdown and peppers links to it around various pages.