### PR TITLE
Currency Conversion and Price Granularities 

### DIFF
--- a/prebid-server/features/pbs-currency.md
+++ b/prebid-server/features/pbs-currency.md
@@ -104,3 +104,9 @@ Note that the `usepbsrates` flag allows you to define which rates to use when PB
 
 A dedicated endpoint on the Admin port will allow you to see what's happening within the currency converter.
 See [currency rates endpoint](/prebid-server/endpoints/pbs-endpoint-admin.html) for more details.
+
+## Price Granularity
+
+When converting to a currency where the typical nominal CPMs are much different than USD such as JPY or INR, use a custom price granularity that reflects the typical range of CPMs in that currency.  
+
+The predefined price granularities such as `medium` or `dense` will not be correctly scaled and thus almost every bid will end in the top bucket.  Unlike Prebid.js, Prebid Server does not support `granularityMultiplier` to scale granularities so a custom price granularity needs to be used.


### PR DESCRIPTION
Added info that custom price granularity is needed when using currencies where the nominal CPM range is greatly different than USD