### PR TITLE
MediaNet adapter: Adding MediaNet into Prebid server bidder list

### DIFF
--- a/dev-docs/bidders/medianet.md
+++ b/dev-docs/bidders/medianet.md
@@ -13,6 +13,7 @@ gvl_id: 142
 schain_supported: true
 floors_supported: true
 fpd_supported: true
+pbs: true
 ---
 
 ### Bid Params


### PR DESCRIPTION
Adding MediaNet into the Prebid server bidder list.
[PR Link](https://github.com/prebid/prebid-server-java/pull/1378)