### PR TITLE
bidder-adaptor.md: missing required field in bid response

### DIFF
--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -361,6 +361,7 @@ The `interpretResponse` function will be called when the browser has received th
         ttl: TIME_TO_LIVE,
         ad: CREATIVE_BODY,
         dealId: DEAL_ID,
+        mediaType: MEDIA_TYPE,
         meta: {
             advertiserDomains: [ARRAY_OF_ADVERTISER_DOMAINS],        
             advertiserId: ADVERTISER_ID,


### PR DESCRIPTION
The documentation for `interpretResponse` outlines the fields required in a bid response, but is missing the top-level `mediaType` field.