### PR TITLE
Fix pubProvidedId example

### DIFF
--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -909,7 +909,7 @@ The PubProvided Id module allows publishers to set and pass a first party user i
 pbjs.setConfig({
     userSync: {
         userIds: [{
-            name: "publisherProvided",
+            name: "pubProvidedId",
             params: {
                 eidsFunction: getIdsFn   // any function that exists in the page
             }


### PR DESCRIPTION
Module name was incorrect in the example