### PR TITLE
Algorix: add Server Region Support

### DIFF
--- a/dev-docs/bidders/algorix.md
+++ b/dev-docs/bidders/algorix.md
@@ -28,7 +28,9 @@ AlgoriX adapter requires setup and approval from the AlgoriX team, even for exis
 | `token`       | required | Token         | `'028bca2d3b5c4f0ba155fa34864b0c4d'` | `string` |
 | `placementId` | optional | Placement Id  | `'123456'`                           | `string` |
 | `appId`       | optional | App Id        | `'asdasdasd'`                        | `string` |
+| `region`      | optional | Server Region | `'APAC' or 'USE'`                    | `string` |
 
 Note:
 * Prebid Server adapter only checks for and uses first imp bid params. All other imp bid params are ignored.
 * placementId and appId will be generated on AlgoriX Platform.
+* region is optional param, which determine the AlgoriX server. APAC for SG endpoint, USE for US endpoint, Other for Global endpoint.


### PR DESCRIPTION
Add Server Region Support:
* add region in ext.bidder: APAC for request to SG EP, USE for request to US EP, other for request to Global EP

PBS-Go: https://github.com/prebid/prebid-server/pull/2096
PBS-Java: https://github.com/prebid/prebid-server-java/pull/1598