### PR TITLE
Eplanning Bid Adapter: add support for mobile apps and gvl_id

### DIFF
--- a/dev-docs/bidders/eplanning.md
+++ b/dev-docs/bidders/eplanning.md
@@ -7,6 +7,8 @@ pbs: true
 biddercode: eplanning
 usp_supported: true
 gdpr_supported: true
+pbs_app_supported: true
+gvl_id: 90
 ---
 
 


### PR DESCRIPTION
Updated Eplanning docs to add mobile app support and gvl_id