### PR TITLE
Conversant adapter now supports FPD options through ortb2 and ortb2Imp

### DIFF
--- a/dev-docs/bidders/conversant.md
+++ b/dev-docs/bidders/conversant.md
@@ -74,3 +74,57 @@ The following values are defined in the [ORTB 2.5 spec](https://www.iab.com/wp-c
 + `8` : VAST 4.0 Wrapper
 + `9` : DAAST 1.0
 + `10` : DAAST 1.0 Wrapper
+
+### First Party Data
+Publishers should use the `ortb2` method of setting for setting First Party Data.
+Example first party data configuration that is available to all adUnits
+```
+pbjs.setConfig({
+    debug: true,
+    cache: {
+    url: 'https://prebid.adnxs.com/pbc/v1/cache'
+    },
+    ortb2: { 
+        site: { 
+            content: { 
+                series: 'MySeries', 
+                season: 'My Season', 
+                episode: 3, 
+                title: 'My Title' 
+            } 
+        } 
+    }
+});
+``` 
+
+Example AdUnit specific data using the `ortb2Imp` object
+```
+        var videoAdUnit = {
+            code: 'video1',
+            mediaTypes: {
+                video: {
+                    playerSize: [[640, 480]]
+                }
+            },
+            ortb2Imp: {
+                instl: 1,
+                ext: {
+                    data: {
+                        adUnitSpecificAttribute: "123"
+                    }
+                }
+            },
+            bids: [{
+                bidder: 'conversant',
+                params: {
+                    site_id: '108060',
+                    mimes: ['video/mp4', 'video/webm']
+                }
+            }]
+        }
+
+        pbjs.que.push(function(){
+            pbjs.addAdUnits(videoAdUnits);
+        }
+```
+


### PR DESCRIPTION
Update to add support for first party data and examples.  
The PR for the adapter update is https://github.com/prebid/Prebid.js/pull/7966