### PR TITLE
Update Apacdex, Quantumdex, Valueimpression docs

### DIFF
--- a/dev-docs/bidders/apacdex.md
+++ b/dev-docs/bidders/apacdex.md
@@ -10,6 +10,8 @@ schain_supported: true
 usp_supported: true
 userIds: all
 floors_supported: true
+pbs: true
+pbs_app_supported: true
 ---
 
 ### Table of Contents

--- a/dev-docs/bidders/quantumdex.md
+++ b/dev-docs/bidders/quantumdex.md
@@ -11,6 +11,8 @@ schain_supported: true
 usp_supported: true
 userIds: all
 floors_supported: true
+pbs: true
+pbs_app_supported: true
 ---
 
 # Description

--- a/dev-docs/bidders/valueimpression.md
+++ b/dev-docs/bidders/valueimpression.md
@@ -12,6 +12,7 @@ usp_supported: true
 userIds: all
 floors_supported: true
 pbs: true
+pbs_app_supported: true
 ---
 
 # Description


### PR DESCRIPTION
As mentioned in PR https://github.com/prebid/prebid-server/pull/2097, we currently support bidding via PBS.
This PR updates documentation regarding the Apacdex adapter and its alias (Quantumdex, Valueimpression) to update this to the documentation page.