### PR TITLE
Update prebid.js CDN URLs to use jsDelivr

### DIFF
--- a/_includes/video/head.html
+++ b/_includes/video/head.html
@@ -5,7 +5,7 @@
 {% include head--common.html %}
 
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
     <script type="text/javascript" src="//services.brid.tv/player/build/brid.min.js"></script>
 
     <script type="text/javascript">

--- a/_includes/video/pb-cp-fp.html
+++ b/_includes/video/pb-cp-fp.html
@@ -4,7 +4,7 @@
 <head>
     {% include head--common.html %}
     <!--production version of prebid.js-->
-    <!--<script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>-->
+    <!--<script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>-->
 
     <!--flowplayer & prebid js code-->
     <link rel="stylesheet" href="//cdn.flowplayer.com/releases/native/stable/style/flowplayer.css">

--- a/_includes/video/pb-cp-jw.html
+++ b/_includes/video/pb-cp-jw.html
@@ -2,10 +2,10 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <!--<script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>-->
-    
+    <!--<script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>-->
+
     <!--jwplayer & prebid js code-->
     <script type="text/javascript">
 		var options = {
@@ -50,9 +50,9 @@
 		function doHeaderBidding() {
 		  window.prebidPluginCP.doPrebid(options);
 		}
-		  
+
 	</script>
-	<script src="//acdn.adnxs.com/video/plugins/cp/PrebidPluginCP.min.js" onload="doHeaderBidding()"></script>  
+	<script src="//acdn.adnxs.com/video/plugins/cp/PrebidPluginCP.min.js" onload="doHeaderBidding()"></script>
 </head>
 
 <body>

--- a/_includes/video/pb-cp-kl.html
+++ b/_includes/video/pb-cp-kl.html
@@ -2,11 +2,11 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
-    
+{% include head--common.html %}
+
     <!--production version of prebid.js-->
-    <!--<script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>-->
-    
+    <!--<script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>-->
+
     <!--kaltura & prebid js code-->
     <script type="text/javascript">
 		var options = {
@@ -51,9 +51,9 @@
 		function doHeaderBidding() {
 		  window.prebidPluginCP.doPrebid(options);
 		}
-		  
+
 	</script>
-	<script src="//acdn.adnxs.com/video/plugins/cp/PrebidPluginCP.min.js" onload="doHeaderBidding()"></script> 
+	<script src="//acdn.adnxs.com/video/plugins/cp/PrebidPluginCP.min.js" onload="doHeaderBidding()"></script>
 </head>
 
 <body>

--- a/_includes/video/pb-cp-vjs.html
+++ b/_includes/video/pb-cp-vjs.html
@@ -2,10 +2,10 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <!--<script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>-->
-    
+    <!--<script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>-->
+
     <!--videojs & prebid js code-->
     <!-- use recent version of videojs to ensure proper functioning with the iOS devices -->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/video.js/6.4.0/video-js.css">
@@ -13,7 +13,7 @@
 	<!-- videojs-vast-vpaid -->
 	<link href="https://cdnjs.cloudflare.com/ajax/libs/videojs-vast-vpaid/2.0.2/videojs.vast.vpaid.min.css" rel="stylesheet">
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/videojs-vast-vpaid/2.0.2/videojs_5.vast.vpaid.min.js"></script>
-	
+
 	<script type="text/javascript">
 	  var options = {
 	    biddersSpec: {
@@ -57,7 +57,7 @@
 	  function doHeaderBidding() {
 	    window.prebidPluginCP.doPrebid(options);
 	  }
-	    
+
 	</script>
 	<script src="//acdn.adnxs.com/video/plugins/cp/PrebidPluginCP.min.js" onload="doHeaderBidding()"></script>
 </head>

--- a/_includes/video/pb-cp.html
+++ b/_includes/video/pb-cp.html
@@ -2,10 +2,10 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
     <!--brightcove & prebid js code-->
     <script>
 		var pbjs = pbjs || {};
@@ -43,7 +43,7 @@
 			bids: [{
 				bidder: 'appnexus',
 				params: {
-					placementId: iosDevice ? 13239390 : 13232361, // Add your own placement id here. Note, skippable video is not supported on iOS 
+					placementId: iosDevice ? 13239390 : 13232361, // Add your own placement id here. Note, skippable video is not supported on iOS
 					video: {
 						skipppable: true,
 						playback_method: ['auto_play_sound_off']
@@ -79,7 +79,7 @@
 		});
 
 	</script>
-    
+
 </head>
 
 <body>

--- a/_includes/video/pb-is-amp.html
+++ b/_includes/video/pb-is-amp.html
@@ -4,7 +4,7 @@
 <head>
 {% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
     <script type="text/javascript" src="https://amp.akamaized.net/hosted/1.1/player.esi?apikey=prebid.org.samples"></script>
 
     <script type="text/javascript">

--- a/_includes/video/pb-is-app.html
+++ b/_includes/video/pb-is-app.html
@@ -4,7 +4,7 @@
 <head>
 {% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
 
     <!--Ad Player Pro & prebid js code-->
     <script type="text/javascript" src="https://static.adplayer.pro/player/demo.js"></script>

--- a/_includes/video/pb-is-bc.html
+++ b/_includes/video/pb-is-bc.html
@@ -2,10 +2,10 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
     <!--flowplayer & prebid js code-->
     <script>
 		var pbjs = pbjs || {};
@@ -79,7 +79,7 @@
 		});
 
 	</script>
-    
+
 </head>
 
 <body>

--- a/_includes/video/pb-is-br.html
+++ b/_includes/video/pb-is-br.html
@@ -2,28 +2,28 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
     <!--brid & prebid js code-->
-    <script type="text/javascript" src="//services.brid.tv/player/build/brid.min.js"></script>  	
-    
+    <script type="text/javascript" src="//services.brid.tv/player/build/brid.min.js"></script>
+
     <script type="text/javascript">
-    	
+
 		var pbjs = pbjs || {};
 		pbjs.que = pbjs.que || [];
-		
+
 		// define invokeVideoPlayer in advance in case we get the bids back from prebid before the entire page loads
 		var tempTag = false;
 		var invokeVideoPlayer = function(url){
 		  tempTag = url;
 		}
-		
+
 		/*
 		Prebid Video adUnit
 		*/
-		
+
 		var videoAdUnit = {
 		  code: 'video1',
 		  sizes: [640,480],
@@ -46,17 +46,17 @@
 		    }
 		  ]
 		};
-		
+
 		pbjs.que.push(function(){
 		  pbjs.addAdUnits(videoAdUnit); // add your ad units to the bid request
-		
-		  pbjs.setConfig({ 
+
+		  pbjs.setConfig({
 		    usePrebidCache: true,
 				cache: {
 					url: 'https://prebid.adnxs.com/pbc/v1/cache'
-				} 
+				}
 		  });
-		
+
 		  pbjs.requestBids({
 		      bidsBackHandler: function(bids) {
 		          var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
@@ -74,7 +74,7 @@
 		      }
 		  });
 		});
-		
+
 		pbjs.bidderSettings =
 		{
 		    standard: {
@@ -98,15 +98,15 @@
 		                key: "hb_size",
 		                val: function (bidResponse) {
 		                    return bidResponse.size;
-		
+
 		                }
 		            }
 		        ]
 		    }
 		};
-			     
+
 	</script>
-    
+
 </head>
 
 <body>

--- a/_includes/video/pb-is-fp.html
+++ b/_includes/video/pb-is-fp.html
@@ -2,32 +2,32 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
-    <!--pbjs and player code -->	
-    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+    <!--pbjs and player code -->
+
     <link rel="stylesheet" href="//cdn.flowplayer.com/releases/native/stable/style/flowplayer.css">
     <script src="//cdn.flowplayer.com/releases/native/stable/flowplayer.min.js"></script>
     <script src="//cdn.flowplayer.com/releases/native/stable/plugins/ads.min.js"></script>
     <script src="//imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
-    
+
     <style>
 	        #player {
 	            max-width: 40em;
 	            width: 100%;
 	            float: left;
 	        }
-	
+
 	        #controls {
 	            float: left;
 	            padding: 1em;
 	        }
 	    </style>
-	    
+
     <script type="text/javascript">
-	    
+
       var pbjs = pbjs || {};
       pbjs.que = pbjs.que || [];
 
@@ -100,9 +100,9 @@
           }
         });
       });
-			     
+
 	</script>
-    
+
 </head>
 
 <body>

--- a/_includes/video/pb-is-jw01.html
+++ b/_includes/video/pb-is-jw01.html
@@ -2,24 +2,24 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
-    <!--pbjs and player code -->	
-    
-    	    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+    <!--pbjs and player code -->
+
+
     <script type="text/javascript">
-	    
+
       	var pbjs = pbjs || {};
 	    pbjs.que = pbjs.que || [];
