### PR TITLE
pixfuture: fixing data type, PBJS flag

### DIFF
--- a/dev-docs/bidders/pixfuture.md
+++ b/dev-docs/bidders/pixfuture.md
@@ -9,12 +9,11 @@ prebid_member: false
 coppa_supported: true
 usp_supported: true
 userIds: flocId, criteoId, unifiedId, id5Id, sharedId, identityLink, liveIntentId, fabrickId
-pbs: true
-pbjs: false
+pbs: false
+pbjs: true
 ---
 #### Bid Params
 
 | Name                | Scope    | Description                                                                                                                                                                   | Example                                               | Type             |
 |---------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|------------------|
-| `pix_id`       | required | The pix_id is an ID from PixFuture.  The `pix_id` parameter should be an`integer`                                                  | `"Abc123"`                                            | `string`         |
-
+| `pix_id`       | required | The pix_id is an ID from PixFuture.  The `pix_id` parameter should be a `string`                                                  | `"Abc123"`                                            | `string`         |


### PR DESCRIPTION
replaces #3108 

In the future, allowing us to modify your fork would make fixing conflicts like this easier.