### PR TITLE
appnexus bidder - add getFloors support

### DIFF
--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -10,6 +10,7 @@ userIds: criteo, unifiedId, netId, identityLink
 schain_supported: true
 coppa_supported: true
 usp_supported: true
+getFloor: true
 pbjs: true
 pbs: true
 gvl_id: 32


### PR DESCRIPTION
A follow-up to https://github.com/prebid/Prebid.js/pull/6653

Update the flag in the appnexus bidder for `getFloors`.