-	
+
 	    // define invokeVideoPlayer in advance in case we get the bids back from prebid before the entire page loads
 	    var tempTag = false;
 	    var invokeVideoPlayer = function(url) {
 	        tempTag = url;
 	    }
-	
+
 	    var videoAdUnit = {
 	        code: 'video1',
 	        mediaTypes: {
@@ -39,17 +39,17 @@
 	            }
 	        }]
 	    };
-	
+
 	    pbjs.que.push(function() {
 	        pbjs.addAdUnits(videoAdUnit); // add your ad units to the bid request
-	
+
 	        pbjs.setConfig({
 	            debug: true,
 	            cache: {
 	                url: 'https://prebid.adnxs.com/pbc/v1/cache'
 	            }
 	        });
-	
+
 	        pbjs.requestBids({
 	            bidsBackHandler: function(bids) {
 	                var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
@@ -66,9 +66,9 @@
 	                invokeVideoPlayer(videoUrl);
 	            }
 	        });
-	    });			     
+	    });
 	</script>
-    
+
 </head>
 
 <body>

--- a/_includes/video/pb-is-jw02.html
+++ b/_includes/video/pb-is-jw02.html
@@ -2,28 +2,28 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
-    <!--pbjs and player code -->	
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+    <!--pbjs and player code -->
     <script type="text/javascript" src="https://ssl.p.jwpcdn.com/player/v/8.0.5/jwplayer.js"></script>
 	<script type="text/javascript">
 	 jwplayer.key = "ssbF6k0i9BPe87xfG/s0ipdp5gwbLoZaDON/GQvuwPU9nVJy"; //Test Key - replace this with your own valid JWPlayer license key
 	</script>
 
-    	    
+
     <script type="text/javascript">
-	    
+
       	var pbjs = pbjs || {};
 	    pbjs.que = pbjs.que || [];
-	
+
 	    // define invokeVideoPlayer in advance in case we get the bids back from prebid before the entire page loads
 	    var tempTag = false;
 	    var invokeVideoPlayer = function(url) {
 	        tempTag = url;
 	    }
-	
+
 	    var videoAdUnit = {
 	        code: 'video1',
 	        mediaTypes: {
@@ -43,7 +43,7 @@
 	            }
 	        }]
 	    };
-	
+
 	    pbjs.que.push(function() {
 	        pbjs.addAdUnits(videoAdUnit); // add your ad units to the bid request
 	        pbjs.setConfig({
@@ -52,7 +52,7 @@
 	                url: 'https://prebid.adnxs.com/pbc/v1/cache'
 	            }
 	        });
-	
+
 	        pbjs.requestBids({
 	            bidsBackHandler: function(bids) {
 	                var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
@@ -71,7 +71,7 @@
 	        });
 	    });
 	</script>
-    
+
 </head>
 
 <body>

--- a/_includes/video/pb-is-kl.html
+++ b/_includes/video/pb-is-kl.html
@@ -2,42 +2,42 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
-    <!--pbjs and player code -->	
-    	    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+    <!--pbjs and player code -->
+
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/video.js/6.4.0/video-js.css">
 	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/video.js/6.4.0/video.js"></script>
 	<!-- videojs-vast-vpaid -->
 	<link href="https://cdnjs.cloudflare.com/ajax/libs/videojs-vast-vpaid/2.0.2/videojs.vast.vpaid.min.css" rel="stylesheet">
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/videojs-vast-vpaid/2.0.2/videojs_5.vast.vpaid.min.js"></script>
-	
+
 	<script>
 	    var pbjs = pbjs || {};
 	    pbjs.que = pbjs.que || [];
-	
+
 	    /* PRE-DEFINE `invokeVideoPlayer`
-	
+
 	    Because we have no way of knowing when all the bids will be
 	    returned from Prebid we can't be sure that the browser will
 	    reach the point where `invokeVideoPlayer` is defined before
 	    `bidsBackHandler` fires and tries to call it.
-	
+
 	    To prevent an "`invokeVideoPlayer` not defined" error, we
 	    pre-define it before we make the call to Prebid, and redefine
 	    it later on with the code to create the player and play the
 	    ad.
-	
+
 	    In this first version it simply stores the winning VAST to use
 	    later. */
-	
+
 	    var tempTag = false;
 	    var invokeVideoPlayer = function(url) {
 	        tempTag = url;
 	    }
-	
+
 	    var videoAdUnit = {
 	        code: 'video1',
 	        mediaTypes: {
@@ -57,17 +57,17 @@
 	            }
 	        }]
 	    };
-	
+
 	    pbjs.que.push(function() {
 	        pbjs.addAdUnits(videoAdUnit); // add your ad units to the bid request
-	
+
 	        pbjs.setConfig({
 	            debug: true,
 	            cache: {
 	                url: 'https://prebid.adnxs.com/pbc/v1/cache'
 	            }
 	        });
-	
+
 	        pbjs.requestBids({
 	            bidsBackHandler: function(bids) {
 	                var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
@@ -85,9 +85,9 @@
 	            }
 	        });
 	    });
-	
+
 	</script>
-    
+
 </head>
 
 <body>

--- a/_includes/video/pb-is-ol.html
+++ b/_includes/video/pb-is-ol.html
@@ -2,12 +2,12 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
-    <!--pbjs and player code -->	
-    	    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+    <!--pbjs and player code -->
+
 	<!-- LOAD OOYALA PLUGINS
 
      Load the Ooyala player scripts you plan to use.
@@ -115,8 +115,8 @@
             });
         });
 
-    </script>      
-    
+    </script>
+
 </head>
 
 <body>

--- a/_includes/video/pb-is-rd.html
+++ b/_includes/video/pb-is-rd.html
@@ -2,13 +2,13 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
     <!-- Radiant Media Player core library - debug browser console mode (use rmp.min.js for production) -->
 	<script src="https://cdn.radiantmediatechs.com/rmp/5.5.6/js/rmp.debug.js"></script>
-	
+
 </head>
 
 <body>

--- a/_includes/video/pb-is-vjs.html
+++ b/_includes/video/pb-is-vjs.html
@@ -2,12 +2,12 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
-    <!--pbjs and player code -->	
-    	    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+    <!--pbjs and player code -->
+
 	<!-- use recent version of videojs to ensure proper functioning with the iOS devices -->
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/video.js/6.4.0/video-js.css">
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/video.js/6.4.0/video.js"></script>
@@ -70,8 +70,8 @@
                 });
             });
 
-        </script>    
-    
+        </script>
+
 </head>
 
 <body>

--- a/_includes/video/pb-lf-fw.html
+++ b/_includes/video/pb-lf-fw.html
@@ -2,12 +2,12 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
-    <!--pbjs and player code -->	
-    	    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+    <!--pbjs and player code -->
+
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
     <link rel="stylesheet" type="text/css" href="//netdna.bootstrapcdn.com/font-awesome/3.0.2/css/font-awesome.css"/>
     <script type="text/javascript" src="https://mssl.fwmrm.net/libs/adm/6.24.0/AdManager-debug.js"></script>
@@ -16,10 +16,10 @@
     <link rel="stylesheet" href="https://jqueryui.com/resources/demos/style.css">
     <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
-    
+
     <!--style specific to the long-form demo-->
 	<style type="text/css">
-	
+
     	#videoPlayer {
     		height: 480px;
     		width: 100%;
@@ -54,12 +54,12 @@
 	        left: 20px;
 	        top: 20px;
 	      }
-	      
+
     </style>
 
-    
+
 	<script>
-      
+
       var pbjs = pbjs || {};
       pbjs.que = pbjs.que || [];
 
@@ -87,7 +87,7 @@
 
       pbjs.que.push(function(){
         pbjs.addAdUnits(videoAdUnit);
-        pbjs.setConfig({ 
+        pbjs.setConfig({
           debug: true,
           cache: {
             url: 'https://prebid.adnxs.com/pbc/v1/cache'
@@ -115,7 +115,7 @@
         });
       });
     </script>
-    
+
     <script type="text/javascript">
     $(function() {
       $("#tabs").tabs();
@@ -146,7 +146,7 @@
           }
         }
         return industry;
-      } 
+      }
     }
 
     function loadKv(targetingArr) {
@@ -158,7 +158,7 @@
             html += '<tr id='+targeting[key]+'><td>'+key+'</td><td>'+targeting[key]+'</td></tr>'
           });
         });
-      });  
+      });
       html += '</tbody></table>';
       div.innerHTML = html;
     }
@@ -184,7 +184,7 @@
             }
           });
         });
-      });  
+      });
       html += '</tbody></table>';
       div.innerHTML = html;
     }
@@ -277,7 +277,7 @@
         comBreak++;
       }
     }
-    
+
     function skipAd() {
       clearInterval(timerId);
       if (!adCount) {
@@ -289,7 +289,7 @@
         adCount--;
       }
     }
-    </script>    
+    </script>
 </head>
 
 <body>

--- a/_includes/video/pb-os-app.html
+++ b/_includes/video/pb-os-app.html
@@ -5,7 +5,7 @@
 {% include head--common.html %}
     <!--production version of prebid.js-->
     <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
