### PR TITLE
Update the name of the lotamePanoramaIdSystem module to be accurate

### DIFF
--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -708,7 +708,7 @@ The Lotame privacy policy is at [https://www.lotame.com/about-lotame/privacy/](h
 Add it to your Prebid.js package with:
 
 {: .alert.alert-info :}
-gulp build --modules=lotamePanoramaId
+gulp build --modules=lotamePanoramaIdSystem
 
 #### Lotame Panorama ID Configuration
 


### PR DESCRIPTION
The example code omitted the word System from the module name