### PR TITLE
Restored zoneId parameter in criteo bid adapter doc

### DIFF
--- a/dev-docs/bidders/criteo.md
+++ b/dev-docs/bidders/criteo.md
@@ -22,7 +22,8 @@ See [Sending Asset Placeholders]({{site.baseurl}}/dev-docs/show-native-ads.html#
 {: .table .table-bordered .table-striped }
 | Name              | Scope    | Description                                                                                                          | Example                                       | Type       |
 |-------------------|----------|----------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|------------|
-| `networkId`       | required | The network ID from Criteo.Please reach out your Criteo representative for more details.                             | `456456`                                      | `integer`  |
+| `zoneId`          | required | (deprecated) The zone ID from Criteo. Should be replaced by `networkId` when using zone matching.                                    | `234234`                                      | `integer`  |
+| `networkId`       | required | The network ID from Criteo. Please reach out your Criteo representative for more details.                             | `456456`                                      | `integer`  |
 | `nativeCallback`  | optional | Callback to perform render in native integrations. Please reach out your Criteo representative for more details.     | `function(payload) { console.log(payload); }` | `function` |
 | `integrationMode` | optional | Integration mode to use for ad render (none or 'AMP'). Please reach out your Criteo representative for more details. | `'AMP'`                                       | `string`   |
 


### PR DESCRIPTION
Following this request : https://github.com/prebid/prebid.github.io/issues/1929

Restored the param in the doc, specifying that it is deprecated.