-    <script async src="https://acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
+    <script async src="https://cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
 
     <!--AdPlayer.Pro code-->
     <script src="https://static.adplayer.pro/player/demo.js"></script>

--- a/_includes/video/pb-os-dfp.html
+++ b/_includes/video/pb-os-dfp.html
@@ -2,13 +2,13 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
     <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
-    <!--pbjs and player code -->	
-    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+    <!--pbjs and player code -->
+
 	<script>
 
             var pbjs = pbjs || {};

--- a/_includes/video/pb-os-nas.html
+++ b/_includes/video/pb-os-nas.html
@@ -2,17 +2,17 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
     <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
-    <!--pbjs and player code -->	
-    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+    <!--pbjs and player code -->
+
 	<script>
 	    var pbjs = pbjs || {};
 	    pbjs.que = pbjs.que || [];
-	
+
 	    var adUnits = [{
 	        code: 'video1',
 	        mediaTypes: {
@@ -45,7 +45,7 @@
         });
 
     </script>
-    
+
 </head>
 
 <body>

--- a/_includes/video/pb-os-rd.html
+++ b/_includes/video/pb-os-rd.html
@@ -2,11 +2,11 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
     <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
-    <script async src="https://acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
+    <script async src="https://cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
     <!--radiant code-->
 	<script src="https://cdn.radiantmediatechs.com/rmp/5.5.6/js/rmp.debug.js"></script>
 </head>

--- a/_includes/video/pb-ve-lf-fw.html
+++ b/_includes/video/pb-ve-lf-fw.html
@@ -2,13 +2,13 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/1/prebid.js"></script>
-    
-        
-    <!--pbjs and player code and 3rd party js & css -->	
-    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+
+    <!--pbjs and player code and 3rd party js & css -->
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
     <link rel="stylesheet" type="text/css" href="//netdna.bootstrapcdn.com/font-awesome/3.0.2/css/font-awesome.css"/>
     <script type="text/javascript" src="https://mssl.fwmrm.net/libs/adm/6.24.0/AdManager-debug.js"></script>
@@ -17,10 +17,10 @@
     <link rel="stylesheet" href="https://jqueryui.com/resources/demos/style.css">
     <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
-    
+
     <!--style specific to the long-form demo-->
 	<style type="text/css">
-	
+
     	#videoPlayer {
     		height: 480px;
     		width: 100%;
@@ -55,12 +55,12 @@
 	        left: 20px;
 	        top: 20px;
 	      }
-	      
+
     </style>
 
-    
+
 	<script>
-      
+
       var pbjs = pbjs || {};
       pbjs.que = pbjs.que || [];
 
@@ -88,7 +88,7 @@
 
       pbjs.que.push(function(){
         pbjs.addAdUnits(videoAdUnit);
-        pbjs.setConfig({ 
+        pbjs.setConfig({
           debug: true,
           cache: {
             url: 'https://prebid.adnxs.com/pbc/v1/cache'
@@ -116,7 +116,7 @@
         });
       });
     </script>
-    
+
     <script type="text/javascript">
     $(function() {
       $("#tabs").tabs();
@@ -147,7 +147,7 @@
           }
         }
         return industry;
-      } 
+      }
     }
 
     function loadKv(targetingArr) {
@@ -159,7 +159,7 @@
             html += '<tr id='+targeting[key]+'><td>'+key+'</td><td>'+targeting[key]+'</td></tr>'
           });
         });
-      });  
+      });
       html += '</tbody></table>';
       div.innerHTML = html;
     }
@@ -185,7 +185,7 @@
             }
           });
         });
-      });  
+      });
       html += '</tbody></table>';
       div.innerHTML = html;
     }
@@ -278,7 +278,7 @@
         comBreak++;
       }
     }
-    
+
     function skipAd() {
       clearInterval(timerId);
       if (!adCount) {

--- a/_includes/video/pbs-br.html
+++ b/_includes/video/pbs-br.html
@@ -2,12 +2,12 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
-    <!--pbjs and player code -->	
-    	    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+    <!--pbjs and player code -->
+
 	<script type="text/javascript" src="//services.brid.tv/player/build/brid.min.js"></script>
     <script>
         var pbjs = pbjs || {};
@@ -94,7 +94,7 @@
             });
         });
 
-    </script>    
+    </script>
 </head>
 
 <body>

--- a/_includes/video/pbs-jw01.html
+++ b/_includes/video/pbs-jw01.html
@@ -2,9 +2,9 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
     <script>
             var pbjs = pbjs || {};
             pbjs.que = pbjs.que || [];

--- a/_includes/video/pbs-jw02.html
+++ b/_includes/video/pbs-jw02.html
@@ -2,12 +2,12 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
-    <!--pbjs and player code -->	
-    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+    <!--pbjs and player code -->
+
     <script type="text/javascript" src="https://ssl.p.jwpcdn.com/player/v/8.0.5/jwplayer.js"></script>
         <script type="text/javascript">
             jwplayer.key = "ssbF6k0i9BPe87xfG/s0ipdp5gwbLoZaDON/GQvuwPU9nVJy"; //Test Key - replace this with your own valid JWPlayer license key
@@ -99,7 +99,7 @@
             });
 
         </script>
-        
+
 </head>
 
 <body>

--- a/_includes/video/pbs-kl.html
+++ b/_includes/video/pbs-kl.html
@@ -2,12 +2,12 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
-    <!--pbjs and player code -->	
-    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+    <!--pbjs and player code -->
+
 	<script>
         var pbjs = pbjs || {};
         pbjs.que = pbjs.que || [];
@@ -91,7 +91,7 @@
             });
         });
 
-    </script>        
+    </script>
 </head>
 
 <body>

--- a/_includes/video/pbs-oy.html
+++ b/_includes/video/pbs-oy.html
@@ -2,12 +2,12 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
-    <!--ooyala and player code -->	
-    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+    <!--ooyala and player code -->
+
 	<!-- LOAD OOYALA PLUGINS
 
 	 Load the Ooyala player scripts you plan to use.
@@ -121,7 +121,7 @@
             });
         });
 
-    </script>	
+    </script>
 </head>
 
 <body>

--- a/_includes/video/pbs-rd.html
+++ b/_includes/video/pbs-rd.html
@@ -2,12 +2,12 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
-    <!--radiant and player code -->	
-    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+    <!--radiant and player code -->
+
 	<!-- Radiant Media Player core library - debug browser console mode (use rmp.min.js for production) -->
 	<script src="https://cdn.radiantmediatechs.com/rmp/5.5.6/js/rmp.debug.js"></script></head>
 

--- a/_includes/video/pbs-vjs.html
+++ b/_includes/video/pbs-vjs.html
@@ -2,12 +2,12 @@
 <html lang="en" class="html--no-js">
 
 <head>
-{% include head--common.html %}    
+{% include head--common.html %}
     <!--production version of prebid.js-->
-    <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
-    
-    <!--pbjs and player code -->	
-    
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+    <!--pbjs and player code -->
+
 	<!-- LOAD OOYALA PLUGINS
 
 <!-- videojs -->

