### PR TITLE
Smaato bid adapter: Optional bidder params to support in-app webview use cases

### DIFF
--- a/dev-docs/bidders/smaato.md
+++ b/dev-docs/bidders/smaato.md
@@ -2,9 +2,9 @@
 layout: bidder
 title: Smaato
 description: Prebid Smaato Bidder Adaptor
-hide: true
 biddercode: smaato
 gdpr_supported: true
+tcf2_supported: true
 usp_supported: true
 coppa_supported: true
 media_types: banner, video
@@ -12,9 +12,17 @@ pbjs: true
 pbs: true
 ---
 
+### Table of Contents
+
+- [Bid Params](#smaato-bid-params)
+- [App Object](#smaato-app-object)
+- [First Party Data](#smaato-first-party)
+
 ### Registration
 
 The Smaato adapter requires setup and approval from the Smaato team, even for existing Smaato publishers. Please reach out to your account team or prebid@smaato.com for more information.
+
+<a name="smaato-bid-params" />
 
 ### Bid Params
 
@@ -23,6 +31,20 @@ The Smaato adapter requires setup and approval from the Smaato team, even for ex
 |------------|----------|----------------------|------------|----------|
 | `publisherId` | required | Your Smaato publisher id  | `'1100012345'` | `string` |
 | `adspaceId` | required | Your Smaato adspace id | `'11002234'`   | `string` |
+| `app` | optional | Object containing mobile app parameters.  See the [App Object](#smaato-app-object) for details.| `app : { ifa: '56700000-9cf0-22bd-b23e-46b96e40003a'}` | `object` |
+
+<a name="smaato-app-object" />
+
+#### App Object
+
+Smaato supports using prebid within a mobile app's webview.
+
+{: .table .table-bordered .table-striped }
+| Name              | Description                                                                                                                     | Example                                                                  | Type             |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|------------------|
+| `ifa`             | String that contains the advertising identifier of the user (e.g. idfa or aaid).                                                | `'56700000-9cf0-22bd-b23e-46b96e40003a'`                                 | `string`         |
+| `geo`             | Object that contains the latitude (`lat`) and longitude (`lon`) of the user.                                                    | `{ lat: 33.3, lon: -88.8 }`                                              | `object`         |
+
 
 ### Example Banner Ad Unit
 
@@ -74,6 +96,9 @@ var adUnit = {
     }]
 };
 ```
+<a name="smaato-first-party" />
+
+### First Party Data
 
 The Smaato adapter supports passing through first party data configured in your prebid integration.
 
@@ -98,7 +123,7 @@ Following example includes sample `imp` object with publisherId and adSlot which
 ```
 "imp":[
       {
-         "id":“1C86242D-9535-47D6-9576-7B1FE87F282C,
+         "id":"1C86242D-9535-47D6-9576-7B1FE87F282C",
          "banner":{
             "format":[
                {


### PR DESCRIPTION
Related to this PR for Prebid.js: https://github.com/prebid/Prebid.js/pull/5765

In addition we now support tcf2.

We have clients who want to use Prebid.js inside an app's webview and transmit geo info or device ids that they may be able to use in this case.

In order to support this, we accept a new `app` object as an optional bidder param where they can add this additional info.
The params object of an adUnit making use of this feature would look like this:

```
  params: {
    publisherId: 'publisherId',
    adspaceId: 'adspaceId',
    app: {
      ifa: 'aDeviceId',
      geo: {
        lat: 33.3,
        lon: -88.8
      }
    }
  }
```