### PR TITLE
added sampling option to enableAnalytics function

### DIFF
--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -1342,9 +1342,20 @@ Events example 4: Log errors and render fails to your own endpoint
 
 Enable sending analytics data to the analytics provider of your choice.
 
-For usage, see [Integrate with the Prebid Analytics API]({{site.baseurl}}/dev-docs/integrate-with-the-prebid-analytics-api.html).
+Each analytics adapter has their own invocation parameters. For usage, see [Integrate with the Prebid Analytics API](/dev-docs/integrate-with-the-prebid-analytics-api.html).
 
-For a list of analytics adapters, see [Analytics for Prebid]({{site.baseurl}}/overview/analytics.html).
+For a list of analytics adapters, see [Analytics for Prebid](/overview/analytics.html).
+
+Analytics adapters that are built in the standard way should support a `sampling` option. You'll need to check with your analytics provider to confirm
+whether their system recommends the use of this parameter. They may have alternate methods of sampling.
+
+```
+pbjs.enableAnalytics({
+    options: {
+        sampling: 0.25   // only call the analytics adapter this percent of the time
+    }
+});
+```
 
 <hr class="full-rule" />
 

--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -1353,7 +1353,7 @@ pbjs.enableAnalytics([{
         providerSpecificParams: ...
         sampling: 0.25          // only call the analytics adapter this percent of the time
     }
-});
+}]);
 ```
 
 To learn how to build an analytics adapter, see [How to Add an Analytics Adapter](/dev-docs/integrate-with-the-prebid-analytics-api.html).

--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -1340,22 +1340,23 @@ Events example 4: Log errors and render fails to your own endpoint
 
 ### pbjs.enableAnalytics(config)
 
-Enable sending analytics data to the analytics provider of your choice.
+Enables sending analytics data to the analytics provider of your choice. For a list of analytics adapters, see [Analytics for Prebid](/overview/analytics.html).
 
-Each analytics adapter has their own invocation parameters. For usage, see [Integrate with the Prebid Analytics API](/dev-docs/integrate-with-the-prebid-analytics-api.html).
-
-For a list of analytics adapters, see [Analytics for Prebid](/overview/analytics.html).
-
-Analytics adapters that are built in the standard way should support a `sampling` option. You'll need to check with your analytics provider to confirm
+Note that each analytics adapter has it's own invocation parameters. Analytics adapters that are built in the standard way should
+support a `sampling` option. You'll need to check with your analytics provider to confirm
 whether their system recommends the use of this parameter. They may have alternate methods of sampling.
 
 ```
-pbjs.enableAnalytics({
+pbjs.enableAnalytics([{
+    provider: "analyticsA",
     options: {
-        sampling: 0.25   // only call the analytics adapter this percent of the time
+        providerSpecificParams: ...
+        sampling: 0.25          // only call the analytics adapter this percent of the time
     }
 });
 ```
+
+To learn how to build an analytics adapter, see [How to Add an Analytics Adapter](/dev-docs/integrate-with-the-prebid-analytics-api.html).
 
 <hr class="full-rule" />
 


### PR DESCRIPTION
Added text to cover the `sampling` option in the analytics adapter base class. See https://github.com/prebid/prebid.github.io/issues/2504 and https://github.com/prebid/Prebid.js/pull/1011