### PR TITLE
Revert "remove duplicate copy of districtmdmx"

### DIFF
--- a/dev-docs/bidders/districtmdmx.md
+++ b/dev-docs/bidders/districtmdmx.md
@@ -1,0 +1,36 @@
+---
+layout: bidder
+title: DistrictmDMX
+description: Prebid DistrictmDMX Bidder Adaptor
+pbjs: true
+biddercode: districtmDMX
+gdpr_supported: true
+schain_supported: true
+getFloor: true
+usp_supported: true
+coppa_supported: true
+userIds: britepoolId, criteo, id5Id, identityLink, intentiq, liveIntentId, netId, parrableId, pubCommonId, unifiedId
+---
+
+
+
+### Bid Params
+
+##### Prebid version 1.0 and above.
+
+{: .table .table-bordered .table-striped }
+| Name       | Scope    | Description         | Example          |    Type   |
+|------------|----------|---------------------|------------------|-----------|
+| `dmxid`    | required | Placement Id        |  `100001`          | `integer` |
+| `memberid` | required | Account id          |  `100003`          | `integer` |
+
+##### Prebid 0.34~ legacy
+
+{: .table .table-bordered .table-striped }
+| Name       | Scope    | Description             | Example          | Type      |
+|------------|----------|-------------------------|------------------|-----------|
+| `id`       | required | Placement ID            | `123456789`        | `integer` |
+| `floor`    | optional | Bid floor price         | `"1.00"`           | `string`  |
+| `revShare` | optional | Publisher Revenue Share | `"0.85"`           | `string`  |
+| `currency` | optional | Currency code           | `"usd"`            | `string`  |
+


### PR DESCRIPTION
Reverts prebid/prebid.github.io#2888

See https://github.com/prebid/Prebid.js/issues/6799

I think what happened here was confusion around case-sensitivity. There was, at one point, two copies of this file: districtmdmx and districtmDMX. This causes problems. I don't know why both versions are gone now, but anyhow restoring.