### PR TITLE
fix module_code for bidViewable module

### DIFF
--- a/dev-docs/modules/bidViewable.md
+++ b/dev-docs/modules/bidViewable.md
@@ -3,7 +3,7 @@ layout: page_v2
 page_type: module
 title: Module - Bid Viewable Event
 description: Triggers BID_VIEWABLE event when a rendered PBJS-Bid is viewable according to [Active View criteria](https://support.google.com/admanager/answer/4524488)
-module_code : bidViewable
+module_code : bidViewability
 display_name : Bid Viewable Event
 enable_download : true
 sidebarType : 1


### PR DESCRIPTION
Reported here:
https://github.com/prebid/Prebid.js/pull/6206#issuecomment-784018822

Seems like the module code set for this new bidViewable module isn't consistent with the filename in the Prebid.js repo.

This is causing any builds made with this module from the Download page to not work.

This PR should fix the issue (it shouldn't need any fixes from the Prebid.js side).