### PR TITLE
Add additional parameters to config

### DIFF
--- a/dev-docs/bidders/apstream.md
+++ b/dev-docs/bidders/apstream.md
@@ -15,9 +15,29 @@ gvl_id: 394
 {: .table .table-bordered .table-striped }
 | Name           | Scope      | Description                                     | Example            | type    |
 | :-----------   | :--------- | :------------                                   | :----------------- | :---    |
-| `publisherId`  | required   | Publisher Id will be generated on AP Stream.    | '1234'             | string  |
+| `publisherId`  | optional*  | Publisher Id will be generated on AP Stream.    | '1234'             | string  |
 | `code`         | optional   | Ad code                                         | 'S1_Leaderboard'   | string  |
 | `adunitId`     | optional   | Ad unit Id                                      | 1234               | integer |
 | `endpoint`     | optional   | Endpoint for custom bidder                      | 'site.com/v1'      | string  |
-| `test`         | optional   | Use test endpoint                               | true               | boolean |
+| `test`         | optional*  | Use test endpoint                               | true               | boolean |
 | `sendDsu`      | optional   | Send DSU to bidder (default `true`)             | false              | boolean |
+
+\* see description below
+
+#
+
+### Bidder config
+
+Here parameters `test` and `publisherId` can be set globally, but will be overrided if set in specific bid.
+
+```
+pbjs.setBidderConfig({
+    bidders: ["apstream"],
+    config: {
+        appstream: {
+            publisherId: '1234
+            test: true
+        }
+    }
+});
+```


### PR DESCRIPTION
Move `test` and `publisherId` parameters to bidder specific config