### PR TITLE
SmartHub adapter: fix docs displaying

### DIFF
--- a/dev-docs/bidders/smarthub.md
+++ b/dev-docs/bidders/smarthub.md
@@ -12,10 +12,11 @@ pbs: true
 pbs_app_supported: true
 ---
 
-### Prebid Server Bid Params
+### Bid Params
+
 {: .table .table-bordered .table-striped }
-| Name           | Scope    | Description                                              | Example    | Type      |
-|----------------|----------|----------------------------------------------------------|------------|-----------|
-| `partnerName` | required | Unique partner name | `'partnertest'`        | `string` |
-| `seat` | required | Seat value  | `'9Q20EdGxzgWdfPYShScl'`        | `string` |
-| `token` | required | Token  | `'eKmw6alpP3zWQhRCe3flOpz0wpuwRFjW'`        | `string` |
+| Name          | Scope    | Description         | Example                              | Type     |
+|---------------|----------|---------------------|--------------------------------------|----------|
+| `partnerName` | required | Unique partner name | `'partnertest'`                      | `string` |
+| `seat`        | required | Seat value          | `'9Q20EdGxzgWdfPYShScl'`             | `string` |
+| `token`       | required | Token               | `'eKmw6alpP3zWQhRCe3flOpz0wpuwRFjW'` | `string` |

--- a/dev-docs/bidders/smarthub.md
+++ b/dev-docs/bidders/smarthub.md
@@ -12,7 +12,7 @@ pbs: true
 pbs_app_supported: true
 ---
 
-### Bid Params
+### Prebid Server Bid Params
 
 {: .table .table-bordered .table-striped }
 | Name          | Scope    | Description         | Example                              | Type     |


### PR DESCRIPTION
Hello, production [docs for the SmartHub adapter](https://docs.prebid.org/dev-docs/pbs-bidders.html#smarthub) displays wrong now. This PR fixes displaying.

Brefore:
![image](https://user-images.githubusercontent.com/87376145/131508556-6301b3a0-da62-470c-b77e-c6f757429bb5.png)
After:
![image](https://user-images.githubusercontent.com/87376145/131508738-1f87cd8e-d6a7-4a31-ba37-bcca64b2a776.png)


