### PR TITLE
Mobile: fix the pod's names

### DIFF
--- a/prebid-mobile/modules/rendering/ios-sdk-Integration.md
+++ b/prebid-mobile/modules/rendering/ios-sdk-Integration.md
@@ -41,10 +41,10 @@ If you need to integrate Prebid with GAM or MoPub add these pods respectively
 
 ```
 # + Google Ad Manager (optional)
-pod 'PrebidMobile/GAMEventHandlers', '1.13.0-beta1'
+pod 'PrebidMobileGAMEventHandlers', '1.13.0-beta1'
 
 # + MoPub (optional)
-pod 'PrebidMobile/MoPubAdapters', '1.13.0-beta1'
+pod 'PrebidMobileMoPubAdapters', '1.13.0-beta1'
 ```
 
 


### PR DESCRIPTION
Use the actual pod names instead of old ones in the docs