### PR TITLE
Yahoo ConnectID user ID module: Updated the download page

### DIFF
--- a/download.md
+++ b/download.md
@@ -336,7 +336,7 @@ These modules may require accounts with a service provider.<br/>
   <label><input type="checkbox" moduleCode="uid2IdSystem" class="bidder-check-box"> Unified ID 2</label>
   </div></div>  
   <div class="col-md-4"><div class="checkbox">
-  <label><input type="checkbox" moduleCode="verizonMediaIdSystem" class="bidder-check-box"> Verizon Media ID</label>
+  <label><input type="checkbox" moduleCode="connectIdSystem" class="bidder-check-box"> Yahoo ConnectID</label>
   </div></div>
   <div class="col-md-4"><div class="checkbox">
   <label><input type="checkbox" moduleCode="zeotapIdPlusIdSystem" class="bidder-check-box"> Zeotap ID+</label>


### PR DESCRIPTION
This change was missed in the previous changes. 

To recap: Verizon Media branding has been replaced with Yahoo branding. The newly branded user identity module is here: 

https://github.com/prebid/Prebid.js/blob/master/modules/connectIdSystem.js

Here is the previous PR for the rebranding: https://github.com/prebid/prebid.github.io/pull/3334

We would really appreciate this change going through quickly.