--- a/dev-docs/faq.md
+++ b/dev-docs/faq.md
@@ -116,7 +116,7 @@ All prebid adapters that get merged should automatically detect if they're servi
 In other words, you shouldn't have to do anything other than make sure your own page loads Prebid.js securely, e.g.,
 
 ```html
-<script src='https://acdn.adnxs.com/prebid/not-for-prod/prebid.js' async=true />
+<script src='https://cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js' async=true />
 ```
 
 (Except that you should *never never never* use the copy of Prebid.js at that URL in production, it isn't meant for production use and may break everything at any time.)

--- a/dev-docs/plugins/bc/bc-prebid-plugin-prebid-options.md
+++ b/dev-docs/plugins/bc/bc-prebid-plugin-prebid-options.md
@@ -56,7 +56,7 @@ Not required but recommended.
 
 **Default Value:**
 
-https://acdn.adnxs.com/prebid/not-for-prod/prebid.js
+https://cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js
 
 **Example:**
 

--- a/dev-docs/plugins/cross-player-prebid-component/cross-player-config.md
+++ b/dev-docs/plugins/cross-player-prebid-component/cross-player-config.md
@@ -45,7 +45,7 @@ Not required but recommended.
 
 **Default Value:**
 
-https://acdn.adnxs.com/prebid/not-for-prod/prebid.js
+https://cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js
 
 **Example:**
 
@@ -297,7 +297,7 @@ Here is a sample Prebid configuration JSON object returned via URL:
 
 ```
 {
-    "prebidPath" : "//acdn.adnxs.com/prebid/not-for-prod/prebid.js",
+    "prebidPath" : "//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js",
     "biddersSpec" : {
         "code" : "my-video-tag",
         "mediaTypes": {

--- a/examples/legacy/multi-format/multi_format_example.html
+++ b/examples/legacy/multi-format/multi_format_example.html
@@ -4,7 +4,7 @@
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
         <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
+        <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
         <meta charset="utf-8">
         <style>
             body {

--- a/examples/legacy/native/native-demo.html
+++ b/examples/legacy/native/native-demo.html
@@ -3,7 +3,7 @@
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
         <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
-        <script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
+        <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
 
         <script>
             var googletag = googletag || {};

--- a/examples/legacy/pbjs_demo.html
+++ b/examples/legacy/pbjs_demo.html
@@ -90,7 +90,7 @@
                 eventLogger.logEventTime('loadPBJS', 'start');
                 var d = document, pbs = d.createElement("script");
                 pbs.type = "text/javascript";
-                pbs.src = 'https://acdn.adnxs.com/prebid/not-for-prod/prebid.js';
+                pbs.src = 'https://cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js';
                 var target = document.getElementsByTagName("head")[0];
                 target.insertBefore(pbs, target.firstChild);
                 eventLogger.logEventTime('loadPBJS', 'end');

--- a/examples/legacy/simple.html
+++ b/examples/legacy/simple.html
@@ -3,7 +3,7 @@
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
         <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
-        <script async src="https://acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
+        <script async src="https://cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
         <script>
             var sizes = [
                 [300, 250]

--- a/examples/video/crossplayer/flowplayer/pb-cp-flowplayer.html
+++ b/examples/video/crossplayer/flowplayer/pb-cp-flowplayer.html
@@ -46,7 +46,7 @@ sidebarType: 4
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 			<p style="color:#a94443">
-			To allow the Cross-Player plugin to load your custom build of Prebid.js ensure that the option key `prebidPath` is set to the custom build's location. If `prebidPath` is not set, the plugin will point to `//acdn.adnxs.com/prebid/not-for-prod/prebid.js`.</p>
+			To allow the Cross-Player plugin to load your custom build of Prebid.js ensure that the option key `prebidPath` is set to the custom build's location. If `prebidPath` is not set, the plugin will point to `//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js`.</p>
 		</div>
 
 		<div style="width:60vw;">

--- a/examples/video/crossplayer/jwplayer/pb-cp-jwplayer.html
+++ b/examples/video/crossplayer/jwplayer/pb-cp-jwplayer.html
@@ -32,7 +32,7 @@ sidebarType: 4
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 			<p style="color:#a94443">
-			To allow the Cross-Player plugin to load your custom build of Prebid.js ensure that the option key `prebidPath` is set to the custom build's location. If `prebidPath` is not set, the plugin will point to `//acdn.adnxs.com/prebid/not-for-prod/prebid.js`.</p>
+			To allow the Cross-Player plugin to load your custom build of Prebid.js ensure that the option key `prebidPath` is set to the custom build's location. If `prebidPath` is not set, the plugin will point to `//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js`.</p>
 		</div>
 
 		<div style="width:60vw;">

--- a/examples/video/crossplayer/kaltura/pb-cp-kaltura.html
+++ b/examples/video/crossplayer/kaltura/pb-cp-kaltura.html
@@ -32,7 +32,7 @@ sidebarType: 4
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 			<p style="color:#a94443">
-			To allow the Cross-Player plugin to load your custom build of Prebid.js ensure that the option key `prebidPath` is set to the custom build's location. If `prebidPath` is not set, the plugin will point to `//acdn.adnxs.com/prebid/not-for-prod/prebid.js`.</p>
+			To allow the Cross-Player plugin to load your custom build of Prebid.js ensure that the option key `prebidPath` is set to the custom build's location. If `prebidPath` is not set, the plugin will point to `//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js`.</p>
 		</div>
 
 		<div style="width:60vw;">

--- a/examples/video/crossplayer/videojs/pb-cp-videojs.html
+++ b/examples/video/crossplayer/videojs/pb-cp-videojs.html
@@ -37,7 +37,7 @@ sidebarType: 4
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 			<p style="color:#a94443">
-			To allow the Cross-Player plugin to load your custom build of Prebid.js ensure that the option key `prebidPath` is set to the custom build's location. If `prebidPath` is not set, the plugin will point to `//acdn.adnxs.com/prebid/not-for-prod/prebid.js`.</p>
+			To allow the Cross-Player plugin to load your custom build of Prebid.js ensure that the option key `prebidPath` is set to the custom build's location. If `prebidPath` is not set, the plugin will point to `//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js`.</p>
 		</div>
 
 		<div style="width:60vw;">

--- a/examples/video/instream/adplayerpro/pb-ve-adplayerpro.html
+++ b/examples/video/instream/adplayerpro/pb-ve-adplayerpro.html
@@ -38,7 +38,7 @@ sidebarType: 4
 <pre class="pb-code-hl" style="width:60vw;">
 
 <!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;<br>
+&lt;script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"&gt;&lt;/script&gt;<br>
 &lt;script type="text/javascript" src="https://static.adplayer.pro/player/demo.js"&gt;&lt;/script&gt;
 &lt;script&gt;
 	var pbjs = pbjs || {};

--- a/examples/video/instream/akamai/pb-ve-amp.html
+++ b/examples/video/instream/akamai/pb-ve-amp.html
@@ -39,7 +39,7 @@ sidebarType: 4
         <div style="width:60vw;">
             <h4>Place this code in the page header.</h4>
             <pre class="pb-code-hl" style="width:60vw;">
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;<br>
+&lt;script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"&gt;&lt;/script&gt;<br>
 &lt;script type="text/javascript" src="https://amp.akamaized.net/hosted/1.x/player?apikey=sample"&gt;&lt;/script&gt;
 &lt;script&gt;
 	var pbjs = pbjs || {};
@@ -151,7 +151,7 @@ sidebarType: 4
 
     </div>
 
-  
+
 </div>
 
 <div style="width:60vw;">
@@ -175,7 +175,7 @@ sidebarType: 4
                   name: "dfp"
                 },
                 resources: [
-                  { src: "https://acdn.adnxs.com/prebid/not-for-prod/1/prebid.js", type: "text/javascript", async: true },
+                  { src: "https://cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js", type: "text/javascript", async: true },
                   { src: "${paths.plugins}prebid/Prebid.min.js", type: "text/javascript", async: true }
                 ],
                 adUnits: {

--- a/examples/video/instream/brid/pb-ve-brid.html
+++ b/examples/video/instream/brid/pb-ve-brid.html
@@ -36,7 +36,7 @@ sidebarType: 4
 			<h4>Place this code in the page header.</h4>
 <pre class="pb-code-hl" style="width:60vw;">
 <!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;<br>
+&lt;script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"&gt;&lt;/script&gt;<br>
 &lt;script type="text/javascript" src="//services.brid.tv/player/build/brid.min.js"&gt;&lt;/script&gt;
 &lt;script&gt;
     var pbjs = pbjs || {};

--- a/examples/video/instream/brightcove/pb-ve-brightcove.html
+++ b/examples/video/instream/brightcove/pb-ve-brightcove.html
@@ -1,7 +1,7 @@
 ---
 layout: video_sample
-title: Prebid Video | Instream Example with Brightcove Player 
-description: An example of an instream pre-roll ad using Prebid.js and Brightcove player.  
+title: Prebid Video | Instream Example with Brightcove Player
+description: An example of an instream pre-roll ad using Prebid.js and Brightcove player.
 videoType: pb-is-bc
 isVideo: true
 sidebarType: 4
@@ -15,31 +15,31 @@ sidebarType: 4
 			<h1>{{ page.title }}</h1>
 			<p>{{page.description }}</p>
 		</div>
-		
+
 		<!--video warning-->
 		<div class="pb-alert pb-alert-important" style="width:60vw;">
 			<p style="color:#85720f"><b>Important:</b>
 			This example uses a test version of Prebid.js hosted on our CDN that is not recommended for production use. It includes all available adapters. Production implementations should build from source or customize the build using the Download page to make sure only the necessary bidder adapters are included.</p>
 		</div>
-		
+
 		<!--video placeholder | this should be formatted per the needs of each player-->
 		<div>
 			<video id="myVideo" data-account="5530036758001" data-player="HJMTvh2YZ" data-embed="default" data-application-id class="video-js" playsinline controls width="640" height="480"></video>
 		</div>
-		
+
 		<!--video code fencing-->
-					
+
 		<!--header code example-->
 		<div class="pb-alert pb-alert-warning" style="width:60vw;">
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 		</div>
-		
+
 		<div style="width:60vw;">
 			<h4>Place this code in the page header.</h4>
 <pre class="pb-code-hl" style="width:60vw;">
 <!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;<br>
+&lt;script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"&gt;&lt;/script&gt;<br>
 &lt;!--brightcove & prebid js code--&gt;
 &lt;script&gt;
 	var pbjs = pbjs || {};
@@ -81,7 +81,7 @@ sidebarType: 4
 		bids: [{
 			bidder: 'appnexus',
 			params: {
-				placementId: iosDevice ? 13239390 : 13232361 // Add your own placement id here. 
+				placementId: iosDevice ? 13239390 : 13232361 // Add your own placement id here.
 			}
 		}]
 	};
