### PR TITLE
Readpeak: Add tagId to documentation

### DIFF
--- a/dev-docs/bidders/readpeak.md
+++ b/dev-docs/bidders/readpeak.md
@@ -5,6 +5,7 @@ description: Readpeak Bidder Adaptor
 pbjs: true
 biddercode: readpeak
 media_types: native
+gvl_id: 290
 ---
 
 ### Bid Params
@@ -15,3 +16,4 @@ media_types: native
 | `publisherId` | required    | Publisher ID provided by Readpeak  | `'c2aca92893d1b989'` | `string` |
 | `siteId`      | recommended | Site/Media ID provided by Readpeak | `'5d1aef6a9088ced0'` | `string` |
 | `bidfloor`    | optional    | CPM Bid Floor                      | `0.5`                | `float`  |
+| `tagId`       | optional    | Ad placement identifier            | `placement-1`        | `string` |

--- a/dev-docs/bidders/readpeak.md
+++ b/dev-docs/bidders/readpeak.md
@@ -16,4 +16,4 @@ gvl_id: 290
 | `publisherId` | required    | Publisher ID provided by Readpeak  | `'c2aca92893d1b989'` | `string` |
 | `siteId`      | recommended | Site/Media ID provided by Readpeak | `'5d1aef6a9088ced0'` | `string` |
 | `bidfloor`    | optional    | CPM Bid Floor                      | `0.5`                | `float`  |
-| `tagId`       | optional    | Ad placement identifier            | `placement-1`        | `string` |
+| `tagId`       | optional    | Ad placement identifier            | `'placement-1'`      | `string` |


### PR DESCRIPTION
Adds documentation for the optional tagId parameter for the Readpeak bidder.  Also adds the IAB Global Vendor List ID.

Related PR: https://github.com/prebid/Prebid.js/pull/6133