### PR TITLE
Add deprecated Project Limelight Bidder Adaptor

### DIFF
--- a/dev-docs/bidders/projectLimelight.md
+++ b/dev-docs/bidders/projectLimelight.md
@@ -1,0 +1,19 @@
+---
+layout: bidder
+title: Project Limelight
+description: Prebid Project Limelight Bidder Adaptor
+pbjs: true
+biddercode: project-limelight
+aliasCode: projectLimeLight
+media_types: video
+pbjs_version_notes: not in 5.x
+---
+
+### Bid Params
+
+{: .table .table-bordered .table-striped }
+| Name           | Scope      | Description                                                    | Example            |type|
+| :-----------   | :--------- | :------------                                                  | :----------------- |:---|
+| `host` | required | Ad network's RTB host | `'exchange.ortb.net'` | `string` |
+| `adUnitId` | required   | Ad Unit Id will be generated on Limelight Digital Platform. | 0                        |integer|
+| `adUnitType`      | required   | Type of Ad Unit (`'video'`, `'banner'`)                                             | `'banner'`                 |string|


### PR DESCRIPTION
Hello,

We (Limelight Digital formerly known as Project Limelight) have new Limelight Digital Bidder Adaptor in latest 5.x Prebid.js releases. Unfortunately, many of our clients continue to use 4.x Prebid.js releases and want to download Prebid.js releases from https://docs.prebid.org/download.html page with our deprecated Project Limelight Bidder Adaptor. We need add deprecated Project Limelight Bidder Adaptor on https://docs.prebid.org/download.html page.

Thanks.