### PR TITLE
weborama RTD submodule fix typo in example conf

### DIFF
--- a/dev-docs/modules/weboramaRtdProvider.md
+++ b/dev-docs/modules/weboramaRtdProvider.md
@@ -64,7 +64,7 @@ pbjs.setConfig(
 | name | String | Real time data module name | Mandatory. Always 'Weborama' |
 | waitForIt | Boolean | Mandatory. Required to ensure that the auction is delayed until prefetch is complete | Optional. Defaults to false but recommended to true |
 | params | Object | | Optional |
-| params.weboCtxConf | Object | Weborama Contextual Configuration | Mandatory |
+| params.weboCtxConf | Object | Weborama Contextual Configuration | Optional |
 | params.weboCtxConf.token | String | Security Token provided by Weborama, unique per client | Mandatory |
 | params.weboCtxConf.targetURL | String | Url to be profiled in the contextual api | Optional. Defaults to `document.URL` |
 | params.weboCtxConf.defaultProfile | Object | default value of the profile to be used when there are no response from contextual api (such as timeout)| Optional. Default is `{}` |


### PR DESCRIPTION
I forget to include one field in the example