### PR TITLE
Fix broken PubProvidedId example

### DIFF
--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -1385,27 +1385,27 @@ Or, the eids values can be passed directly into the `setConfig` call:
 pbjs.setConfig({
     userSync: {
         userIds: [{
-            name: "example.com",
+            name: "pubProvidedId",
             params: {
                 eids: [{
                     source: "domain.com",
-                    uids:[{
-                      id: "value read from cookie or local storage",
-                      atype: 1,
-                      ext: {
-                          stype: "ppuid"
-                      }
+                    uids: [{
+                        id: "value read from cookie or local storage",
+                        atype: 1,
+                        ext: {
+                            stype: "ppuid"
+                        }
 
-                  }]
-                },{
+                    }]
+                }, {
                     source: "3rdpartyprovided.com",
-                    uids:[{
-                      id: "value read from cookie or local storage",
-                      atype: 3,
-                      ext: {
-                          stype: "dmp"
-                      }
-                  }]
+                    uids: [{
+                        id: "value read from cookie or local storage",
+                        atype: 3,
+                        ext: {
+                            stype: "dmp"
+                        }
+                    }]
                 }]
             }
         }]


### PR DESCRIPTION
The example for specifying eids to PubProvidedId in the getConfig() was broken.  This PR fixes it