### PR TITLE
appnexus - add netid

### DIFF
--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -6,7 +6,7 @@ biddercode: appnexus
 media_types: banner, video, native
 gdpr_supported: true
 prebid_member: true
-userIds: criteo, unifiedId
+userIds: criteo, unifiedId, netId
 schain_supported: true
 coppa_supported: true
 usp_supported: true


### PR DESCRIPTION
Based on https://github.com/prebid/Prebid.js/pull/6114

Adding netId as a supported userId for the appnexus bidder.