### PR TITLE
Add support for Publisher Common ID Module in Sharethrough bid adapter docs

### DIFF
--- a/dev-docs/bidders/sharethrough.md
+++ b/dev-docs/bidders/sharethrough.md
@@ -8,7 +8,7 @@ media_types     : native
 schain_supported: true
 tcf2_supported  : true
 title           : Sharethrough
-userIds         : unifiedId
+userIds         : pubCommonId, unifiedId
 usp_supported   : true
 pbjs            : true
 pbs             : true


### PR DESCRIPTION
- Related feature PR [here](https://github.com/prebid/Prebid.js/pull/5871)
- pubgrowth.engineering@sharethrough.com