### PR TITLE
Gnet Bid Adapter: update to Prebid 5.x and remove externalId parameter

### DIFF
--- a/dev-docs/bidders/gnet.md
+++ b/dev-docs/bidders/gnet.md
@@ -1,10 +1,9 @@
 ---
 layout: bidder
-title: gnet
+title: Gnet
 description: Prebid Gnet Bidder Adaptor
 pbjs: true
 biddercode: gnet
-pbjs_version_notes: not in 5.x
 ---
 
 ### Bid Params
@@ -13,5 +12,4 @@ pbjs_version_notes: not in 5.x
 | Name          | Scope    | Description                                | Example                             | Type     |
 |---------------|----------|--------------------------------------------|-------------------------------------|----------|
 | `websiteId`      | required | The Gnet website ID                            | `'4'`                                    | `string` |
-| `externalId`      | required | The Gnet external ID                          | `'4d52cccf30309282256012cf30309282'`     | `string` |
 


### PR DESCRIPTION
Gnet Bid Adapter: update to Prebid 5.x and remove externalId parameter