### PR TITLE
new bidderSettings field - allowZeroCpmBids

### DIFF
--- a/dev-docs/publisher-api-reference/bidderSettings.md
+++ b/dev-docs/publisher-api-reference/bidderSettings.md
@@ -43,6 +43,7 @@ Some sample scenarios where publishers may wish to alter the default settings:
 | bidCpmAdjustment | standard or adapter-specific | all | n/a | Could, for example, adjust a bidder's gross-price bid to net price. |
 | sendStandardTargeting | adapter-specific | 0.13.0 | true | If adapter-specific targeting is specified, can be used to suppress the standard targeting for that adapter. |
 | suppressEmptyKeys | standard or adapter-specific | 0.13.0 | false | If custom adserverTargeting functions are specified that may generate empty keys, this can be used to suppress them. |
+| allowZeroCpmBids | standard of adapter-specific | 6.2.0 | false | Would allow bids with a 0 CPM to be accepted by Prebid.js and could be passed to the ad server. |
 
 ##### 2.1. adserverTargeting
 
@@ -217,5 +218,11 @@ See the [example above](#key-targeting-specific-bidder) for example usage.
 ##### 2.4. suppressEmptyKeys
 
 If a custom adServerTargeting function can return an empty value, this boolean flag can be used to avoid sending those empty values to the ad server.
+
+##### 2.5. allowZeroCpmBids
+
+By default, 0 CPM bids are ignored by Prebid.js entirely.  However if there's a valid business reason to allow these bids, this setting can be enabled to allow
+either specific bid adapter(s) or all bid adapters the permission for these bids to be processed by Prebid.js and potentially sent to the respective ad server 
+(depending on the Prebid.js auction results).
 
 <hr class="full-rule" />


### PR DESCRIPTION
Adds documentation for the new bidderSettings field `allowZeroCpmBids`.

Related Prebid.js PR: https://github.com/prebid/Prebid.js/pull/7633