### PR TITLE
InvibesBidAdapter - update doc for userid: uid2, zeotapIdPlus, id5id

### DIFF
--- a/dev-docs/bidders/invibes.md
+++ b/dev-docs/bidders/invibes.md
@@ -6,7 +6,7 @@ pbjs: true
 biddercode: invibes
 gdpr_supported: true
 tcf2_supported: true
-userIds: pubCommonId, pubProvidedId
+userIds: pubCommonId, pubProvidedId, uid2, zeotapIdPlus, id5id
 pbs: true
 ---
 
@@ -16,7 +16,6 @@ pbs: true
 | Name            | Scope    | Description                          | Example                                         | Type     |
 |-----------------|----------|--------------------------------------|-------------------------------------------------|----------|
 | `placementId`   | required | The Invibes placement ID             | `'1234567'`                                     | `string` |
-| `adContainerId` | optional | Id of ad container (only prebid js)  | `'test-div'`                                    | `string` |
 | `domainId`      | optional | Id of domain (only prebid server)    | `1001`                                          | `integer`|
 | `debug`         | optional | Debug paramentes (only prebid server)| `{ "testBvid": "1234", "testLog": true }`       | `object` |
 


### PR DESCRIPTION
Adds Unified ID 2.0 to the list of supported userIds: uid2, zeotapIdPlus, id5id

Removed bid param from doc (this was no longer used since prebid 1)