### PR TITLE
userId updates

### DIFF
--- a/dev-docs/bidders/grid.md
+++ b/dev-docs/bidders/grid.md
@@ -10,7 +10,7 @@ gdpr_supported: true
 usp_supported: true
 schain_supported: true
 getFloor: true
-userIds: id5Id, unifiedId, liveIntentId, criteo, identityLink, digitrust
+userIds: id5Id, unifiedId, liveIntentId, criteo, identityLink
 tcf2_supported: true
 ---
 

--- a/dev-docs/bidders/pubmatic.md
+++ b/dev-docs/bidders/pubmatic.md
@@ -9,7 +9,7 @@ usp_supported: true
 coppa_supported: true
 schain_supported: true
 getFloor: true
-userIds: britepoolId, criteo, fabrickId, haloId, id5Id, identityLink, intentiqId, idx, liveIntentId, lotamePanoramaId, netId, parrableId, pubCommonId, quantcastId, sharedId, unifiedId, verizonMediaId, zeotapIdPlus
+userIds: all
 prebid_member: true
 safeframes_ok: true
 tcf2_supported: true

--- a/dev-docs/bidders/rubicon.md
+++ b/dev-docs/bidders/rubicon.md
@@ -10,7 +10,7 @@ coppa_supported: true
 schain_supported: true
 getFloor: true
 media_types: video
-userIds: britepoolId, criteo, fabrickId, haloId, id5Id, identityLink, intentiqId, idx, liveIntentId, lotamePanoramaId, netId, parrableId, pubCommonId, pubProvidedId, quantcastId, sharedId, unifiedId, verizonMediaId, zeotapIdPlus
+userIds: all
 prebid_member: true
 safeframes_ok: true
 bidder_supports_deals: true

--- a/dev-docs/bidders/smartadserver.md
+++ b/dev-docs/bidders/smartadserver.md
@@ -8,7 +8,7 @@ gdpr_supported: true
 schain_supported: true
 tcf2_supported: true
 usp_supported: true
-userIds: britepoolId, criteo, digitrust, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
+userIds: britepoolId, criteo, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
 pbjs: true
 pbs: true
 ---

--- a/dev-docs/bidders/vidazoo.md
+++ b/dev-docs/bidders/vidazoo.md
@@ -3,7 +3,7 @@ layout: bidder
 title: Vidazoo
 description: Prebid Vidazoo Bidder Adaptor
 biddercode: vidazoo
-userIds: britepoolId, criteo, digitrust, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
+userIds: britepoolId, criteo, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
 gdpr_supported: true
 usp_supported: true
 pbjs: true


### PR DESCRIPTION
Setting rubicon and pubmatic to support 'all' user IDs as per issue https://github.com/prebid/prebid.github.io/issues/2492

Removing digitrust from remaining adapters