### PR TITLE
Added TCF v2.0 support to the documentation

### DIFF
--- a/dev-docs/bidders/quantumdex.md
+++ b/dev-docs/bidders/quantumdex.md
@@ -6,6 +6,7 @@ pbjs: true
 biddercode: quantumdex
 media_types: banner, video
 gdpr_supported: true
+tcf2_supported: true
 schain_supported: true
 usp_supported: true
 ---

--- a/dev-docs/bidders/valueimpression.md
+++ b/dev-docs/bidders/valueimpression.md
@@ -2,10 +2,12 @@
 layout: bidder
 title: Valueimpression
 description: Prebid Valueimpression Bidder Adapter
+pbjs: true
 biddercode: valueimpression
 aliasCode: quantumdex
 media_types: banner, video
 gdpr_supported: true
+tcf2_supported: true
 schain_supported: true
 usp_supported: true
 pbs: true


### PR DESCRIPTION
I have added TCF v2.0 support for Quantumdex and Valueimpression bid adapter to the documentation
tcf2_supported: true
Support is handled on the endpoint side so I haven't changed anything in the prebid.js code.
Thanks!