### PR TITLE
Company rebranding of ConnectID from Verizon Media -> Yahoo

### DIFF
--- a/dev-docs/bidders/aol.md
+++ b/dev-docs/bidders/aol.md
@@ -7,7 +7,7 @@ biddercode: aol
 gdpr_supported: true
 usp_supported: true
 gvl_id: 25
-userIds: verizonMediaId
+userIds: ConnectID
 
 ---
 

--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -1926,52 +1926,52 @@ pbjs.setConfig({
 {% endhighlight %}
 
 
-### Verizon Media ConnectID
+### Yahoo ConnectID
 
-Verizon Media ConnectID is a person based ID and does not depend on 3rd party cookies. It enables ad tech platforms to recognize and match users consistently across the open web. Built on top of Verizon Media’s robust and proprietary ID Graph it delivers a higher find rate of audiences on publishers’ sites user targeting that respects privacy.
+Yahoo ConnectID is a person based ID and does not depend on 3rd party cookies. It enables ad tech platforms to recognize and match users consistently across the open web. Built on top of Yahoo’s robust and proprietary ID Graph it delivers a higher find rate of audiences on publishers’ sites user targeting that respects privacy.
 
-Verizon Media ConnectID honors privacy choices from the [Verizon Media Privacy Dashboard](https://www.verizonmedia.com/policies/us/en/verizonmedia/privacy/dashboard/index.html) as well as global privacy acts.
+Verizon Media ConnectID honors privacy choices from the [Yahoo Privacy Dashboard](https://legal.yahoo.com/us/en/yahoo/privacy/dashboard/index.html) as well as global privacy acts.
 
-Add support for Verizon Media ConnectID to your Prebid.js package with:
+Add support for Yahoo ConnectID to your Prebid.js package with:
 
 {: .alert.alert-info :}
-gulp build --modules=userId,verizonMediaIdSystem
+gulp build --modules=userId,connectIDIdSystem
 
-#### Verizon Media ConnectID Registration
+#### Yahoo ConnectID Registration
 
-A Verizon Media supplied publisher specific pixel Id is required. Reach out to your account manager for assistance with setup.
+A Yahoo supplied publisher specific pixel Id is required. Please reach out to your account manager for assistance with setup.
 
-#### Verizon Media ConnectID Configuration
+#### Yahoo ConnectID Configuration
 
 <div class="table-responsive" markdown="1">
 | Param under userSync.userIds[] | Scope | Type | Description | Example |
 | --- | --- | --- | --- | --- |
-| name | Required | String | The name of this module. | `'verizonMediaId'` |
+| name | Required | String | The name of this module. | `'connectID'` |
 | params | Required | Object | Container of all module params. ||
-| params.pixelId | Required | Number | The Verizon Media supplied publisher specific pixel Id  | `8976` |
+| params.pixelId | Required | Number | The Yahoo supplied publisher specific pixel Id  | `8976` |
 | params.he | Required | String | The SHA-256 hashed user email address |`'ed8ddbf5a171981db8ef938596ca297d5e3f84bcc280041c5880dba3baf9c1d4'`|
 | storage | Required | Object | Defines where and for how long the results of the call to get a user ID will be stored. | |
 | storage.type | Required | String | Defines where the resolved user ID will be stored (either `'cookie'` or `'html5'` localstorage).| `'html5'` |
-| storage.name | Required | String | The name of the cookie or html5 localstorage where the resolved user ID will be stored. | `'connectid'` |
+| storage.name | Required | String | The name of the cookie or html5 localstorage where the resolved user ID will be stored. | `'connectID'` |
 | storage.expires | Recommended | Integer | How long (in days) the user ID information will be stored. The recommended value is `15` | `15` |
 {: .table .table-bordered .table-striped }
 </div>
 
-#### Verizon Media ConnectID Examples
+#### Yahoo ConnectID Examples
 
 ```
 pbjs.setConfig({
     userSync: {
         userIds: [{
-            name: "verizonMediaId",
+            name: "connectID",
             params: {
               pixelId: 8976,
               he: "ed8ddbf5a171981db8ef938596ca297d5e3f84bcc280041c5880dba3baf9c1d4"
             },
             storage: {
               type: "html5",
-              name: "connectid",
-              expires: 1
+              name: "connectID",
+              expires: 15
             }
         }]
     }
@@ -2031,7 +2031,7 @@ Bidders that want to support the User ID module in Prebid.js, need to update the
 | SharedID (PBJS 5.x) | n/a | pubcid | pubcid.org | "1111" |
 | SharedID (PBJS 4.x)| Prebid | sharedid | sharedid.org | {"id":"01EAJWWN...", "third":"01EAJ..."} |
 | Unified ID | Trade Desk | tdid | adserver.org | "1111" |
-| Verizon Media ConnectID | Verizon Media | connectid | verizonmedia.com | "72d04af6..." |
+| ConnectID | Yahoo | connectid | yahoo.com | "72d04af6..." |
 
 For example, the adapter code might do something like:
 


### PR DESCRIPTION
Our supply platform now supports both the `verizonmedia.com` and `yahoo.com` eid source values. We do not want any new  publishers to be exposed to the old branding. I will shortly open a PR against the existing AOL bid adapter to support the `yahoo.com` eid, but we also have a new Yahoo bid adapter in PR now that will replace the aol bid adapter.