### PR TITLE
TripeLift: Add pubCommonId to User Ids

### DIFF
--- a/dev-docs/bidders/triplelift.md
+++ b/dev-docs/bidders/triplelift.md
@@ -9,7 +9,7 @@ coppa_supported: true
 schain_supported: true
 getFloor: true
 media_types: banner, video
-userIds: criteo, identityLink, unifiedId
+userIds: criteo, identityLink, unifiedId, pubCommonId
 prebid_member: true
 safeframes_ok: true
 bidder_supports_deals: true


### PR DESCRIPTION
Added 'pubCommonId' to TripleLift Prebid.org dev docs (User IDs)
https://docs.prebid.org/dev-docs/bidders/triplelift
