### PR TITLE
AudienceRun v1.1.0: remove adId disclosure

### DIFF
--- a/dev-docs/bidders/audiencerun.md
+++ b/dev-docs/bidders/audiencerun.md
@@ -8,11 +8,6 @@ media_types: banner
 gdpr_supported: true
 ---
 
-### Disclosure
-
-This bidder sets `adId` on the bid response and hasn't responded to the Prebid.js team to confirm uniqueness
-of this value. See [Issue 6381](https://github.com/prebid/Prebid.js/issues/6381).
-
 ### Bid Params
 
 {: .table .table-bordered .table-striped }


### PR DESCRIPTION
Hi,
Due to our last developement, `adId` is unique and is no longer set by our adapter (https://github.com/prebid/Prebid.js/issues/6381) . We can therefore remove the disclosure.

Related Prebid.js PR (https://github.com/prebid/Prebid.js/pull/6919)