### PR TITLE
[AD-1023] JW Player - Set targeting info to bid.rtd

### DIFF
--- a/dev-docs/modules/jwplayerRtdProvider.md
+++ b/dev-docs/modules/jwplayerRtdProvider.md
@@ -18,9 +18,8 @@ sidebarType : 1
 
 ## Overview
 
-The purpose of this Real Time Data Provider is to allow publishers to target against their JW Player media without 
-being forced to integrate with the Player Bidding product. This prebid module makes JW Player's video ad targeting information accessible 
-to Bid Adapters.
+The JW Player RTD module passes contextual and performance based information about individual video impression opportunities to bid adapters in order to increase monetization. 
+To use this module, you'll need to work with [JW Player](https://www.jwplayer.com/video-monetization/) to get an account and discuss the best integration path.
 
 ## Implementation for Publishers:
 

--- a/dev-docs/modules/jwplayerRtdProvider.md
+++ b/dev-docs/modules/jwplayerRtdProvider.md
@@ -110,11 +110,15 @@ Each bidRequest for which targeting information was found will conform to the fo
    adUnitCode: 'xyz',
    bidId: 'abc',
    ...,
-   jwTargeting: {
-     segments: ['123', '456'],
-     content: {
-       id: 'jw_abc123'
-     }
+   rtd: {
+       jwplayer: {
+           targeting: {
+               segments: ['123', '456'],
+               content: {
+                   id: 'jw_abc123'
+               }
+           }
+       }   
    }
 }
 ```
@@ -126,10 +130,10 @@ Read the bidRequest.jwTargeting object and pass the values to your endpoint as a
 {: .table .table-bordered .table-striped }
 | Name  |Type | Description   | Notes  |
 | :------------ | :------------ | :------------ |:------------ |
-| jwTargeting | Object | | |
-| jwTargeting.segments | Array of Strings | jwpseg targeting segments | |
-| jwTargeting.content | Object | | |
-| jwTargeting.content.id | String | Unique identifier for the specific media asset | |
+| rtd.jwplayer.targeting | Object | | |
+| rtd.jwplayer.targeting.segments | Array of Strings | jwpseg targeting segments | |
+| rtd.jwplayer.targeting.content | Object | | |
+| rtd.jwplayer.targeting.content.id | String | Unique identifier for the specific media asset | |
   
 ## Example
 


### PR DESCRIPTION
Updates the documentation for API change introduced in https://github.com/prebid/Prebid.js/pull/5950
As of the linked PR, targeting information is set to `bid.rtd.jwplayer.targeting` instead of `bid.jwTargeting`.