### PR TITLE
Conversant adapter include mediaTypes.video

### DIFF
--- a/dev-docs/bidders/conversant.md
+++ b/dev-docs/bidders/conversant.md
@@ -24,14 +24,23 @@ gvl_id: 24
 | `secure`      | required (for secure pages) | If impression requires secure HTTPS URL creative assets and markup. 0 for non-secure, 1 for secure. Default is non-secure | `1`               | `integer`        |
 | `bidfloor`    | optional                    | Bid floor                                                                                                                 | `0.50`            | `float`          |
 | `tag_id`      | optional                    | Identifies specific ad placement.                                                                                         | `'cnvr-test-tag'` | `string`         |
-| `position`    | optional                    | Ad position on screen. See details below.                                                                                 | `1`               | `integer`        |
+| `white_label_url`| optional                  | Override the destination URL the request is sent to.                                                                       | `'https://mydomain.com/hbendpoint'`  | `string` |
+| `pubcid_name` | optional                    | Name of the pub common id. Conversant adapter can read the id directly if the UserID module is absent. Default is _pubcid.| `_pubcid`         | `string`         |
+
+### Video Params
+
+{: .table .table-bordered .table-striped }
+
+| Name          | Scope                       | Description                                                                                                               | Example           | Type             |
+|---------------|-----------------------------|---------------------------------------------------------------------------------------------------------------------------|-------------------|------------------|
+| `position`    | optional                    | Ad position on screen. See details below.  Only supported in in bids.params.                                                                               | `1`               | `integer`        |
 | `mimes`       | optional                    | Array of content MIME types supported. Required for video                                                                 | `['video/mp4']`   | `Array<string>`  |
 | `maxduration` | optional                    | Maximum duration in seconds for this video as an integer.                                                                 | `30`              | `integer`        |
 | `api`         | optional                    | Array of supported API frameworks. See details below.                                                                     | `[2]`             | `Array<integer>` |
 | `protocols`   | optional                    | Array of supported video protocols. See details below.                                                                    | `[2]`             | `Array<integer>` |
-| `white_label_url`| optional                  | Override the destination URL the request is sent to.                                                                       | `'https://mydomain.com/hbendpoint'`  | `string` |
-| `pubcid_name` | optional                    | Name of the pub common id. Conversant adapter can read the id directly if the UserID module is absent. Default is _pubcid.| `_pubcid`         | `string`         |
 
+
+Video parameters can be included in either `mediaTypes.video` or `bids.params` except where noted.
 
 The following values are defined in the [ORTB 2.5 spec](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf).
 

--- a/dev-docs/bidders/conversant.md
+++ b/dev-docs/bidders/conversant.md
@@ -25,7 +25,7 @@ gvl_id: 24
 | `bidfloor`    | optional                    | Bid floor                                                                                                                 | `0.50`            | `float`          |
 | `tag_id`      | optional                    | Identifies specific ad placement.                                                                                         | `'cnvr-test-tag'` | `string`         |
 | `white_label_url`| optional                  | Override the destination URL the request is sent to.                                                                       | `'https://mydomain.com/hbendpoint'`  | `string` |
-| `pubcid_name` | optional                    | Name of the pub common id. Conversant adapter can read the id directly if the UserID module is absent. Default is _pubcid.| `_pubcid`         | `string`         |
+| `pubcid_name` | optional                    | Name of the pub common id. Conversant adapter can read the id directly if the UserID module is absent. Default is _pubcid.| `'_pubcid'`         | `string`         |
 
 ### Video Params
 
@@ -33,7 +33,7 @@ gvl_id: 24
 
 | Name          | Scope                       | Description                                                                                                               | Example           | Type             |
 |---------------|-----------------------------|---------------------------------------------------------------------------------------------------------------------------|-------------------|------------------|
-| `position`    | optional                    | Ad position on screen. See details below.  Only supported in in bids.params.                                                                               | `1`               | `integer`        |
+| `position`    | optional                    | Ad position on screen. See details below.  Only supported in bids.params.                                                 | `1`               | `integer`        |
 | `mimes`       | optional                    | Array of content MIME types supported. Required for video                                                                 | `['video/mp4']`   | `Array<string>`  |
 | `maxduration` | optional                    | Maximum duration in seconds for this video as an integer.                                                                 | `30`              | `integer`        |
 | `api`         | optional                    | Array of supported API frameworks. See details below.                                                                     | `[2]`             | `Array<integer>` |


### PR DESCRIPTION
Update Conversant doc to say that video params could include mediaType.video.