@@ -116,7 +116,7 @@ sidebarType: 4
 </pre>
 
 		</div>
-					
+
 		<!--body code example-->
 		<div style="width:60vw;">
 			<h4>Place this code in the page body.</h4>
@@ -206,13 +206,13 @@ need to include this script on the page.  --&gt;
 	 	tempTag = false;
 	}
   &lt;/script&gt;
- 
+
 </pre>
 		</div>
-	
+
 	</div>
 </div>
-	
+
 <!-- INCLUDE PLAYER AND IMA3 PLUGIN SCRIPTS
 
 First, include the player script from Brightcove. This will
@@ -249,7 +249,7 @@ need to include this script on the page.  -->
 		//   Call `videojs()` and pass in the ID of the video element to
 		//   get a reference to the player. Call `.ready` on the player
 		//   to set up the event listener, and place any code that will
-		//   interact with the player inside the callback (such as 
+		//   interact with the player inside the callback (such as
 		//   loading media files, logging events for the player or ads).
 
 		videojs("myVideo").ready(function() {
@@ -297,6 +297,5 @@ need to include this script on the page.  -->
 	 	tempTag = false;
 	}
   </script>
-	
+
 	<script type="text/javascript" src="/assets/js/video/pb-code-highlight.js"></script>
-	

--- a/examples/video/instream/flowplayer/pb-ve-flowplayer.html
+++ b/examples/video/instream/flowplayer/pb-ve-flowplayer.html
@@ -1,7 +1,7 @@
 ---
 layout: video_sample
-title: Prebid Video | Instream Example with  Flowplayer 
-description: An example of an instream pre-roll ad using Prebid.js and Flowplayer.  
+title: Prebid Video | Instream Example with  Flowplayer
+description: An example of an instream pre-roll ad using Prebid.js and Flowplayer.
 videoType: pb-is-fp
 isVideo: true
 sidebarType: 4
@@ -15,17 +15,17 @@ sidebarType: 4
 			<h1>{{ page.title }}</h1>
 			<p>{{page.description }}</p>
 		</div>
-		
+
 		<!--video warning-->
 		<div class="pb-alert pb-alert-important" style="width:60vw;">
 			<p style="color:#85720f"><b>Important:</b>
 			<p style="color:#85720f"><b>Important:</b>
 			This example uses a test version of Prebid.js hosted on our CDN that is not recommended for production use. It includes all available adapters. Production implementations should build from source or customize the build using the Download page to make sure only the necessary bidder adapters are included.</p>
 		</div>
-		
+
 		<!--video placeholder | this should be formatted per the needs of each player-->
 		<div>
-			
+
 			<div id="player"></div>
 			<div id="controls">
 			    <button id="ad-toggle" disabled>
@@ -33,26 +33,26 @@ sidebarType: 4
 			    </button>
 			    <p>The button will be enabled only during ads</p>
 			</div>
-			
+
 		</div>
-		
+
 	</div>
-	
+
 	<div class="row">
-		
+
 		<!--video code fencing-->
-					
+
 		<!--header code example-->
 		<div class="pb-alert pb-alert-warning" style="width:60vw;">
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 		</div>
-		
+
 		<div style="width:60vw;">
 			<h4>Place this code in the page header.</h4>
 <pre class="pb-code-hl" style="width:60vw;">
 <!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 &lt;link rel="stylesheet" href="//cdn.flowplayer.com/releases/native/stable/style/flowplayer.css"&gt;
 &lt;script src="//cdn.flowplayer.com/releases/native/stable/flowplayer.min.js"&gt;&lt;/script&gt;
 &lt;script src="//cdn.flowplayer.com/releases/native/stable/plugins/ads.min.js"&gt;&lt;/script&gt;
@@ -142,12 +142,12 @@ sidebarType: 4
       }
     });
   });
-    
+
 &lt;/script&gt;
 </pre>
 
 		</div>
-					
+
 		<!--body code example-->
 		<div style="width:60vw;">
 			<h4>Place this code in the page body.</h4>
@@ -162,7 +162,7 @@ sidebarType: 4
     &lt;/button&gt;
     &lt;p&gt;The button will be enabled only during ads&lt;/p&gt;
 &lt;/div&gt;
-	
+
 &lt;script type="text/javascript"&gt;
   var player = flowplayer('#player', {
     src: "//edge.flowplayer.org/drive.mp4",
@@ -176,7 +176,7 @@ sidebarType: 4
     },
     token:"eyJraWQiOiJZSVI0VVJZODA2TGoiLCJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJjIjoie1wiYWNsXCI6NixcImlkXCI6XCJZSVI0VVJZODA2TGpcIn0iLCJpc3MiOiJGbG93cGxheWVyIn0.YUoY8b2vl1Z15PikwgYeWQ8Cp85C-TvtmwIJ_UFxpfAYYH8yiiUrhmd3SaY_qb3AvVDz45xVV6R9wizYl-NRGQ"
   })
-  
+
   var btn = document.querySelector('#ad-toggle');
 
   btn.addEventListener('click', function() {
@@ -192,14 +192,14 @@ sidebarType: 4
   player.ads.on(flowplayer.AdEvents.AD_COMPLETED, toggleDisabled(true));
   player.ads.on(flowplayer.AdEvents.AD_SKIPPED, toggleDisabled(true));
 
-&lt;/script&gt;      
+&lt;/script&gt;
 
 </pre>
 		</div>
-	
+
 	</div>
 </div>
-	
+
 <!--video player code-->
 	<script type="text/javascript">
 		var player = flowplayer('#player', {
@@ -214,24 +214,23 @@ sidebarType: 4
 		},
 		token:"eyJraWQiOiJZSVI0VVJZODA2TGoiLCJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJjIjoie1wiYWNsXCI6NixcImlkXCI6XCJZSVI0VVJZODA2TGpcIn0iLCJpc3MiOiJGbG93cGxheWVyIn0.YUoY8b2vl1Z15PikwgYeWQ8Cp85C-TvtmwIJ_UFxpfAYYH8yiiUrhmd3SaY_qb3AvVDz45xVV6R9wizYl-NRGQ"
 		})
-		
+
 		var btn = document.querySelector('#ad-toggle');
-		
+
 		btn.addEventListener('click', function() {
 		if (player.ads.adPlaying) player.ads.pause();
 		else player.ads.resume();
 		})
-		
+
 		function toggleDisabled(disabled) {
 		return function() { btn.disabled = disabled }
 		}
-		
+
 		player.ads.on(flowplayer.AdEvents.AD_STARTED, toggleDisabled(false));
 		player.ads.on(flowplayer.AdEvents.AD_COMPLETED, toggleDisabled(true));
 		player.ads.on(flowplayer.AdEvents.AD_SKIPPED, toggleDisabled(true));
-	
+
 	</script>
 
-	
+
 	<script type="text/javascript" src="/assets/js/video/pb-code-highlight.js"></script>
-	

--- a/examples/video/instream/jwplayer/pb-ve-jwplayer-hosted.html
+++ b/examples/video/instream/jwplayer/pb-ve-jwplayer-hosted.html
@@ -1,7 +1,7 @@
 ---
 layout: video_sample
-title: Prebid Video | Instream Example with JW Player (Self-Hosted) 
-description: An example of an instream pre-roll ad using Prebid.js and JW Player (Hosted).  
+title: Prebid Video | Instream Example with JW Player (Self-Hosted)
+description: An example of an instream pre-roll ad using Prebid.js and JW Player (Hosted).
 videoType: pb-is-jw02
 isVideo: true
 sidebarType: 4
@@ -15,31 +15,31 @@ sidebarType: 4
 			<h1>{{ page.title }}</h1>
 			<p>{{page.description }}</p>
 		</div>
-		
+
 		<!--video warning-->
 		<div class="pb-alert pb-alert-important" style="width:60vw;">
 			<p style="color:#85720f"><b>Important:</b>
 			This example uses a test version of Prebid.js hosted on our CDN that is not recommended for production use. It includes all available adapters. Production implementations should build from source or customize the build using the Download page to make sure only the necessary bidder adapters are included.</p>
 		</div>
-		
+
 		<!--video placeholder | this should be formatted per the needs of each player-->
 		<div id="playerContainerJW" style='width:640px; height:480px; border:1px solid black;'></div>
-		
+
 		<!--video code fencing-->
-					
+
 		<!--header code example-->
 		<div class="pb-alert pb-alert-warning" style="width:60vw;">
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 		</div>
-		
+
 		<div style="width:60vw;">
 			<h4>Place this code in the page header.</h4>
 
 <pre class="pb-code-hl" style="width:60vw;">
 
 <!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 &lt;script type="text/javascript" src="https://ssl.p.jwpcdn.com/player/v/7.2.4/jwplayer.js"&gt;&lt;/script&gt;
 &lt;script type="text/javascript"&gt;
 	jwplayer.key = "YOUR_JW_PLAYER_KEY"; //Test Key - replace this with your own valid JWPlayer license key<br>
@@ -47,13 +47,13 @@ sidebarType: 4
 &lt;script&gt;
 	var pbjs = pbjs || {};
 	pbjs.que = pbjs.que || [];
-	
+
 	// define invokeVideoPlayer in advance in case we get the bids back from prebid before the entire page loads<br>
 	var tempTag = false;
 	var invokeVideoPlayer = function(url) {
 	    tempTag = url;
 	}
-	
+
 	var videoAdUnit = {
 	    code: 'video1',
 	    mediaTypes: {
@@ -73,7 +73,7 @@ sidebarType: 4
 	        }
 	    }]
 	};
