### PR TITLE
Add supported modules table for GDPR Enforcement module.

### DIFF
--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -1002,6 +1002,7 @@ registerBidder(spec);
     - Add `pbjs: true`. If you also have a [Prebid Server bid adapter](/prebid-server/developers/add-new-bidder-go.html), add `pbs: true`. Default is false for both.
     - If you support the GDPR consentManagement module and TCF1, add `gdpr_supported: true`. Default is false.
     - If you support the GDPR consentManagement module and TCF2, add `tcf2_supported: true`. Default is false.
+    - If you have an IAB Global Vendor List ID, add `gvl_id: ID`. There's no default.
     - If you support the US Privacy consentManagementUsp module, add `usp_supported: true`. Default is false.
     - If you support one or more userId modules, add `userId: (list of supported vendors)`. No default value.
     - If you support video and/or native mediaTypes add `media_types: video, native`. Note that display is added by default. If you don't support display, add "no-display" as the first entry, e.g. `media_types: no-display, native`. No default value.
@@ -1031,6 +1032,7 @@ bidder_supports_deals: true/false
 pbjs: true/false
 pbs: true/false
 prebid_member: true/false
+gvl_id: none
 ---
 ### Note:
 

--- a/dev-docs/bidders.md
+++ b/dev-docs/bidders.md
@@ -50,7 +50,7 @@ You can also download the full <a href="/dev-docs/bidder-data.csv" download>CSV 
 | **SChain Support** | {% if page.schain_supported  == true %}yes{% else %}no{% endif %} | **COPPA Support** | {% if page.coppa_supported == true %}yes{% else %}no{% endif %} |
 | **Safeframes OK** | {% if page.safeframes_ok == false %}no{% elsif page.safeframes_ok == true %}yes{% else %}check with bidder{% endif %} | **USP/CCPA Support** | {% if page.usp_supported == true %}yes{% else %}no{% endif %} |
 | **Supports Deals** | {% if page.bidder_supports_deals == false %}no{% elsif page.bidder_supports_deals == true %}yes{% else %}check with bidder{% endif %} | **Prebid.js Adapter** | yes |
-| | | **Prebid Server Adapter** | {% if page.pbs == true %}yes{% else %}no{% endif %} |
+| **IAB GVL ID** | {% if page.gvl_id %}{{page.gvl_id}}{% else %}check with bidder{% endif %} | **Prebid Server Adapter** | {% if page.pbs == true %}yes{% else %}no{% endif %} |
 
 <h3>"Send All Bids" Ad Server Keys</h3>
 

--- a/dev-docs/bidders/aardvark.md
+++ b/dev-docs/bidders/aardvark.md
@@ -9,6 +9,7 @@ tcf2_supported: true
 usp_supported: true
 schain_supported: true
 userIds: unifiedId
+gvl_id: 52
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/adagio.md
+++ b/dev-docs/bidders/adagio.md
@@ -8,6 +8,7 @@ media_types: banner
 gdpr_supported: true
 schain_supported: true
 tcf2_supported: true
+gvl_id: 617
 ---
 
 ### Note

--- a/dev-docs/bidders/adform.md
+++ b/dev-docs/bidders/adform.md
@@ -11,6 +11,7 @@ prebid_member: true
 pbjs: true
 pbs: true
 userIds: britepoolId, criteo, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, sharedId, unifiedId
+gvl_id: 50
 ---
 
 

--- a/dev-docs/bidders/adformOpenRTB.md
+++ b/dev-docs/bidders/adformOpenRTB.md
@@ -10,6 +10,7 @@ tcf2_supported: true
 prebid_member: true
 pbjs: true
 userIds: britepoolId, criteo, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, sharedId, unifiedId
+gvl_id: 50
 ---
 
 ### Bid params

--- a/dev-docs/bidders/adhese.md
+++ b/dev-docs/bidders/adhese.md
@@ -9,6 +9,7 @@ media_types: banner, video
 gdpr_supported: true
 tcf2_supported: true
 userIds: id5Id
+gvl_id: 553
 ---
 
 ### Note

--- a/dev-docs/bidders/adtelligent.md
+++ b/dev-docs/bidders/adtelligent.md
@@ -14,6 +14,7 @@ safeframes_ok: true
 prebid_member: true
 pbjs: true
 pbs: true
