### PR TITLE
[Triplelift] Avoid versions 4.3-4.14

### DIFF
--- a/dev-docs/bidders/triplelift.md
+++ b/dev-docs/bidders/triplelift.md
@@ -11,7 +11,7 @@ biddercode: triplelift
 userIds: criteo, identityLink, unifiedId
 pbjs: true
 pbs: true
-pbjs_version_notes: avoid 4.3 - 4.12
+pbjs_version_notes: avoid 4.3 - 4.14
 ---
 
 ### Bid Params


### PR DESCRIPTION
Video bug fixes in effect starting 4.15: https://github.com/prebid/Prebid.js/releases/tag/4.15.0