### PR TITLE
Yieldlab: Add Supply Chain Support to Docs

### DIFF
--- a/dev-docs/bidders/yieldlab.md
+++ b/dev-docs/bidders/yieldlab.md
@@ -6,6 +6,7 @@ biddercode: yieldlab
 media_types: video
 gdpr_supported: true
 tcf2_supported: true
+schain_supported: true
 userIds: britepoolId, criteo, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
 prebid_member: true
 pbjs: true


### PR DESCRIPTION
Schain Support for Yieldlab was merged and released via: https://github.com/prebid/Prebid.js/pull/5521

Thanks!