+gvl_id: 410
 ---
 
 ### Bid params

--- a/dev-docs/bidders/aol.md
+++ b/dev-docs/bidders/aol.md
@@ -6,6 +6,7 @@ pbjs: true
 biddercode: aol
 gdpr_supported: true
 usp_supported: true
+gvl_id: 25
 ---
 
 ### Note:

--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -13,6 +13,7 @@ usp_supported: true
 tcf2_supported: true
 pbjs: true
 pbs: true
+gvl_id: 32
 ---
 
 ### Table of Contents

--- a/dev-docs/bidders/apstream.md
+++ b/dev-docs/bidders/apstream.md
@@ -7,6 +7,7 @@ pbjs: true
 media_types: banner
 gdpr_supported: true
 tcf2_supported: true
+gvl_id: 394
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/beintoo.md
+++ b/dev-docs/bidders/beintoo.md
@@ -6,6 +6,7 @@ pbjs: true
 pbs: true
 biddercode: beintoo
 aliasCode : appnexus
+gvl_id: 618
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/conversant.md
+++ b/dev-docs/bidders/conversant.md
@@ -10,6 +10,7 @@ gdpr_supported: true
 userIds: criteo, id5Id, identityLink, liveIntentId, parrableId, pubCommonId, unifiedId
 prebid_member: true
 tcf2_supported: true
+gvl_id: 24
 ---
 
 

--- a/dev-docs/bidders/criteo.md
+++ b/dev-docs/bidders/criteo.md
@@ -9,6 +9,7 @@ gdpr_supported: true
 usp_supported: true
 prebid_member: true
 tcf2_supported: true
+gvl_id: 91
 ---
 ### Note
 {: .alert.alert-warning :}

--- a/dev-docs/bidders/districtm.md
+++ b/dev-docs/bidders/districtm.md
@@ -9,7 +9,7 @@ biddercode: districtm
 aliasCode : appnexus
 sidebarType: 1
 isBidder: true
-
+gvl_id: 144
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/emx_digital.md
+++ b/dev-docs/bidders/emx_digital.md
@@ -8,6 +8,7 @@ biddercode: emx_digital
 bidder_supports_deals: false
 media_types: banner, video
 gdpr_supported: true
+gvl_id: 183
 ---
 
 ### Registration

--- a/dev-docs/bidders/fidelity.md
+++ b/dev-docs/bidders/fidelity.md
@@ -8,6 +8,7 @@ biddercode: fidelity
 media_types: banner
 gdpr_supported: true
 usp_supported: true
+gvl_id: 408
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/improvedigital.md
+++ b/dev-docs/bidders/improvedigital.md
@@ -10,6 +10,7 @@ usp_supported: true
 media_types: banner, native, video
 schain_supported: true
 tcf2_supported: true
+gvl_id: 253
 ---
 
 ### Bid params

--- a/dev-docs/bidders/indexExchange.md
+++ b/dev-docs/bidders/indexExchange.md
@@ -10,6 +10,7 @@ gdpr_supported: true
 usp_supported: true
 tcf2_supported: true
 media_types: banner, video
+gvl_id: 10
 ---
 
 ## Overview

--- a/dev-docs/bidders/medianet.md
+++ b/dev-docs/bidders/medianet.md
@@ -10,6 +10,7 @@ userIds: britepoolId, criteo, id5Id, identityLink, liveIntentId, netId, parrable
 prebid_member: true
 tcf2_supported: true
 pbjs: true
+gvl_id: 142
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/openx.md
+++ b/dev-docs/bidders/openx.md
@@ -13,6 +13,7 @@ coppa_supported: true
 userIds: britepoolId, criteo, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
 prebid_member: true
 tcf2_supported: true
+gvl_id: 69
 ---
 
 ### Registration

--- a/dev-docs/bidders/openxoutstream.md
+++ b/dev-docs/bidders/openxoutstream.md
@@ -7,6 +7,7 @@ biddercode: openxoutstream
 media_types: native
 prebid_member: true
 coppa_supported: true
+gvl_id: 69
 ---
 
 