-	
+
 	pbjs.que.push(function() {
 	    pbjs.addAdUnits(videoAdUnit); // add your ad units to the bid request<br>
 	    pbjs.setConfig({
@@ -82,7 +82,7 @@ sidebarType: 4
 	            url: 'https://prebid.adnxs.com/pbc/v1/cache'
 	        }
 	    });
-	
+
 	    pbjs.requestBids({
 	        bidsBackHandler: function(bids) {
 	            var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
@@ -101,11 +101,11 @@ sidebarType: 4
 	    });
 	});
 
-&lt;/script&gt;	
+&lt;/script&gt;
 </pre>
 
 		</div>
-					
+
 		<!--body code example-->
 		<div style="width:60vw;">
 			<h4>Place this code in the page body.</h4>
@@ -117,7 +117,7 @@ sidebarType: 4
 &lt;div id="playerContainerJW" style='width:640px; height:480px; border:1px solid black;'&gt;&lt;/div&gt;
 &lt;script&gt;
 	var jwPlayerInstance = jwplayer("playerContainerJW");
-	
+
 	invokeVideoPlayer = function(url) {
 	    jwPlayerInstance.setup({
 	        "file": "https://vjs.zencdn.net/v/oceans.mp4",
@@ -129,12 +129,12 @@ sidebarType: 4
 	            client: "vast",
 	        }
 	    });
-	
+
 	    jwPlayerInstance.on('beforePlay', function() {
 	        jwPlayerInstance.playAd(url);
 	    })
 	}
-	
+
 	if (tempTag) {
 	    invokeVideoPlayer(tempTag);
 	    tempTag = false;
@@ -145,14 +145,14 @@ sidebarType: 4
 
 </pre>
 		</div>
-	
+
 	</div>
 </div>
-	
+
 <!--video player code-->
 	<script>
 	    var jwPlayerInstance = jwplayer("playerContainerJW");
-	
+
 	    invokeVideoPlayer = function(url) {
 	        jwPlayerInstance.setup({
 	            "file": "https://vjs.zencdn.net/v/oceans.mp4",
@@ -164,19 +164,18 @@ sidebarType: 4
 	                client: "vast",
 	            }
 	        });
-	
+
 	        jwPlayerInstance.on('beforePlay', function() {
 	            jwPlayerInstance.playAd(url);
 	        })
 	    }
-	
+
 	    if (tempTag) {
 	        invokeVideoPlayer(tempTag);
 	        tempTag = false;
 	    }
-	
+
 	</script>
 
-	
+
 	<script type="text/javascript" src="/assets/js/video/pb-code-highlight.js"></script>
-	

--- a/examples/video/instream/jwplayer/pb-ve-jwplayer-platform.html
+++ b/examples/video/instream/jwplayer/pb-ve-jwplayer-platform.html
@@ -1,7 +1,7 @@
 ---
 layout: video_sample
-title: Prebid Video | Instream Example with  JW Player (Platform) 
-description: An example of an instream pre-roll ad using Prebid.js and JW Player (Platform).  
+title: Prebid Video | Instream Example with  JW Player (Platform)
+description: An example of an instream pre-roll ad using Prebid.js and JW Player (Platform).
 videoType: pb-is-jw01
 isVideo: true
 sidebarType: 4
@@ -15,31 +15,31 @@ sidebarType: 4
 			<h1>{{ page.title }}</h1>
 			<p>{{page.description }}</p>
 		</div>
-		
+
 		<!--video warning-->
 		<div class="pb-alert pb-alert-important" style="width:60vw;">
 			<p style="color:#85720f"><b>Important:</b>
 			This example uses a test version of Prebid.js hosted on our CDN that is not recommended for production use. It includes all available adapters. Production implementations should build from source or customize the build using the Download page to make sure only the necessary bidder adapters are included.</p>
 		</div>
-		
+
 		<!--video placeholder | this should be formatted per the needs of each player-->
 		<div id="myElement1"></div>
-		
+
 		<!--video code fencing-->
-					
+
 		<!--header code example-->
 		<div class="pb-alert pb-alert-warning" style="width:60vw;">
 			<i class="fa fa-exclamation-circle"></i>
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 		</div>
-		
+
 		<div style="width:60vw;">
 			<h4>Place this code in the page header.</h4>
 <pre class="pb-code-hl" style="width:60vw;">
 <!--put javascript code here-->
 &lt;!--Prebid.js and video player code--&gt;
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 &lt;script&gt;
     var pbjs = pbjs || {};
     pbjs.que = pbjs.que || [];
@@ -72,7 +72,7 @@ sidebarType: 4
 
     pbjs.que.push(function() {
 	    //put your adunits here<br>
-        pbjs.addAdUnits(videoAdUnit); 
+        pbjs.addAdUnits(videoAdUnit);
 
         pbjs.setConfig({
             debug: true,
@@ -103,7 +103,7 @@ sidebarType: 4
 </pre>
 
 		</div>
-					
+
 		<!--body code example-->
 		<div style="width:60vw;">
 			<h4>Place this code in the page body.</h4>
@@ -140,14 +140,14 @@ sidebarType: 4
         tempTag = false;
     }
 
-&lt;/script&gt;   
+&lt;/script&gt;
 
 </pre>
 		</div>
-	
+
 	</div>
 </div>
-	
+
 <!--video player code-->
 <!-- This line loads a player without loading any video content -->
 <!-- Replace this with the correct url for your player -->
@@ -179,8 +179,7 @@ sidebarType: 4
         tempTag = false;
     }
 
-</script>   
+</script>
 
-	
+
 	<script type="text/javascript" src="/assets/js/video/pb-code-highlight.js"></script>
-	

--- a/examples/video/instream/ooyala/pb-ve-ooyala.html
+++ b/examples/video/instream/ooyala/pb-ve-ooyala.html
@@ -1,7 +1,7 @@
 ---
 layout: video_sample
-title: Prebid Video | Instream Example with  Ooyala player 
-description: An example of an instream pre-roll ad using Prebid.js and Ooyala player .  
+title: Prebid Video | Instream Example with  Ooyala player
+description: An example of an instream pre-roll ad using Prebid.js and Ooyala player .
 videoType: pb-is-ol
 isVideo: true
 sidebarType: 4
@@ -15,31 +15,31 @@ sidebarType: 4
 			<h1>{{ page.title }}</h1>
 			<p>{{page.description }}</p>
 		</div>
-		
+
 		<!--video warning-->
 		<div class="pb-alert pb-alert-important" style="width:60vw;">
 			<p style="color:#85720f"><b>Important:</b>
 			This example uses a test version of Prebid.js hosted on our CDN that is not recommended for production use. It includes all available adapters. Production implementations should build from source or customize the build using the Download page to make sure only the necessary bidder adapters are included.</p>
 		</div>
-		
+
 		<!--video placeholder | this should be formatted per the needs of each player-->
 		<div id='container' style='width:640px;height:480px;'></div>
-		
+
 		<!--video code fencing-->
-					
+
 		<!--header code example-->
 		<div class="pb-alert pb-alert-warning" style="width:60vw;">
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 		</div>
-		
+
 		<div style="width:60vw;">
 			<h4>Place this code in the page header.</h4>
 		</div>
-		
+
 <pre class="pb-code-hl" style="width:60vw; display:block; overflow:normal; overflow-x:auto;"><code>
 <!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 &lt;!-- LOAD OOYALA PLUGINS
 
  Load the Ooyala player scripts you plan to use.
@@ -109,7 +109,7 @@ sidebarType: 4
         bids: [{
             bidder: 'appnexus',
             params: {
-                placementId: iosDevice ? 13239390 : 13232361 // Add your own placement id here. 
+                placementId: iosDevice ? 13239390 : 13232361 // Add your own placement id here.
             }
         }]
     };
@@ -147,11 +147,11 @@ sidebarType: 4
         });
     });
 
-&lt;/script&gt;      
+&lt;/script&gt;
 
 </code></pre>
 
-					
+
 		<!--body code example-->
 		<div style="width:60vw;">
 			<h4>Place this code in the page body.</h4>
