### PR TITLE
Updating Revcontent documentation to include prebid-server

### DIFF
--- a/dev-docs/bidders/revcontent.md
+++ b/dev-docs/bidders/revcontent.md
@@ -15,14 +15,14 @@ pbs: true
 
 To use RevContent bidder, you need to have an existing RevContent account. To create a new account visit https://www.RevContent.com. If you are an existing user, contact the account rep for api access and information. 
 
-If you are using prebid server, Revcontent will provide you with a custom endpoint that will contain your account details that you will specify in your adapater configuration. For example, your pbs.yaml would contain the following:
+For prebid server, Revcontent only uses basic OpenRTB requests, so only the endpoint will need to be customized. Your request must contain either `app.name` or `site.domain` to be considered valid. Revcontent will provide you with a custom endpoint that will contain your account details that you will specify in your adapater configuration. For example, your pbs.yaml would contain the following:
 ```
 adapters:
   revcontent:
     endpoint: https://trends.revcontent.com/rtb?apiKey=<api key here>&userId=<account user id here>
 ```
 
-### Bid Params
+### Prebid.js Bid Params
 
 
 {: .table .table-bordered .table-striped }

--- a/dev-docs/bidders/revcontent.md
+++ b/dev-docs/bidders/revcontent.md
@@ -15,7 +15,7 @@ pbs: true
 
 To use RevContent bidder, you need to have an existing RevContent account. To create a new account visit https://www.RevContent.com. If you are an existing user, contact the account rep for api access and information. 
 
-For prebid server, Revcontent only uses basic OpenRTB requests, so only the endpoint will need to be customized. Your request must contain either `app.name` or `site.domain` to be considered valid. Revcontent will provide you with a custom endpoint that will contain your account details that you will specify in your adapater configuration. For example, your pbs.yaml would contain the following:
+For prebid server, Revcontent only uses basic OpenRTB requests, so only the endpoint will need to be customized. Your request must contain either `app.name` or `site.domain` to be considered valid. Revcontent will provide you with a custom endpoint that will contain your account details that you will specify in your adapater configuration, and you must manually enable the adapter. For example, your pbs.yaml would contain the following:
 ```
 adapters:
   revcontent:

--- a/dev-docs/bidders/revcontent.md
+++ b/dev-docs/bidders/revcontent.md
@@ -4,15 +4,23 @@ title: RevContent
 description: RevContent Bidder Adaptor
 biddercode: revcontent
 media_types: native
-gdpr_supported: true
-coppa_supported: true
-usp_supported: true
+gdpr_supported: false
+coppa_supported: false
+usp_supported: false
 pbjs: true
+pbs: true
 ---
 
 ### Note
 
-To use RevContent bidder, you need to have an existing RevContent account. To create a new account visit https://www.RevContent.com. If you are an existing user, contact the account rep for api access and information.
+To use RevContent bidder, you need to have an existing RevContent account. To create a new account visit https://www.RevContent.com. If you are an existing user, contact the account rep for api access and information. 
+
+If you are using prebid server, Revcontent will provide you with a custom endpoint that will contain your account details that you will specify in your adapater configuration. For example, your pbs.yaml would contain the following:
+```
+adapters:
+  revcontent:
+    endpoint: https://trends.revcontent.com/rtb?apiKey=<api key here>&userId=<account user id here>
+```
 
 ### Bid Params
 

--- a/dev-docs/bidders/revcontent.md
+++ b/dev-docs/bidders/revcontent.md
@@ -19,6 +19,7 @@ For prebid server, Revcontent only uses basic OpenRTB requests, so only the endp
 ```
 adapters:
   revcontent:
+    disabled: false
     endpoint: https://trends.revcontent.com/rtb?apiKey=<api key here>&userId=<account user id here>
 ```
 


### PR DESCRIPTION
Prebid server support is being added for Revcontent, and this is the accompanying documentation.

Regarding the gdpr_supported, etc changes, while our company does not do anything with the data that would be out of band with the regulations, we didn't see https://docs.prebid.org/dev-docs/modules/consentManagement.html previously, and so I'm setting false for these values until we have a chance to review that.