### PR TITLE
Add skip params to Beachfront doc

### DIFF
--- a/dev-docs/bidders/beachfront.md
+++ b/dev-docs/bidders/beachfront.md
@@ -44,6 +44,9 @@ For further information, please contact adops@beachfront.com.
 | `playbackmethod` | optional | Playback method supported by the publisher.<br/>`1`: Auto-play sound on<br/>`2`: Auto-play sound off<br/>`3`: Click-to-play<br/>`4`: Mouse-over | `1` | `integer` |
 | `maxduration`    | optional | Maximum video ad duration in seconds. | `30` | `integer` |
 | `placement`      | optional | Placement type for the impression.<br/>`1`: In-Stream<br/>`2`: In-Banner<br/>`3`: In-Article<br/>`4`: In-Feed<br/>`5`: Interstitial/Slider/Floating | `1` | `integer` |
+| `skip`           | optional | Indicates if the player will allow the video to be skipped. | `1` | `integer` |
+| `skipmin`        | optional | Videos of total duration greater than this number of seconds can be skippable. | `15` | `integer` |
+| `skipafter`      | optional | Number of seconds a video must play before skipping is enabled. | `5` | `integer` |
 
 <a name="beachfront-banner"></a>
 


### PR DESCRIPTION
Adds documentation for optional video params `skip`, `skipmin`, and `skipafter`.