### PR TITLE
Adding note to AMP about load-cookie-with-consent

### DIFF
--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -163,7 +163,7 @@ keywords: {
 
 #### User Sync in AMP
 
-If you are syncing user id's with Prebid Server and are using AppNexus' managed service, use the following URL for the source:<br> <code>https://acdn.adnxs.com/prebid/amp/user-sync/load-cookie.html</code> or if the AMP page has a CMP, <code>https://acdn.adnxs.com/prebid/amp/user-sync/load-cookie-with-consent.html</code>
+If you are syncing user id's with Prebid Server and are using AppNexus' managed service, see [AMP Implementation Guide cookie-sync instructions](/dev-docs/show-prebid-ads-on-amp-pages.html#user-sync) for details.
 
 <a name="appnexus-debug-auction" />
 

--- a/dev-docs/show-prebid-ads-on-amp-pages.md
+++ b/dev-docs/show-prebid-ads-on-amp-pages.md
@@ -234,7 +234,7 @@ The following examples include a transparent image as a placeholder which will a
 {% include alerts/alert_tip.html content=tipNote %}
 
 {% capture consentNote %}
- The load-cookie-with-consent.html file has the same argument syntax as load-cookie.html. It's a different file because it's larger and depends on the existence of an AMP Consent Management Platform.
+ The load-cookie-with-consent.html file has the same argument syntax as load-cookie.html. It's a different file because it's larger and depends on the existence of an AMP Consent Management Platform. Note that the `sandbox` parameter to the amp-iframe must include both "allow-scripts" and "allow-same-origin".
 {% endcapture %}
 {% include alerts/alert_tip.html content=consentNote %}
 
@@ -242,7 +242,7 @@ If you're using AppNexus' managed service, you would enter something like this:
 ```html
 <amp-iframe width="1" title="User Sync"
   height="1"
-  sandbox="allow-scripts"
+  sandbox="allow-scripts allow-same-origin"
   frameborder="0"
   src="https://acdn.adnxs.com/prebid/amp/user-sync/load-cookie.html?endpoint=appnexus&max_sync_count=5">
   <amp-img layout="fill" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" placeholder></amp-img>
@@ -253,7 +253,7 @@ If you are utilizing Magnite's managed service, there's an extra parameter:
 ```html
 <amp-iframe width="1" title="User Sync"
   height="1"
-  sandbox="allow-scripts"
+  sandbox="allow-scripts allow-same-origin"
   frameborder="0"
   src="https://PROVIDED_BY_MAGNITE/prebid/load-cookie.html?endpoint=rubicon&max_sync_count=5&args=account:MAGNITE_ACCOUNT_ID">
   <amp-img layout="fill" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" placeholder></amp-img>

--- a/prebid-server/developers/pbs-cookie-sync.md
+++ b/prebid-server/developers/pbs-cookie-sync.md
@@ -69,7 +69,7 @@ See [the AMP implementation guide](/dev-docs/show-prebid-ads-on-amp-pages.html#u
 ```
 <amp-iframe width="1" title="User Sync"
   height="1"
-  sandbox="allow-scripts"
+  sandbox="allow-scripts allow-same-origin"
   frameborder="0"
   src="https://PROVIDED_BY_HOSTCOMPANY/load-cookie.html?endpoint=HOSTCOMPANY&max_sync_count=5">
   <amp-img layout="fill" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" placeholder></amp-img>


### PR DESCRIPTION
Based on a slack conversation, publishers need an extra parameter in the `sandbox` attribute of the amp-iframe.

@jeanstemp - I tweaked the appnexus.md file, so looking for your approval. Just linking it out to the full doc.