### PR TITLE
Example to listen for click event and pass to GAM

### DIFF
--- a/dev-docs/examples/tracking-ad-clicks
+++ b/dev-docs/examples/tracking-ad-clicks
@@ -1,0 +1,17 @@
+---
+layout: example
+title: Tracking Clicks with GAM
+description: Send event to Google Ad Manager when ad is clicked on page
+sidebarType: 1
+
+
+about:
+- Listen for click event and send eevent to Google Ad Manager
+
+
+
+jsfiddle_link: 
+
+code_height: 
+
+---


### PR DESCRIPTION
Basic example that shows how to listen for a click on an ad slot and trigger an event to be sent to Google Ad Manager. (js fiddle link coming)

*related to issue https://github.com/prebid/Prebid.js/issues/6130