### PR TITLE
Update jsFiddle links to versions that use new CDN URL for Prebid

### DIFF
--- a/dev-docs/examples/adunit-refresh.md
+++ b/dev-docs/examples/adunit-refresh.md
@@ -9,7 +9,7 @@ about:
 - Ability to <strong>refresh individual ad units</strong> - useful for infinite scrolling ad slots
 - When auto-refreshing is done incorrectly, it could cause the same bids to be rendered repeatedly. For instance, when googletag.pubads.refresh() is called directly without removing the PBJS targeting, the same hb_ variables get re-sent to GAM, re-chosen, and re-rendered. Over and over without ever asking PBJS for updated targeting variables.  Please see <a href="/dev-docs/publisher-api-reference/setConfig.html#setConfig-auctionOptions">Auction Options</a> for more info.
 
-jsfiddle_link: jsfiddle.net/Prebid_Examples/cu7tpexf/2/embedded/html,result
+jsfiddle_link: jsfiddle.net/Prebid_Examples/cu7tpexf/embedded/html,result
 
 code_height: 1540
 

--- a/dev-docs/examples/basic-example.md
+++ b/dev-docs/examples/basic-example.md
@@ -11,7 +11,7 @@ about:
 - Default keyword targeting setup (<a href="/dev-docs/publisher-api-reference/bidderSettings.html">reference</a>)
 - Default price granularity
 
-jsfiddle_link: jsfiddle.net/Prebid_Examples/94jt62b8/7/embedded/html,result
+jsfiddle_link: jsfiddle.net/Prebid_Examples/94jt62b8/embedded/html,result
 
 code_height: 2300
 

--- a/dev-docs/examples/custom-price-buckets.md
+++ b/dev-docs/examples/custom-price-buckets.md
@@ -9,7 +9,7 @@ about:
 - Custom price granularity buckets using <code>pbjs.setConfig()</code>
 - See the <a href="/dev-docs/publisher-api-reference/setConfig.html#setConfig-Price-Granularity">the API reference</a> for more detail.
 
-jsfiddle_link: jsfiddle.net/Prebid_Examples/vq05dhnj/2/embedded/html,result
+jsfiddle_link: jsfiddle.net/Prebid_Examples/vq05dhnj/embedded/html,result
 
 code_height: 2152
 

--- a/dev-docs/examples/instream-banner-mix.md
+++ b/dev-docs/examples/instream-banner-mix.md
@@ -5,7 +5,7 @@ description: An example of displaying both instream video and banner ads using P
 
 sidebarType: 1
 
-jsfiddle_link: jsfiddle.net/Prebid_Examples/nowfejh7/2/embedded/html,result/
+jsfiddle_link: jsfiddle.net/Prebid_Examples/nowfejh7/embedded/html,result/
 
 code_height: 3050
 

--- a/dev-docs/examples/meta-bid-filtering.md
+++ b/dev-docs/examples/meta-bid-filtering.md
@@ -9,7 +9,7 @@ about:
 - Bidders can supply metadata about the bid such as advertiser domain. See the "meta" fields in the <a href="/dev-docs/bidder-adaptor.html#interpreting-the-response">bid response</a> for the full list.
 - This is an example that filters bid responses based on the metadata object.
 
-jsfiddle_link: jsfiddle.net/Prebid_Examples/0s4eug1d/18/embedded/html,result
+jsfiddle_link: jsfiddle.net/Prebid_Examples/0s4eug1d/embedded/html,result
 
 code_height: 2300
 ---

--- a/dev-docs/examples/multi-format-example.md
+++ b/dev-docs/examples/multi-format-example.md
@@ -11,7 +11,7 @@ about:
 - For engineering setup instructions, see <a href="/dev-docs/show-multi-format-ads.html">Show Multi-Format Ads</a>
 - For ad ops setup instructions, see <a href="/adops/setting-up-prebid-multi-format-in-dfp.html">Setting up Prebid Multi-Format in Google Ad Manager</a>
 
-jsfiddle_link: jsfiddle.net/Prebid_Examples/yxsgcj71/2/embedded/html,result
+jsfiddle_link: jsfiddle.net/Prebid_Examples/yxsgcj71/embedded/html,result
 
 code_height: 3050
 

