### PR TITLE
deprecating somoaudience

### DIFF
--- a/dev-docs/bidders/somoaudience.md
+++ b/dev-docs/bidders/somoaudience.md
@@ -4,9 +4,9 @@ title: Somo Audience
 description: Somo Audience Bidder Adapter
 biddercode: somoaudience
 media_types: banner, native, video
-pbs: true
+pbs: false
 enable_download: false
-pbjs_version_notes: not ported to 5.x
+pbs_version_notes: they've pulled their PBS adapter
 ---
 
 


### PR DESCRIPTION
As noted in https://github.com/prebid/prebid-server/issues/2152, somoaudience no longer supports their server-side adapter