### PR TITLE
Add getFloor support for adyoulike bidder

### DIFF
--- a/dev-docs/bidders/adyoulike.md
+++ b/dev-docs/bidders/adyoulike.md
@@ -8,6 +8,7 @@ media_types: banner, video, native
 biddercode: adyoulike
 gdpr_supported: true
 usp_supported: true
+getFloor: true
 ---
 
 ### Note:


### PR DESCRIPTION
This page id showing "Floors Module Support: no"  for adyoulike bidder which is wrong now.
https://docs.prebid.org/dev-docs/bidders/adyoulike

I've updated the getFloor flag to 'true'. 
Will the be sufficient ? 

Thanks for any advice.