### PR TITLE
Gumgum: ADJS-1059 Update prebid documentation for flex slot Placement ID

### DIFF
--- a/dev-docs/bidders/gumgum.md
+++ b/dev-docs/bidders/gumgum.md
@@ -33,6 +33,7 @@ Client side and server side parameters differ slightly. For Server side (Prebid 
 | `zone`         | required for all bid requests tracking a single domain or site   | Tracking ID           | `'ggumtest'`           | `string`  |
 | `pubId`        | required for all bid requests tracking multiple domains or sites | Publisher ID          | `123`                  | `integer` |
 | `irisid`       | optional                                                         | Iris.tv ID            | `'iris_6f9285823a4'`   | `string`  |
+| `slot`         | optional                                                         | Placement ID          | `40`                   | `number`  |
 
 ### Client Side Bid Params
 


### PR DESCRIPTION
Updates Server Side params to include the new `slot` param - a placement ID that will be used to identify flex-slot placements