@@ -251,13 +251,13 @@ sidebarType: 4
         tempTag = false;
     }
 
-&lt;/script&gt; 
+&lt;/script&gt;
 </pre>
 		</div>
-	
+
 	</div>
 </div>
-	
+
 <!--video player code-->
 	<script>
         var invokeVideoPlayer = function(url) {
@@ -353,6 +353,5 @@ sidebarType: 4
             tempTag = false;
         }
 
-    </script>	
+    </script>
 	<script type="text/javascript" src="/assets/js/video/pb-code-highlight.js"></script>
-	

--- a/examples/video/instream/radiant/pb-ve-radiant.html
+++ b/examples/video/instream/radiant/pb-ve-radiant.html
@@ -38,7 +38,7 @@ sidebarType: 4
 <pre class="pb-code-hl" style="width:60vw; display:block; overflow:normal; overflow-x:auto;"><code>
 <!--put javascript code here-->
 &lt;!--production version of prebid.js--&gt;
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 
 &lt;!-- Radiant Media Player core library - debug browser console mode (use rmp.min.js for production) --&gt;
 &lt;script src="https://cdn.radiantmediatechs.com/rmp/5.5.6/js/rmp.debug.js"&gt;&lt;/script&gt;

--- a/examples/video/instream/videojs/pb-ve-videojs.html
+++ b/examples/video/instream/videojs/pb-ve-videojs.html
@@ -1,7 +1,7 @@
 ---
 layout: video_sample
-title: Prebid Video | Instream Example with VideoJS 
-description: An example of an instream pre-roll ad using Prebid.js and VideoJS.  
+title: Prebid Video | Instream Example with VideoJS
+description: An example of an instream pre-roll ad using Prebid.js and VideoJS.
 videoType: pb-is-vjs
 isVideo: true
 sidebarType: 4
@@ -15,13 +15,13 @@ sidebarType: 4
 			<h1>{{ page.title }}</h1>
 			<p>{{page.description }}</p>
 		</div>
-		
+
 		<!--video warning-->
 		<div class="pb-alert pb-alert-important" style="width:60vw;">
 			<p style="color:#85720f"><b>Important:</b>
 			This example uses a test version of Prebid.js hosted on our CDN that is not recommended for production use. It includes all available adapters. Production implementations should build from source or customize the build using the Download page to make sure only the necessary bidder adapters are included.</p>
 		</div>
-		
+
 		<!--video placeholder | this should be formatted per the needs of each player-->
 		<div class="example-video-container">
 		<video id="vid1" class="video-js vjs-default-skin vjs-big-play-centered" controls data-setup='{}' width='640' height='480'>
@@ -29,20 +29,20 @@ sidebarType: 4
 			<source src="https://vjs.zencdn.net/v/oceans.webm" type='video/webm'/>
 			<source src="https://vjs.zencdn.net/v/oceans.ogv" type='video/ogg'/>
 		</video>
-				
+
 		<!--video code fencing-->
-					
+
 		<!--header code example-->
 		<div class="pb-alert pb-alert-warning" style="width:60vw;">
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 		</div>
-		
+
 		<div style="width:60vw;">
 			<h4>Place this code in the page header.</h4>
 <pre class="pb-code-hl" style="width:60vw;">
 <!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 &lt;!-- use recent version of videojs to ensure proper functioning with the iOS devices --&gt;
 &lt;link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/video.js/6.4.0/video-js.css"&gt;
 &lt;script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/video.js/6.4.0/video.js"&gt;&lt;/script&gt;
@@ -105,13 +105,13 @@ sidebarType: 4
         });
     });
 
-&lt;/script&gt;    
+&lt;/script&gt;
 
 
 </pre>
 
 		</div>
-					
+
 		<!--body code example-->
 		<div style="width:60vw;">
 			<h4>Place this code in the page body.</h4>
@@ -124,7 +124,7 @@ sidebarType: 4
 		&lt;source src="https://vjs.zencdn.net/v/oceans.ogv" type='video/ogg'/&gt;
 	&lt;/video&gt;
 &lt;/div&gt;
-        
+
 
 &lt;script&gt;
     var page_load_time;
@@ -185,10 +185,10 @@ sidebarType: 4
 &lt;/script&gt;
 </pre>
 		</div>
-	
+
 	</div>
 </div>
-	
+
 <!--video player code-->
 	<script>
             var page_load_time;
@@ -246,6 +246,5 @@ sidebarType: 4
                 });
             }
 
-        </script>	
+        </script>
 	<script type="text/javascript" src="/assets/js/video/pb-code-highlight.js"></script>
-	

--- a/examples/video/long-form/long-form-video-with-freewheel.html
+++ b/examples/video/long-form/long-form-video-with-freewheel.html
@@ -3,7 +3,7 @@
   <head>
     <title>Prebid Freewheel Integration Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <script async src="https://acdn.adnxs.com/prebid/not-for-prod/prebid.js"></script>
+    <script async src="https://cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script><link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
@@ -78,7 +78,7 @@
 
       pbjs.que.push(function(){
         pbjs.addAdUnits(videoAdUnit);
-        pbjs.setConfig({ 
+        pbjs.setConfig({
           debug: true,
           cache: {
             url: 'https://prebid.adnxs.com/pbc/v1/cache'
@@ -136,7 +136,7 @@
           }
         }
         return industry;
-      } 
+      }
     }
 
     function loadKv(targetingArr) {
@@ -148,7 +148,7 @@
             html += '<tr id='+targeting[key]+'><td>'+key+'</td><td>'+targeting[key]+'</td></tr>'
           });
         });
-      });  
+      });
       html += '</tbody></table>';
       div.innerHTML = html;
     }
@@ -174,7 +174,7 @@
             }
           });
         });
-      });  
+      });
       html += '</tbody></table>';
       div.innerHTML = html;
     }
@@ -267,7 +267,7 @@
         comBreak++;
       }
     }
-    
+
     function skipAd() {
       clearInterval(timerId);
       if (!adCount) {

--- a/examples/video/outstream/pb-ve-outstream-app.html
+++ b/examples/video/outstream/pb-ve-outstream-app.html
@@ -46,7 +46,7 @@ sidebarType: 4
 		<div style="width:60vw;">
 			<h4>Place this code in the page header.</h4>
 <pre class="pb-code-hl" style="width:60vw;">
-&lt;script src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
+&lt;script src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 &lt;!--AdPlayer.Pro code--&gt;
 &lt;script src="https://static.adplayer.pro/player/demo.js"&gt;&lt;/script&gt;
 </pre>

--- a/examples/video/pb-video-template.html
+++ b/examples/video/pb-video-template.html
@@ -1,7 +1,7 @@
 ---
 layout: video_sample
-title: Prebid Video | Video Outstream Example with  Google Ad Manager 
-description: An example of an outstream video with a pre-roll ad using Prebid.js and Google Ad Manager.  
+title: Prebid Video | Video Outstream Example with  Google Ad Manager
+description: An example of an outstream video with a pre-roll ad using Prebid.js and Google Ad Manager.
 videoType: pb-os-dfp
 isVideo: true
 sidebarType: 4
@@ -13,27 +13,27 @@ sidebarType: 4
 	<div class="row">
 		<h1>{{ page.title }}</h1>
 		<p>{{page.description }}</p>
-		
+
 		<!--video warning-->
 		<div markdown="span" class="pb-alert pb-alert-important" role="alert">
 			<i class="fa fa-exclamation-circle"></i>
 			<p style="color:#85720f"><b>Important:</b>
 			This example uses a test version of Prebid.js hosted on our CDN that is not recommended for production use. It includes all available adapters. Production implementations should build from source or customize the build using the Download page to make sure only the necessary bidder adapters are included.</p>
 		</div>
-		
+
 		<!--video placeholder | this should be formatted per the needs of each player-->
 		<h1>{{page.title}}</h1>
-					
+
 					<!--video example explanation-->
 					<div>{{page.description}}</div>
-					
+
 					<!--video warning-->
 					<div markdown="span" class="pb-alert pb-alert-important" role="alert">
 						<i class="fa fa-exclamation-circle"></i>
 						<p style="color:#85720f"><b>Important:</b>
 						This example uses a test version of Prebid.js hosted on our CDN that is not recommended for production use. It includes all available adapters. Production implementations should build from source or customize the build using the Download page to make sure only the necessary bidder adapters are included.</p>
 					</div>
-					
+
 					<!--video placeholder | this should be formatted per the needs of each player-->
 					<div>
 							<p>
@@ -59,10 +59,10 @@ sidebarType: 4
 		                    googletag.cmd.push(function() {
 		                        googletag.display('video1');
 		                    });
-		
+
 		                </script>
 		            </div>
-		            
+
 		            <div style="padding:7px;"><a href="#codesample">Code Sample</a></div>
 		            <p>
 		                Quisque ac luctus nisi, vitae ornare arcu. Proin fermentum sapien vitae odio vestibulum porta. Suspendisse faucibus sapien enim, et faucibus urna tempus et. Integer porttitor justo sed faucibus blandit. Morbi semper lectus vitae semper facilisis. Quisque
@@ -159,24 +159,24 @@ sidebarType: 4
 		                vel tortor. Aenean ultrices libero sed neque fermentum tempor. Morbi tincidunt dui turpis, non mollis est dignissim at. Suspendisse molestie convallis interdum. Donec sit amet fermentum purus.
 		            </p>
 					</div>
-				
 
-				
+
+
 		<!--video code fencing-->
-					
+
 		<!--header code example-->
 		<div markdown="span" class="pb-alert pb-alert-warning" role="alert">
 			<i class="fa fa-exclamation-circle"></i>
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 		</div>
-		
+
 		<div>
 			<h4>Place this code in the page header.</h4>
 <pre class="pb-code-hl">
 	<!--put javascript code here-->
 	&lt;script async src="//www.googletagservices.com/tag/js/gpt.js"&gt;&lt;/script&gt;
-		&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
+		&lt;script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 		&lt;script type="text/javascript" src="https://ssl.p.jwpcdn.com/player/v/8.0.5/jwplayer.js"&gt;&lt;/script&gt;
         &lt;script type="text/javascript"&gt;
             jwplayer.key = "ssbF6k0i9BPe87xfG/s0ipdp5gwbLoZaDON/GQvuwPU9nVJy"; //Test Key - replace this with your own valid JWPlayer license key
@@ -248,7 +248,7 @@ sidebarType: 4
 </pre>
 
 		</div>
-					
+
 		<!--body code example-->
 		<div>
 			<h4>Place this code in the page body.</h4>
@@ -261,14 +261,14 @@ sidebarType: 4
 				googletag.display('video1');
 			});
 		&lt;/script&gt;
