### PR TITLE
Update Teads bidder doc with support for some userIds

### DIFF
--- a/dev-docs/bidders/teads.md
+++ b/dev-docs/bidders/teads.md
@@ -8,6 +8,7 @@ gdpr_supported: true
 tcf2_supported: true
 usp_supported: true
 schain_supported: true
+userIds: flocId, uid2Id
 media_types: banner, video
 ---
 


### PR DESCRIPTION
Update the Teads adapter documentation to add support for **FLoC ID** (`flocId`) and **Unified ID v2** (`uid2Id`) user ID systems.