### PR TITLE
ATS-identityLinkIdSystem - add explanation for new notUse3P config parameter

### DIFF
--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -500,7 +500,7 @@ The IdentityLink privacy policy is at [https://liveramp.com/privacy/service-priv
 | name | Required | String | `"identityLink"` | `"identityLink"` |
 | params | Required for Id Link | Object | Details for identityLink initialization. | |
 | params.pid | This parameter is required for IdentityLink | String | This is the placementId, value needed for obtaining user’s IdentityLink envelope
-| params.use3P | This parameter is not required for IdentityLink | Boolean | Property for choosing should 3P Liveramp envelope endpoint be fired or not, in order to get IdentityLink envelope
+| params.notUse3P | This parameter is not required for IdentityLink | Boolean | Property for choosing should 3P Liveramp envelope endpoint be fired or not, in order to get IdentityLink envelope
 
 #### IdentityLink Examples
 
@@ -514,7 +514,7 @@ pbjs.setConfig({
             name: "identityLink",
             params: {
                 pid: '999',             // Set your real identityLink placement ID here
-                // use3P: true/false    // If you want to use 3P endpoint to retrieve the envelope. If you do not set this property to true, 3P endpoint will not be fired. By default this property is undefined and 3P request are not fired.
+                // notUse3P: true/false    // If you do not want to use 3P endpoint to retrieve the envelope. If you do not set this property to true, 3P endpoint will be fired. By default this property is undefined and 3P request will be fired.
             },
             storage: {
                 type: "cookie",
@@ -536,7 +536,7 @@ pbjs.setConfig({
             name: "identityLink",
             params: {
                 pid: '999',          // Set your real identityLink placement ID here
-                // use3P: true/false    // If you want to use 3P endpoint to retrieve the envelope. If you do not set this property to true, 3P endpoint will not be fired. By default this property is undefined and 3P request are not fired.
+                // notUse3P: true/false    // If you do not want to use 3P endpoint to retrieve the envelope. If you do not set this property to true, 3P endpoint will be fired. By default this property is undefined and 3P request will be fired.
             },
             storage: {
                 type: "html5",


### PR DESCRIPTION
Change name of config parameter from use3P to notUse3P in order to have required behaviour, by default 3P endpoint will be triggered. 

@smenzer 