### PR TITLE
Prebid Publisher API: update setBidderConfig, mergeConfig, mergeBidderConfig

### DIFF
--- a/dev-docs/publisher-api-reference/mergeBidderConfig.md
+++ b/dev-docs/publisher-api-reference/mergeBidderConfig.md
@@ -1,0 +1,20 @@
+---
+layout: api_prebidjs
+title: pbjs.mergeBidderConfig(options)
+description:
+---
+
+This is the same as [`setBidderConfig(options, true)`](/dev-docs/publisher-api-reference/setBidderConfig.html) -- it merges the supplied bidder config into the config structure rather than replacing it.
+
+The page usage is:
+
+{% highlight js %}
+pbjs.mergeBidderConfig({
+   bidders: ['bidderA'],
+   config: {
+      customArg: "customVal"
+   }
+});
+{% endhighlight %}
+
+Intrepration: When 'bidderA' calls `getConfig('customArg')`, it will receive the object that contains 'customArg'. If any other bidder calls `getConfig('customArg')`, it will receive nothing.

--- a/dev-docs/publisher-api-reference/mergeConfig.md
+++ b/dev-docs/publisher-api-reference/mergeConfig.md
@@ -6,5 +6,5 @@ description:
 
 This is the same as [`setConfig(options)`](/dev-docs/publisher-api-reference/setConfig.html) except that it merges the supplied config into the structure rather than replacing it.
 
-This is a convenience function for real time data modules so they don't have to read the
+This is a convenience function, particularly useful to real time data modules, so one doesn't have to read the
 config structure, update it, then call setConfig.

--- a/dev-docs/publisher-api-reference/mergeConfig.md
+++ b/dev-docs/publisher-api-reference/mergeConfig.md
@@ -1,0 +1,10 @@
+---
+layout: api_prebidjs
+title: pbjs.mergeConfig(options)
+description:
+---
+
+This is the same as [`setConfig(options)`](/dev-docs/publisher-api-reference/setConfig.html) except that it merges the supplied config into the structure rather than replacing it.
+
+This is a convenience function for real time data modules so they don't have to read the
+config structure, update it, then call setConfig.

--- a/dev-docs/publisher-api-reference/setBidderConfig.md
+++ b/dev-docs/publisher-api-reference/setBidderConfig.md
@@ -1,6 +1,6 @@
 ---
 layout: api_prebidjs
-title: pbjs.setBidderConfig(options, mergeFlag: false)
+title: pbjs.setBidderConfig(options, mergeFlag)
 description:
 ---
 
@@ -12,7 +12,7 @@ globally available to all bidder adapters. This makes sense because
 most of these settings are global in nature. However, there are use cases where different bidders require different data, or where certain parameters apply only to a given
 bidder. Use `setBidderConfig` when you need to support these cases.
 
-Note if you would like to add to existing config you can pass in `true` for the second argument like `setBidderConfig(options, true)`. If not passed or true this argument defaults to false and `setBidderConfig` functions as above.
+Note if you would like to add to existing config you can pass `true` for the optional second `mergeFlag` argument like `setBidderConfig(options, true)`. If not passed, this argument defaults to false and `setBidderConfig` replaces all values for specified bidders.
 
 The page usage is:
 

--- a/dev-docs/publisher-api-reference/setBidderConfig.md
+++ b/dev-docs/publisher-api-reference/setBidderConfig.md
@@ -1,6 +1,6 @@
 ---
 layout: api_prebidjs
-title: pbjs.setBidderConfig(options)
+title: pbjs.setBidderConfig(options, mergeFlag: false)
 description:
 ---
 
@@ -11,6 +11,8 @@ Configuration provided through the [`setConfig`](/dev-docs/publisher-api-referen
 globally available to all bidder adapters. This makes sense because
 most of these settings are global in nature. However, there are use cases where different bidders require different data, or where certain parameters apply only to a given
 bidder. Use `setBidderConfig` when you need to support these cases.
+
+Note if you would like to add to existing config you can pass in `true` for the second argument like `setBidderConfig(options, true)`. If not passed or true this argument defaults to false and `setBidderConfig` functions as above.
 
 The page usage is:
 

--- a/dev-docs/publisher-api-reference/setConfig.md
+++ b/dev-docs/publisher-api-reference/setConfig.md
@@ -5,7 +5,9 @@ description:
 ---
 
 
-`setConfig` supports a number of advanced configuration options:
+`setConfig` supports a number of configuration options. Every
+call to setConfig overwrites supplied values at the top level. e.g. if `ortb2` is provided as a value, any previously-supplied `ortb2` values will disappear.
+If this is not the desired behavior, there is a [`mergeConfig()`](mergeConfig.html) function that will preserve previous values to do not conflict with the newly supplied values.
 
 See below for usage examples.
 


### PR DESCRIPTION
New mergeConfig feature updates `setBidderConfig` now to include a second argument that defaults to false and sets bidder config normally. If the argument is set to true the config is added. Supporting pr for new feature here. -> https://github.com/prebid/Prebid.js/pull/7396