### PR TITLE
Unruly consolidated adapter - vendor id update

### DIFF
--- a/dev-docs/bidders/unruly.md
+++ b/dev-docs/bidders/unruly.md
@@ -16,7 +16,7 @@ bidder_supports_deals: check with bidder
 pbjs: true
 pbs: true
 pbs_app_supported: true
-gvl_id: 162
+gvl_id: 36
 ---
 
 ### Bid Params


### PR DESCRIPTION
Updating vendor id to the RhythmOne id since the consolidation adapter.