### PR TITLE
Update docs to reflect that native asset's ID field is optional

### DIFF
--- a/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.md
+++ b/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.md
@@ -352,7 +352,7 @@ for each Bidder by using the `/cookie_sync` endpoint, and calling the URLs that 
 
 #### Native Request
 
-For each native request, the `assets` object's `id` field must not be defined. Prebid Server will set this automatically, using the index of the asset in the array as the ID.
+For each native request, the `assets` object's `id` field is optional and if not defined, Prebid Server will set this automatically, using the index of the asset in the array as the ID.
 
 
 #### Bidder Aliases


### PR DESCRIPTION
Addresses https://github.com/prebid/prebid-server/issues/1517

Currently the documentation says that native asset object's ID is not to be defined in the request. However, both Prebid Server Go and Prebid Server Java treat this as an optional field such that if the asset's ID isn't provided in the request, it assigns it based on the asset's index value in the array of assets. This behavior makes sense because if the request is requesting two types of data assets such as `sponsored` (type: `1`) and `desc` (type: `2`), and if the assets in the response don't have the types set (Based on the openrtb native spec the `type` field in the data asset response object is optional) then there's no way for the Publisher to know which data asset is of which type. Therefore, updating the documentation to reflect this behavior.

Ref to Prebid Server Go: https://github.com/prebid/prebid-server/blob/7b50f96df28dfcecfdfce97f62b13b79596a40ea/endpoints/openrtb2/auction.go#L575-L588

Ref to Prebid Server Java: https://github.com/rubicon-project/prebid-server-java/blob/05a5b119ede5ed404289794d50b201706cd8b45a/src/main/java/org/prebid/server/validation/RequestValidator.java#L577