### PR TITLE
Triplelift: Removing disclaimer

### DIFF
--- a/dev-docs/bidders/triplelift.md
+++ b/dev-docs/bidders/triplelift.md
@@ -18,7 +18,6 @@ pbjs: true
 pbs: true
 pbs_app_supported: true
 gvl_id: 28
-pbjs_version_notes: avoid 4.3 - 4.14
 ---
 
 ### Bid Params


### PR DESCRIPTION
Removing disclaimer as these versions are no longer available for download.
https://docs.prebid.org/download.html