### PR TITLE
Add note about aliasSyncEnabled on Outbrain adapter

### DIFF
--- a/dev-docs/bidders/outbrain.md
+++ b/dev-docs/bidders/outbrain.md
@@ -25,11 +25,16 @@ The Outbrain Adapter requires setup before beginning. Please contact us at prebi
 The Outbrain adapter does not work without setting the correct bidder and usersync URLs.
 You will receive the URLs when contacting us.
 
+Also note that the Outbrain adapter is an aliased adapter and for usersync to work you also need to enable it as shown below 
+on the `usersync` config object.
 ```
 pbjs.setConfig({
     outbrain: {
       bidderUrl: 'https://bidder-url.com',
       usersyncUrl: 'https://usersync-url.com'
+    },
+    userSync: {
+        aliasSyncEnabled: true
     }
 });
 ```


### PR DESCRIPTION
Hey! This PR just adds a note for publishers about enabling usersync on aliased adapters so we can avoid potential issues.