--- a/dev-docs/bidders/pubmatic.md
+++ b/dev-docs/bidders/pubmatic.md
@@ -14,6 +14,7 @@ safeframes_ok: true
 tcf2_supported: true
 pbjs: true
 pbs: true
+gvl_id: 76
 ---
 
 ### Prebid Server Note:

--- a/dev-docs/bidders/pulsepoint.md
+++ b/dev-docs/bidders/pulsepoint.md
@@ -10,6 +10,7 @@ media_types: banner, video, native
 userIds: britepoolId, criteo, id5Id, identityLink, liveIntentId, parrableId, pubCommonId, unifiedId
 pbjs: true
 pbs: true
+gvl_id: 81
 ---
 
 

--- a/dev-docs/bidders/rubicon.md
+++ b/dev-docs/bidders/rubicon.md
@@ -15,6 +15,7 @@ safeframes_ok: true
 bidder_supports_deals: true
 pbjs: true
 pbs: true
+gvl_id: 52
 ---
 
 ### Registration

--- a/dev-docs/bidders/spotx.md
+++ b/dev-docs/bidders/spotx.md
@@ -12,6 +12,7 @@ schain_supported: true
 usp_supported: true
 safeframes_ok: false
 pbjs: true
+gvl_id: 165
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/sublime.md
+++ b/dev-docs/bidders/sublime.md
@@ -5,6 +5,7 @@ description: Prebid Sublime Bidder Adapter
 pbjs: true
 biddercode: sublime
 gdpr_supported: true
+gvl_id: 114
 ---
 
 ### Note