--- a/dev-docs/examples/native-ad-example.md
+++ b/dev-docs/examples/native-ad-example.md
@@ -10,7 +10,7 @@ about:
 - For engineering setup instructions, see <a href="/dev-docs/show-native-ads.html">Show Native Ads</a>
 - For ad ops setup instructions, see <a href="/adops/setting-up-prebid-native-in-dfp.html">Setting up Prebid Native in Google Ad Manager (Alpha)</a>
 
-jsfiddle_link: jsfiddle.net/Prebid_Examples/s5L7p3yd/2/embedded/html,result/
+jsfiddle_link: jsfiddle.net/Prebid_Examples/s5L7p3yd/embedded/html,result/
 
 code_height: 3050
 

--- a/dev-docs/examples/postbid.md
+++ b/dev-docs/examples/postbid.md
@@ -14,7 +14,7 @@ about:
 - There is no need to create line items for each price bucket as the postbid creative is served after the ad server has chosen the line item. 
 - This postbid creative <strong>supports passback</strong>. See how this works below.
 
-jsfiddle_link: jsfiddle.net/Prebid_Examples/mtuq7kz0/2/embedded/html,result
+jsfiddle_link: jsfiddle.net/Prebid_Examples/mtuq7kz0/embedded/html,result
 
 code_height: 1450
 ---

--- a/dev-docs/examples/size-mapping.md
+++ b/dev-docs/examples/size-mapping.md
@@ -10,7 +10,7 @@ about:
 - Dynamic filtering on ad unit sizes
 - Ad unit labels applied based on CSS media queries
 
-jsfiddle_link: jsfiddle.net/Prebid_Examples/qourvse1/3/embedded/html,result
+jsfiddle_link: jsfiddle.net/Prebid_Examples/qourvse1/embedded/html,result
 
 code_height: 2400
 

--- a/dev-docs/examples/use-prebid-with-appnexus-ad-server.md
+++ b/dev-docs/examples/use-prebid-with-appnexus-ad-server.md
@@ -10,6 +10,6 @@ about:
 - See the <a href="https://docs.xandr.com/bundle/seller-tag/page/seller-tag.html">Seller Tag (AST)</a> documentation for more information
 - To configure the Seller Tag to use SafeFrames, refer to the <a href="https://docs.xandr.com/bundle/seller-tag/page/safeframe-api-reference.html">SafeFrame API Reference</a>.
 
-jsfiddle_link: jsfiddle.net/Prebid_Examples/tr1djf9e/3/embedded/html,result
+jsfiddle_link: jsfiddle.net/Prebid_Examples/tr1djf9e/embedded/html,result
 code_height: 2404
 ---

--- a/dev-docs/getting-started.md
+++ b/dev-docs/getting-started.md
@@ -26,12 +26,10 @@ The easiest way to get started with Prebid.js is to use the example code below.
 </div>
 
 <script type="text/javascript">
-Optanon.InsertHtml('<iframe width="100%" height="1600" src="//jsfiddle.net/Prebid_Examples/bryzc7g6/3/embedded/html,result/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>', 'jsfiddle', null, {deleteSelectorContent: true}, 3);
+Optanon.InsertHtml('<iframe width="100%" height="1600" src="//jsfiddle.net/Prebid_Examples/bryzc7g6/embedded/html,result/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>', 'jsfiddle', null, {deleteSelectorContent: true}, 3);
 </script>
 
 ### Next Steps
 
 1. Set up your ad server using the [corresponding Ad Ops setup instructions]({{site.baseurl}}/adops/send-all-bids-adops.html)
 2. Once you're comfortable with the basic setup, check out [the examples showing other use cases]({{site.baseurl}}/dev-docs/examples/basic-example.html)
-
-


### PR DESCRIPTION
This updates jsFiddle links to all point to the "base" version of the fiddle. Separately, the base versions have all been updated to use the new jsDelivr Prebid URL (instead of appnexus').

## 🏷 Type of documentation

- [x] enhancement (wording, typos)


