### PR TITLE
adding AMX RTB ID system to downloads page

### DIFF
--- a/download.md
+++ b/download.md
@@ -216,6 +216,10 @@ Prebid.js is open source software that is offered for free as a convenience. Whi
 </div></div>
 <div class="row">  
 <div class="col-md-4"><div class="checkbox">
+<label><input type="checkbox" moduleCode="amxIdSystem" class="bidder-check-box"> AMX RTB ID</label>
+</div></div>
+<div class="row">  
+<div class="col-md-4"><div class="checkbox">
 <label><input type="checkbox" moduleCode="akamaiDAPIdSystem" class="bidder-check-box"> Akamap DAP ID</label>
 </div></div>
 <div class="col-md-4"><div class="checkbox">


### PR DESCRIPTION
Adding AMX RTB ID system to the downloads page. The module was originally added here: https://github.com/prebid/prebid.github.io/pull/3026