### PR TITLE
added page Support > AdOps > Other Tools > Automated Line Item Setup

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -1148,6 +1148,24 @@
   sectionTitle:
   subgroup: 2
 
+- sbSecId: 3
+  title: "Other Tools"
+  link:
+
+  isHeader: 0
+  isSectionHeader: 0
+  isCatHeader: 1
+  sectionTitle:
+  subgroup: 0
+
+- sbSecId: 3
+  title: 'Automated Line Item Setup'
+  link: /adops/automated-line-item-setup.html
+  isHeader: 0
+  isSectionHeader: 0
+  sectionTitle:
+  subgroup: 0
+
 #--------------Prebid Video--------------|
 
 - sbSecId: 4

--- a/adops/automated-line-item-setup.md
+++ b/adops/automated-line-item-setup.md
@@ -1,0 +1,26 @@
+---
+layout: page_v2
+title: Automated Line Item Setup
+head_title: Automated Line Item Setup
+sbUUID: 3.2
+
+top_nav_section: adops
+nav_section: tutorials
+sidebarType: 3
+---
+
+# Automated Line Item Setup
+
+[PubMonkey](https://pubmonkey.postindustria.com/) Chrome Extension allows to automate Prebid order setup for Google Ad Manager and MoPub. 
+
+1. Download Chrome Extension [here](https://chrome.google.com/webstore/detail/pubmonkey/cjbdhopmleoleednpeaknmmbepfkhaml)
+
+2. The extension will guide you to login to either Google Ad Manager or MoPub.
+
+3. Click "Create" order button.  
+
+4. Choose "Prebid.org" as Header Bidding Service. 
+
+5. Enter order name, choose granularity and ad units and confirm creation. 
+
+The detailed documentation is available [here](https://doc.pubmonkey.postindustria.com/)


### PR DESCRIPTION
This page mentions a tool that automates Prebid order generation for Google Ad Manager and MoPub