### PR TITLE
Fix timeout module doc missing link

### DIFF
--- a/dev-docs/add-rtd-submodule.md
+++ b/dev-docs/add-rtd-submodule.md
@@ -280,6 +280,7 @@ Once everything looks good, submit the code, tests, and markdown as a pull reque
     ---
     layout: page_v2
     title: Example Module
+    display_name: Example
     description: Useful statement for what this does
     page_type: module
     module_type: rtd

--- a/dev-docs/modules/timeoutRtdProvider.md
+++ b/dev-docs/modules/timeoutRtdProvider.md
@@ -1,6 +1,7 @@
 ---
 layout: page_v2
 title: Timeout Rtd Module
+display_name: Timeout RTD
 description: Module for managing timeouts in real time
 page_type: module
 module_type: rtd


### PR DESCRIPTION
The link for the timeout rtd module doc seems to be missing 
<img width="1102" alt="Screen Shot 2021-10-13 at 4 57 09 PM" src="https://user-images.githubusercontent.com/48766825/137228530-89cbba48-cca3-4400-883b-da67ce5cd245.png">

I think it has to do with dev-docs/modules/timeoutRtdProvider.md not having a `display_name` in its header, so I added it. I also added it to the sample header in dev-docs/add-rtd-submodule.md