### PR TITLE
Apacdex, Quantumdex, Valueimpression docs update

### DIFF
--- a/dev-docs/bidders/apacdex.md
+++ b/dev-docs/bidders/apacdex.md
@@ -26,12 +26,13 @@ getFloor: true
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
-|  Name        | Scope    | Description                                                                         | Example                                           | Type     |
-|--------------|----------|-------------------------------------------------------------------------------------|---------------------------------------------------|----------|
-| `siteId`     | required | Publisher site ID from Apacdex                                                      | `'apacdex1234'`                                   | `string` |
-| `floorPrice` | optional | CPM bidfloor in USD                                                                 | `0.03`                                            | `float`  |
-| `geo`        | optional | GEO data of device. See [Geo Object](#apacdex-geo-object) for details.              | `{"lat":17.98928,"lon":99.7741712,"accuracy":20}` | `object` |
-
+|  Name         | Scope    | Description                                                                         | Example                                           | Type     |
+|---------------|----------|-------------------------------------------------------------------------------------|---------------------------------------------------|----------|
+| `placementId`*| required | Placement ID provided by Apacdex                                                    | `'plc100000'`                                     | `string` |
+| `siteId`*     | required | Publisher site ID from Apacdex                                                      | `'apacdex1234'`                                   | `string` |
+| `floorPrice`  | optional | CPM bidfloor in USD                                                                 | `0.03`                                            | `float`  |
+| `geo`         | optional | GEO data of device. See [Geo Object](#apacdex-geo-object) for details.              | `{"lat":17.98928,"lon":99.7741712,"accuracy":20}` | `object` |
+(*) Please do not use `placementId` and `siteId` at the same time.
 
 <a name="apacdex-geo-object" />
 
@@ -59,9 +60,9 @@ Publishers declare video inventory by passing the following parameters via media
 |----------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|-----------|
 | `context` | required | instream or outstream |`"outstream"` | `string` |
 | `playerSize`| required | width, height of the player in pixels | `[640,360]` - will be translated to w and h in bid request | `array<integers>` |
-| `mimes` | required | List of content MIME types supported by the player (see openRTB v2.5 for options) | `["video/mp4"]`| `array<string>`|
-| `protocols` | required | Supported video bid response protocol values <br />1: VAST 1.0 <br />2: VAST 2.0 <br />3: VAST 3.0 <br />4: VAST 1.0 Wrapper <br />5: VAST 2.0 Wrapper <br />6: VAST 3.0 Wrapper <br />7: VAST 4.0 <br />8: VAST 4.0 Wrapper | `[2,3,5,6]` | `array<integers>`|
-| `api` | required | Supported API framework values: <br />1: VPAID 1.0 <br />2: VPAID 2.0 <br />3: MRAID-1 <br />4: ORMMA <br />5: MRAID-2 | `[2]` |  `array<integers>` |
+| `mimes` | recommended | List of content MIME types supported by the player (see openRTB v2.5 for options) | `["video/mp4"]`| `array<string>`|
+| `protocols` | recommended | Supported video bid response protocol values <br />1: VAST 1.0 <br />2: VAST 2.0 <br />3: VAST 3.0 <br />4: VAST 1.0 Wrapper <br />5: VAST 2.0 Wrapper <br />6: VAST 3.0 Wrapper <br />7: VAST 4.0 <br />8: VAST 4.0 Wrapper | `[2,3,5,6]` | `array<integers>`|
+| `api` | recommended | Supported API framework values: <br />1: VPAID 1.0 <br />2: VPAID 2.0 <br />3: MRAID-1 <br />4: ORMMA <br />5: MRAID-2 | `[2]` |  `array<integers>` |
 | `maxduration` | recommended | Maximum video ad duration in seconds. | `30` | `integer` |
 | `minduration` | recommended | Minimum video ad duration in seconds | `6` | `integer` |
 | `playbackmethod` | recommended | Playback methods that may be in use. Only one method is typically used in practice. (see openRTB v2.5 section 5.10 for options)| `[2]`| `array<integers>` |


### PR DESCRIPTION
This PR updates documentation regarding the Apacdex adapter and its alias (Quantumdex, Valueimpression)

- Add placementId param updated in PR https://github.com/prebid/Prebid.js/pull/7236.
- Change from 'required' to 'recommended' for some video parameters.