### PR TITLE
Limelight Digital Bid Adapter: Backport latest changes to 4.43.x version branch

### DIFF
--- a/dev-docs/bidders/limelightDigital.md
+++ b/dev-docs/bidders/limelightDigital.md
@@ -5,6 +5,7 @@ description: Prebid Limelight Digital Bidder Adaptor
 pbjs: true
 biddercode: limelightDigital
 media_types: video
+pbjs_version_notes: for 4.43.5 and later
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/projectLimelight.md
+++ b/dev-docs/bidders/projectLimelight.md
@@ -6,7 +6,7 @@ pbjs: true
 biddercode: project-limelight
 aliasCode: projectLimeLight
 media_types: video
-pbjs_version_notes: not in 5.x
+pbjs_version_notes: for 4.43.4 and earlier
 ---
 
 ### Bid Params


### PR DESCRIPTION
We (Limelight Digital formerly known as Project Limelight) backported latest our changes to 4.x version. Unfortunately, many of our clients continue to use 4.x Prebid.js releases.