### PR TITLE
Rename Zemanta to Outbrain

### DIFF
--- a/dev-docs/bidders/outbrain.md
+++ b/dev-docs/bidders/outbrain.md
@@ -1,7 +1,7 @@
 ---
 layout: bidder
-title: Zemanta
-description: Zemanta Prebid Bidder Adapter
+title: Outbrain
+description: Outbrain Prebid Bidder Adapter
 biddercode: zemanta
 gdpr_supported: true
 gvl_id: 210
@@ -15,13 +15,13 @@ pbjs: true
 
 ### Registration
 
-The Zemanta Adapter requires setup before beginning. Please contact us at prebid.org@outbrain.com.
+The Outbrain Adapter requires setup before beginning. Please contact us at prebid.org@outbrain.com.
 
 ### Configuration
 
 #### Bidder and usersync URLs
 
-The Zemanta adapter does not work without setting the correct bidder and usersync URLs.
+The Outbrain adapter does not work without setting the correct bidder and usersync URLs.
 You will receive the URLs when contacting us.
 
 ```

--- a/dev-docs/bidders/outbrain.md
+++ b/dev-docs/bidders/outbrain.md
@@ -2,9 +2,10 @@
 layout: bidder
 title: Outbrain
 description: Outbrain Prebid Bidder Adapter
-biddercode: zemanta
+biddercode: outbrain
+aliasCode : zemanta
 gdpr_supported: true
-gvl_id: 210
+gvl_id: 164
 tcf2_supported: true
 usp_supported: true
 coppa_supported: true
@@ -26,7 +27,7 @@ You will receive the URLs when contacting us.
 
 ```
 pbjs.setConfig({
-    zemanta: {
+    outbrain: {
       bidderUrl: 'https://bidder-url.com',
       usersyncUrl: 'https://usersync-url.com'
     }
@@ -75,7 +76,7 @@ var adUnits = [
         }
     },
     bids: [{
-        bidder: 'zemanta',
+        bidder: 'outbrain',
         params: {
             publisher: {
               id: '2706',
@@ -98,7 +99,7 @@ var adUnits = [
       } 
     },
     bids: [{
-        bidder: 'zemanta',
+        bidder: 'outbrain',
         params: {
             publisher: {
               id: '2706',


### PR DESCRIPTION
Hey!
This PR renames the Zemanta adapter to Outbrain. We only want Outbrain to be seen to publishers so the biddercode and naming in the source code stays the same.