### PR TITLE
I want to add dgkeyword rtd module page.

### DIFF
--- a/dev-docs/modules/dgkeywordRtdProvider.md
+++ b/dev-docs/modules/dgkeywordRtdProvider.md
@@ -1,0 +1,58 @@
+---
+layout: page_v2
+title: Digital Garage Keyword Module
+display_name: Digital Garage Keyword
+description: Digital Garage Keyword
+page_type: module
+module_type: rtd
+module_code : dgkeywordRtdProvider
+enable_download : true
+sidebarType : 1
+---
+
+# Digital Garage Keyword Module
+{:.no_toc}
+
+* TOC
+{:toc}
+
+## Integration
+
+1) Compile the Digital Garage Keyword Module and Appnexus Bid Adapter into your Prebid build:  
+
+```
+gulp build --modules="dgkeywordRtdProvider,appnexusBidAdapter,..."  
+```
+
+2) Use `setConfig` to instruct Prebid.js to initilize the dgkeyword module, as specified below. 
+
+## Configuration
+
+This module is configured as part of the `realTimeData.dataProviders`  
+
+```javascript
+var DGKEYWORD_TIMEOUT = 1000;
+pbjs.setConfig({
+    realTimeData: {
+        auctionDelay: DGKEYWORD_TIMEOUT,
+        dataProviders: [{
+            name: 'dgkeyword',
+            waitForIt: true,
+            params: {
+                timeout: DGKEYWORD_TIMEOUT
+            }
+        }]
+    }
+});
+```
+
+Syntax details:
+
+{: .table .table-bordered .table-striped }
+| Name  |Type | Description   | Notes  |
+| :------------ | :------------ | :------------ |:------------ |
+| name  | String | Real time data module name | Always 'dgkeyword' |
+| waitForIt | Boolean | Should be `true` if there's an `auctionDelay` defined (optional) | `false` |
+| params  | Object |   |   |
+| params.timeout  | Integer |timeout (ms)| 1000 |
+


### PR DESCRIPTION
Thank you for merging our dgkeyword rtd module to muster.
Now I checked prebid.js download site, and I found that dgkeyword real time
sub-module can not select.
I think dgkeyword real time sub-module can use only when using gulp build.
https://docs.prebid.org/download.html

So I want to change, our dgkeyword real time sub-module can download from
the prebid.js download site.