### PR TITLE
pbjs_version_notes feature

### DIFF
--- a/dev-docs/bidders/triplelift.md
+++ b/dev-docs/bidders/triplelift.md
@@ -11,6 +11,7 @@ biddercode: triplelift
 userIds: criteo, identityLink, unifiedId
 pbjs: true
 pbs: true
+pbjs_version_notes: avoid 4.3 - 4.12
 ---
 
 ### Bid Params

--- a/download.md
+++ b/download.md
@@ -182,11 +182,8 @@ Prebid.js is open source software that is offered for free as a convenience. Whi
 <div class="col-md-4">
  <div class="checkbox">
   <label>
-  {% if page.aliasCode %}
-    <input type="checkbox" moduleCode="{{ page.aliasCode }}BidAdapter" class="bidder-check-box"> {{ page.title }}
-  {% else %}
-    <input type="checkbox" moduleCode="{{ page.biddercode }}BidAdapter" class="bidder-check-box"> {{ page.title }}
-  {% endif %}
+  {% if page.aliasCode %} <input type="checkbox" moduleCode="{{ page.aliasCode }}BidAdapter" class="bidder-check-box"> {{ page.title }} {% else %} <input type="checkbox" moduleCode="{{ page.biddercode }}BidAdapter" class="bidder-check-box"> {{ page.title }} {% endif %}
+  {% if page.pbjs_version_notes %}<br/><div style="font-size:80%">{{page.pbjs_version_notes}}</div>{% endif %}
   </label>
 </div>
 </div>


### PR DESCRIPTION
Driven by a [specific adapter issue](https://github.com/prebid/Prebid.js/pull/5872), this is a new piece of optional metadata. e.g.:

```
pbjs_version_notes: v4.13+
```
