### PR TITLE
appnexus bidder - add identityLink userid

### DIFF
--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -6,7 +6,7 @@ biddercode: appnexus
 media_types: banner, video, native
 gdpr_supported: true
 prebid_member: true
-userIds: criteo, unifiedId, netId
+userIds: criteo, unifiedId, netId, identityLink
 schain_supported: true
 coppa_supported: true
 usp_supported: true


### PR DESCRIPTION
Related PBJS PR:
https://github.com/prebid/Prebid.js/pull/6245

This PR just adds `identityLink` to the list of supported userIds.