### PR TITLE
Outbrain adapter: reinstate as alias for zemanta

### DIFF
--- a/dev-docs/bidders/outbrain.md
+++ b/dev-docs/bidders/outbrain.md
@@ -3,6 +3,7 @@ layout: bidder
 title: Outbrain
 description: Outbrain Prebid Bidder Adapter
 biddercode: outbrain
+aliasCode: zemanta
 gdpr_supported: true
 gvl_id: 164
 usp_supported: true

--- a/dev-docs/bidders/outbrain_old.md
+++ b/dev-docs/bidders/outbrain_old.md
@@ -1,8 +1,9 @@
 ---
 layout: bidder
-title: Outbrain
+title: Outbrain - Old
 description: Outbrain Prebid Bidder Adapter
 biddercode: outbrain
+aliasCode: zemanta
 gdpr_supported: true
 gvl_id: 164
 usp_supported: true
@@ -13,7 +14,7 @@ pbjs: true
 pbs: true
 pbs_app_supported: true
 prebid_member: true
-pbjs_version_notes: for versions 4.35+
+pbjs_version_notes: for versions 4.20-4.34
 ---
 
 ### Registration


### PR DESCRIPTION
Hey,

please see the linked PR for the reasoning behind this. In short, the issue is that the non-aliased outbrain adapter only exists in the lastest prebid.js version where it was released so trying to download it with a previous version fails.

If you agree with the proposed changes, would it be possible for this to be merged as soon as possible? Because if it is, only the latest version would not work with outbrain and not the other way around and we would not have to wait for the next prebid.js release. Any issues here?

