### PR TITLE
Updated IX pbs_app_supported flag

### DIFF
--- a/dev-docs/bidders/indexExchange.md
+++ b/dev-docs/bidders/indexExchange.md
@@ -5,6 +5,7 @@ description: Prebid Index Exchange Bidder Adapter
 biddercode: ix
 pbjs: true
 pbs: true
+pbs_app_supported: true
 schain_supported: true
 gdpr_supported: true
 usp_supported: true


### PR DESCRIPTION
With our latest PBS adapter update, IX now supports mobile app supply. Updated the pbs_app_supported flag to reflect that.