### PR TITLE
Criteo: update instructions for Native and Floor module currency

### DIFF
--- a/dev-docs/bidders/criteo.md
+++ b/dev-docs/bidders/criteo.md
@@ -16,12 +16,8 @@ gvl_id: 91
 ---
 ### Notes
 {: .alert.alert-warning :}
-For Native Ads, in order to avoid further decoding issues of special characters, the assets need to be sent as placeholders. 
-That means, `sendId: true` becomes mandatory for all fields receiving URLs, notably: `icon`, `image`, `clickUrl`, `privacyLink`, `privacyIcon`.
+*Criteo currently only supports getFloor if floors are in USD and if the publisher is enabling the Criteo Publisher Tag external js call. 
 
-*Criteo currently only supports getFloor if floors are in Euros and if the publisher is enabling the Criteo Publisher Tag external js call. 
-
-See [Sending Asset Placeholders]({{site.baseurl}}/dev-docs/show-native-ads.html#sending-asset-placeholders).
 
 {: .alert.alert-warning :}
 Prebid-Server support is on alpha test and is currently a non-finished product. Activation requires setup and approval before beginning. Please reach out to your account manager or publishers@criteo.com for more details.


### PR DESCRIPTION
Removed sendid requirements since the new native solution addresses the limitations: https://docs.prebid.org/prebid/native-implementation.html 

Update on floor module currency support. 