--- a/dev-docs/modules/gdprEnforcement.md
+++ b/dev-docs/modules/gdprEnforcement.md
@@ -171,7 +171,7 @@ See the [IAB TCF Consent String Format](https://github.com/InteractiveAdvertisin
 
 ## Modules that Support GVL ID
 
-The GDPR Enforcement module requires the GVL ID for a module to be specified. If no GVL ID is found the module will be blocked by default, unless it is specifically listed under `vendorExceptions`. The following modules have listed their GVL IDs.
+The GDPR Enforcement module requires the GVL ID for a module to be specified. If no GVL ID is found the module will be blocked by default unless it is specifically listed under `vendorExceptions`. The following modules have listed their GVL IDs.
 
 {% assign bidder_pages = site.pages | where: "layout", "bidder" %}
 

--- a/dev-docs/modules/gdprEnforcement.md
+++ b/dev-docs/modules/gdprEnforcement.md
@@ -169,38 +169,36 @@ Before allowing an activity tied to a TCF-protected Purpose for a given vendor, 
 
 See the [IAB TCF Consent String Format](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md) for details.
 
-## Supported Modules
+## Modules that Support GVL ID
 
-The GDPR Enforcement module requires the GVL ID for a module to be specified. If no GVL ID found, the module will be blocked by default unless it is specifically listed under `vendorExceptions`. The following is a list of modules which have listed their GVL IDs.
+The GDPR Enforcement module requires the GVL ID for a module to be specified. If no GVL ID found, the module will be blocked by default unless it is specifically listed under `vendorExceptions`. The following are the modules which have listed their GVL IDs.
 
-| Modules that Support GVL ID   |
-|-------------------------------|
-| `aardvarkBidAdapter.js`       |
-| `adagioBidAdapter.js`         |
-| `adformBidAdapter.js`         |
-| `adformOpenRTBBidAdapter.js`  |
-| `adheseBidAdapter.js`         |
-| `adtelligentBidAdapter.js`    |
-| `aolBidAdapter.js`            |
-| `appnexusAnalyticsAdapter.js` |
-| `appnexusBidAdapter.js`       |
-| `apstreamBidAdapter.js`       |
-| `conversantBidAdapter.js`     |
-| `criteoBidAdapter.js`         |
-| `emx_digitalBidAdapter.js`    |
-| `fidelityBidAdapter.js`       |
-| `id5IdSystem.js`              |
-| `improvedigitalBidAdapter.js` |
-| `invibesBidAdapter.js`        |
-| `ixBidAdapter.js`             |
-| `medianetBidAdapter.js`       |
-| `openxBidAdapter.js`          |
-| `pubmaticBidAdapter.js`       |
-| `pulsepointBidAdapter.js`     |
-| `rubiconBidAdapter.js`        |
-| `spotxBidAdapter.js`          |
-| `sublimeBidAdapter.js`        |
+{% assign bidder_pages = site.pages | where: "layout", "bidder" %}
 
+<table class="table table-bordered table-striped">
+  <thead>
+    <tr>
+      <th>Module Type</th>
+      <th>Module</th>
+    </tr>
+  </thead>
+  <tbody>
+{% for page in bidder_pages %}{% unless page.gvl_id %}{% continue %}{% endunless %}
+    <tr>
+      <td>Bid Adapter</td>
+      <td>{{page.title}}</td>
+    </tr>
+{% endfor %}
+    <tr>
+      <td>Analytics Adapter</td>
+      <td>AppNexus</td>
+    </tr>
+    <tr>
+      <td>User ID</td>
+      <td>ID5</td>
+    </tr>
+</tbody>
+</table>
 
 ## Build the Package
 

--- a/dev-docs/modules/gdprEnforcement.md
+++ b/dev-docs/modules/gdprEnforcement.md
@@ -171,7 +171,7 @@ See the [IAB TCF Consent String Format](https://github.com/InteractiveAdvertisin
 
 ## Modules that Support GVL ID
 
-The GDPR Enforcement module requires the GVL ID for a module to be specified. If no GVL ID found, the module will be blocked by default unless it is specifically listed under `vendorExceptions`. The following are the modules which have listed their GVL IDs.
+The GDPR Enforcement module requires the GVL ID for a module to be specified. If no GVL ID is found the module will be blocked by default, unless it is specifically listed under `vendorExceptions`. The following modules have listed their GVL IDs.
 
 {% assign bidder_pages = site.pages | where: "layout", "bidder" %}
 

--- a/dev-docs/modules/gdprEnforcement.md
+++ b/dev-docs/modules/gdprEnforcement.md
@@ -169,6 +169,39 @@ Before allowing an activity tied to a TCF-protected Purpose for a given vendor, 
 
 See the [IAB TCF Consent String Format](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md) for details.
 
+## Supported Modules
+
+The GDPR Enforcement module requires the GVL ID for a module to be specified. If no GVL ID found, the module will be blocked by default unless it is specifically listed under `vendorExceptions`. The following is a list of modules which have listed their GVL IDs.
+
+| Modules that Support GVL ID   |
+|-------------------------------|
+| `aardvarkBidAdapter.js`       |
+| `adagioBidAdapter.js`         |
+| `adformBidAdapter.js`         |
+| `adformOpenRTBBidAdapter.js`  |
+| `adheseBidAdapter.js`         |
+| `adtelligentBidAdapter.js`    |
+| `aolBidAdapter.js`            |
+| `appnexusAnalyticsAdapter.js` |
+| `appnexusBidAdapter.js`       |
+| `apstreamBidAdapter.js`       |
+| `conversantBidAdapter.js`     |
+| `criteoBidAdapter.js`         |
+| `emx_digitalBidAdapter.js`    |
+| `fidelityBidAdapter.js`       |
+| `id5IdSystem.js`              |
+| `improvedigitalBidAdapter.js` |
+| `invibesBidAdapter.js`        |
+| `ixBidAdapter.js`             |
+| `medianetBidAdapter.js`       |
+| `openxBidAdapter.js`          |
+| `pubmaticBidAdapter.js`       |
+| `pulsepointBidAdapter.js`     |
+| `rubiconBidAdapter.js`        |
+| `spotxBidAdapter.js`          |
+| `sublimeBidAdapter.js`        |
+
+
 ## Build the Package
 
 Follow the basic build instructions in the GitHub Prebid.js repo's main [README](https://github.com/prebid/Prebid.js/blob/master/README.md). Include the base consent management module and this enforcement module as additional options on the **gulp build** command:


### PR DESCRIPTION
The GDPR Enforcement modules requires bid adapters, userid submodules and analytics adapters to provide GVL ID, otherwise the module will be blocked by default unless its present in `vendorExceptions`.

Related PR: https://github.com/prebid/Prebid.js/pull/5643