-	&lt;/div&gt;  
+	&lt;/div&gt;
 
 </pre>
 		</div>
-	
+
 	</div>
 </div>
-	
+
 <!--video player code-->
 
 <script type=text/javascript>
@@ -302,4 +302,3 @@ sidebarType: 4
 
 
 	<script type="text/javascript" src="/assets/js/video/pb-code-highlight.js"></script>
-	

--- a/examples/video/server/brid/pbs-ve-brid.html
+++ b/examples/video/server/brid/pbs-ve-brid.html
@@ -1,7 +1,7 @@
 ---
 layout: video_sample
-title: Prebid Video | Prebid Server Example with  Brid player 
-description: An example of a pre-roll ad using Prebid Server and Brid player.  
+title: Prebid Video | Prebid Server Example with  Brid player
+description: An example of a pre-roll ad using Prebid Server and Brid player.
 videoType: pbs-br
 isVideo: true
 sidebarType: 4
@@ -15,29 +15,29 @@ sidebarType: 4
 		<h1>{{ page.title }}</h1>
 		<p>{{page.description }}</p>
 	</div>
-		
+
 		<!--video warning-->
 		<div class="pb-alert pb-alert-important" style="width:60vw;">
 			<p style="color:#85720f"><b>Important:</b>
 			This example uses a test version of Prebid.js hosted on our CDN that is not recommended for production use. It includes all available adapters. Production implementations should build from source or customize the build using the Download page to make sure only the necessary bidder adapters are included.</p>
 		</div>
-		
+
 		<!--video placeholder | this should be formatted per the needs of each player-->
 		<div id="myDiv" class="brid" style="width:640px; height:360;"></div>
-				
+
 		<!--video code fencing-->
-					
+
 		<!--header code example-->
 		<div class="pb-alert pb-alert-warning" style="width:60vw;">
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 		</div>
-		
+
 		<div>
 			<h4>Place this code in the page header.</h4>
 <pre class="pb-code-hl">
 <!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 
 &lt;script type="text/javascript" src="//services.brid.tv/player/build/brid.min.js"&gt;&lt;/script&gt;
 &lt;script&gt;
@@ -131,7 +131,7 @@ sidebarType: 4
 </pre>
 
 		</div>
-					
+
 		<!--body code example-->
 		<div>
 			<h4>Place this code in the page body.</h4>
@@ -153,15 +153,15 @@ sidebarType: 4
                 "cuepoints": null
             }
         ]
-    }); 
+    });
   }
 &lt;/script&gt;
 </pre>
 		</div>
-	
+
 	</div>
 </div>
-	
+
 <!--video player code-->
 	<script type="text/javascript">
       invokeVideoPlayer = function(url) {
@@ -177,9 +177,8 @@ sidebarType: 4
                     "cuepoints": null
                 }
             ]
-        }); 
+        });
       }
     </script>
-	
+
 	<script type="text/javascript" src="/assets/js/video/pb-code-highlight.js"></script>
-	

--- a/examples/video/server/jwplayer/pbs-ve-jwplayer-hosted.html
+++ b/examples/video/server/jwplayer/pbs-ve-jwplayer-hosted.html
@@ -1,7 +1,7 @@
 ---
 layout: video_sample
-title: Prebid Video | Prebid Server Example with JW Player (Self-Hosted) 
-description: An example of a pre-roll ad using Prebid Server and JW Player (Hosted).  
+title: Prebid Video | Prebid Server Example with JW Player (Self-Hosted)
+description: An example of a pre-roll ad using Prebid Server and JW Player (Hosted).
 videoType: pbs-jw02
 isVideo: true
 sidebarType: 4
@@ -14,29 +14,29 @@ sidebarType: 4
 			<h1>{{ page.title }}</h1>
 			<p>{{page.description }}</p>
 		</div>
-		
+
 		<!--video warning-->
 		<div class="pb-alert pb-alert-important" style="width:60vw;">
 			<p style="color:#85720f"><b>Important:</b>
 			This example uses a test version of Prebid.js hosted on our CDN that is not recommended for production use. It includes all available adapters. Production implementations should build from source or customize the build using the Download page to make sure only the necessary bidder adapters are included.</p>
 		</div>
-		
+
 		<!--video placeholder | this should be formatted per the needs of each player-->
 		<div id="playerContainerJW" style='width:640px; height:480px; border:1px solid black;'></div>
-				
+
 		<!--video code fencing-->
-					
+
 		<!--header code example-->
 		<div class="pb-alert pb-alert-warning" style="width:60vw;">
 			<p style="color:#a94443"><b>Warning:</b>
 			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
 		</div>
-		
+
 		<div>
 			<h4>Place this code in the page header.</h4>
 <pre class="pb-code-hl">
 	<!--put javascript code here-->
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 &lt;script type="text/javascript" src="https://ssl.p.jwpcdn.com/player/v/8.0.5/jwplayer.js"&gt;&lt;/script&gt;
 &lt;script type="text/javascript"&gt;
     jwplayer.key = "YOUR_JW_PLAYER_KEY"; //Test Key - replace this with your own valid JWPlayer license key<br>
@@ -134,7 +134,7 @@ sidebarType: 4
 </pre>
 
 		</div>
-					
+
 		<!--body code example-->
 		<div>
 			<h4>Place this code in the page body.</h4>
@@ -148,7 +148,7 @@ sidebarType: 4
     invokeVideoPlayer = function(url) {
         console.log("starting player with url " + url);
         jwPlayerInstance.setup({
-           
+
            "file": "https://vjs.zencdn.net/v/oceans.mp4",
             "width": 640,
             "height": 480,
@@ -173,10 +173,10 @@ sidebarType: 4
 
 </pre>
 		</div>
-	
+
 	</div>
 </div>
-	
+
 <!--video player code-->
 	<script>
 	    var jwPlayerInstance = jwplayer("playerContainerJW");
@@ -202,7 +202,6 @@ sidebarType: 4
         if (tempTag) {
             invokeVideoPlayer(tempTag);
             tempTag = false;
-        }	
-	</script>	
+        }
+	</script>
 	<script type="text/javascript" src="/assets/js/video/pb-code-highlight.js"></script>
-	

--- a/examples/video/server/radiant/pbs-ve-radiant.html
+++ b/examples/video/server/radiant/pbs-ve-radiant.html
@@ -38,7 +38,7 @@ sidebarType: 4
 <pre class="pb-code-hl" style="width:60vw; display:block; overflow:normal; overflow-x:auto;"><code>
 <!--put javascript code here-->
 &lt;!--production version of prebid.js--&gt;
-&lt;script async src="//acdn.adnxs.com/prebid/not-for-prod/prebid.js"&gt;&lt;/script&gt;
+&lt;script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"&gt;&lt;/script&gt;
 
 &lt;!-- Radiant Media Player core library - debug browser console mode (use rmp.min.js for production) --&gt;
 &lt;script src="https://cdn.radiantmediatechs.com/rmp/5.5.6/js/rmp.debug.js"&gt;&lt;/script&gt;


### PR DESCRIPTION
Starting from version 6.12.0 the complete prebid.js bundle is included in the npm package and fronted by jsDelivr; this is a search-and-replace across the whole site to use the new URL.
