### PR TITLE
Remove old data race condition test documentation

### DIFF
--- a/prebid-server/features/pbs-currency.md
+++ b/prebid-server/features/pbs-currency.md
@@ -80,7 +80,7 @@ Here are a couple examples showing the logic behind the currency converter:
 
 ## Request-Defined Conversion Rates
 
-Using PBS-Java, rates can be passed in on the request:
+With both PBS-Go and PBS-Java, custom currency conversion rates can be passed in the request:
 
 ```
 "ext": {


### PR DESCRIPTION
This PR:
- Remove old data race condition test documentation found in `prebid-server/developers/add-new-bidder-go.md`
- Document our newly added currency conversion functionality better