### PR TITLE
Relevant Yield Analytics adapter added

### DIFF
--- a/download.md
+++ b/download.md
@@ -395,6 +395,14 @@ Prebid.js is open source software that is offered for free as a convenience. Whi
 <div class="col-md-4">
   <div class="checkbox">
     <label>
+      <input type="checkbox" analyticscode="relevant" class="analytics-check-box" /> Relevant Yield
+    </label>
+  </div>
+</div>
+
+<div class="col-md-4">
+  <div class="checkbox">
+    <label>
       <input type="checkbox" analyticscode="rivr" class="analytics-check-box" /> Rivr Analytics
     </label>
   </div>

--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -37,6 +37,7 @@ There are several analytics adapter plugins available to track header bidding pe
 | PubXAi | Contact vendor | [Website](http://pubx.ai/) |
 | PulsePoint | Contact vendor | [Website](https://www.pulsepoint.com/) |
 | RealVu | Contact vendor | [Website](https://www.realvu.com/rvaa/) |
+| [Relevant Yield](https://www.relevant-digital.com/relevantyield) | <a href="mailto:sales@relevant-digital.com">Contact vendor</a> | [Website](https://www.relevant-digital.com/relevantyield) |
 | Rivr Analytics | Contact vendor | [Website](https://www.rivr.ai/)|
 | Rubicon Project | <a href="mailto: sales@rubiconproject.com">Contact vendor</a> | [Website](https://rubiconproject.com/header-bidding-for-publishers/) |
 | Scaleable.ai Analytics | Free & Paid | [Website](https://scaleable.ai) |


### PR DESCRIPTION
Relevant Yield analytics adapter added in overview/analytics.md + download.md.

**Notice:** The adapter itself is not merged yet at the time of writing this, so the documentation depends on this pull request being merged: [https://github.com/prebid/Prebid.js/pull/6195](https://github.com/prebid/Prebid.js/pull/6195) (therefore the download isn't working when selecting the Relevant Yield checkbox)