### PR TITLE
appnexus bid adapter: flocid support

### DIFF
--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -6,7 +6,7 @@ biddercode: appnexus
 media_types: banner, video, native
 gdpr_supported: true
 prebid_member: true
-userIds: criteo, unifiedId, netId, identityLink, flocId
+userIds: criteo, unifiedId, netId, identityLink, flocId, uid2
 schain_supported: true
 coppa_supported: true
 usp_supported: true

--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -6,7 +6,7 @@ biddercode: appnexus
 media_types: banner, video, native
 gdpr_supported: true
 prebid_member: true
-userIds: criteo, unifiedId, netId, identityLink
+userIds: criteo, unifiedId, netId, identityLink, flocId
 schain_supported: true
 coppa_supported: true
 usp_supported: true


### PR DESCRIPTION
Small change to note the appnexus bidder supports the `flocId` userId.

Related to:
https://github.com/prebid/Prebid.js/pull/6801