### PR TITLE
Add recommendation to set API for Open Measurement if available + Cleanup

### DIFF
--- a/dev-docs/adunit-reference.md
+++ b/dev-docs/adunit-reference.md
@@ -188,24 +188,20 @@ The `native` object contains the following properties that correspond to the ass
 | `context`        | Recommended    | String                 | The video context, either `'instream'`, `'outstream'`, or `'adpod'` (for long-form videos).  Example: `context: 'outstream'`. Defaults to 'instream'. |
 | `placement`        | Recommended    | Integer                 | 1=in-stream, 2=in-banner, 3=in-article, 4=in-feed, 5=interstitial/floating. **Highly recommended** because some bidders require more than context=outstream. |
 | `playerSize`     | Optional    | Array[Integer,Integer] | The size (width, height) of the video player on the page, in pixels.  Example: `playerSize: [640, 480]`                                                                                                  |
-| `api`            | Recommended | Array[Integer]         | List of supported API frameworks for this impression.  If an API is not explicitly listed, it is assumed not to be supported.  For list, see [OpenRTB spec][openRTB].                                                  |
+| `api`            | Recommended | Array[Integer]         | List of supported API frameworks for this impression.  If an API is not explicitly listed, it is assumed not to be supported.  For list, see [OpenRTB spec][openRTB].  If your video player or video ads SDK supports [Open Measurement][OpenMeasurement], **recommended** to set `7` for OMID-1|
 | `mimes`          | Recommended | Array[String]          | Content MIME types supported, e.g., `"video/x-ms-wmv"`, `"video/mp4"`. **Required by OpenRTB when using [Prebid Server][pbServer]**.                                                                                   |
 | `protocols`      | Optional    | Array[Integer]         | Array of supported video protocols.  For list, see [OpenRTB spec][openRTB]. **Required by OpenRTB when using [Prebid Server][pbServer]**.                                                                            |
 | `playbackmethod` | Optional    | Array[Integer]         | Allowed playback methods. If none specified, all are allowed.  For list, see [OpenRTB spec][openRTB]. **Required by OpenRTB when using [Prebid Server][pbServer]**.                                                     |
 | `minduration`      | Recommended    | Integer         | Minimum video ad duration in seconds, see [OpenRTB spec][openRTB].           |
 | `maxduration`      | Recommended    | Integer         | Maximum video ad duration in seconds, see [OpenRTB spec][openRTB].           |
-| `w`      | Recommended    | Integer         |
-Width of the video player in device independent pixels (DIPS)., see [OpenRTB spec][openRTB].           |
+| `w`      | Recommended    | Integer         | Width of the video player in device independent pixels (DIPS)., see [OpenRTB spec][openRTB].           |
 | `h`      | Recommended    | Integer         | Height of the video player in device independent pixels (DIPS)., see [OpenRTB spec][openRTB].           |
 | `startdelay`      | Recommended    | Integer         | Indicates the start delay in seconds, see [OpenRTB spec][openRTB].           |
 | `placement`      | Optional    | Integer         | Placement type for the impression, see [OpenRTB spec][openRTB].           |
 | `linearity`      | Optional    | Integer         | Indicates if the impression must be linear, nonlinear, etc, see [OpenRTB spec][openRTB].           |
-| `skip`      | Optional    | Integer         | Indicates if the player will allow the video to be skipped,
-where 0 = no, 1 = yes., see [OpenRTB spec][openRTB].           |
-| `skipmin`      | Optional    | Integer         | Videos of total duration greater than this number of seconds
-can be skippable; only applicable if the ad is skippable., see [OpenRTB spec][openRTB].           |
-| `skipafter`      | Optional    | Integer         | Number of seconds a video must play before skipping is
-enabled; only applicable if the ad is skippable., see [OpenRTB spec][openRTB].           |
+| `skip`      | Optional    | Integer         | Indicates if the player will allow the video to be skipped, where 0 = no, 1 = yes., see [OpenRTB spec][openRTB].           |
+| `skipmin`      | Optional    | Integer         | Videos of total duration greater than this number of seconds can be skippable; only applicable if the ad is skippable., see [OpenRTB spec][openRTB].           |
+| `skipafter`      | Optional    | Integer         | Number of seconds a video must play before skipping is enabled; only applicable if the ad is skippable., see [OpenRTB spec][openRTB].           |
 | `minbitrate`      | Optional    | Integer         | Minimum bit rate in Kbps., see [OpenRTB spec][openRTB].           |
 | `maxbitrate`      | Optional    | Integer         | Maximum bit rate in Kbps., see [OpenRTB spec][openRTB].           |
 | `delivery`      | Optional    | Array[Integer]         | Supported delivery methods (e.g., streaming, progressive), see [OpenRTB spec][openRTB].           |
@@ -611,3 +607,4 @@ For more information on Interstitial ads, reference the [Interstitial feature pa
 [configureResponsive]: {{site.baseurl}}/dev-docs/publisher-api-reference/setConfig.html#setConfig-Configure-Responsive-Ads
 [openRTB]: https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf
 [pbServer]: {{site.baseurl}}/prebid-server/overview/prebid-server-overview.html
+[OpenMeasurement]: https://iabtechlab.com/standards/open-measurement-sdk/

--- a/dev-docs/show-outstream-video-ads.md
+++ b/dev-docs/show-outstream-video-ads.md
@@ -30,7 +30,7 @@ There should be no changes required on the ad ops side, since the outstream unit
 
 Use the `adUnit.mediaTypes` object to set up your ad units with the `video` media type and assign the appropriate context
 
-The fields supported in a given `bid.params.video` object will vary based on the rendering options supported by each bidder.  For more information, see [Bidders' Params]({{site.github.url}}/dev-docs/bidders.html).
+For full details on video ad unit parameters, see [Ad Unit Reference for Video]({{site.baseurl}}/dev-docs/adunit-reference.html#adunitmediatypesvideo)
 
 {% highlight js %}
 
@@ -43,17 +43,14 @@ var videoAdUnits = [{
                 mimes: ['video/mp4'],
                 protocols: [1, 2, 3, 4, 5, 6, 7, 8],
                 playbackmethod: [2],
-                skip: 1
+                skip: 1,
+                playback_method: ['auto_play_sound_off']
         }
     },
     bids: [{
         bidder: 'appnexus',
         params: {
             placementId: 13232385,
-            video: {
-                skip: 1,
-                playback_method: ['auto_play_sound_off']
-            }
         }
     }]
 }];

--- a/dev-docs/show-video-with-a-dfp-video-tag.md
+++ b/dev-docs/show-video-with-a-dfp-video-tag.md
@@ -75,6 +75,8 @@ var videoAdUnit = {
 };
 ```
 
+For full details on video ad unit parameters, see [Ad Unit Reference for Video]({{site.baseurl}}/dev-docs/adunit-reference.html#adunitmediatypesvideo)
+
 ### 2. Implement Custom Price Buckets
 
 By default, Prebid.js caps all CPMs at $20.  As a video seller, you may expect to see CPMs over $20.  In order to receive those bids, you'll need to implement custom price buckets setting the [priceGranularity](/dev-docs/publisher-api-reference/setConfig.html#setConfig-Price-Granularity) object in the `setConfig` method.

--- a/prebid-video/video-getting-started.md
+++ b/prebid-video/video-getting-started.md
@@ -86,6 +86,8 @@ The mediaTypes.video.playerSize field is where you define the player size that w
   <p>If you’re using Prebid Server, you must also include the mediaTypes.video.mimes field, as this is required by OpenRTB.</p>
 </div>
 
+For full details on video ad unit parameters, see [Ad Unit Reference for Video]({{site.baseurl}}/dev-docs/adunit-reference.html#adunitmediatypesvideo)
+
 In your ad unit you also need to define your list of bidders. For example, including AppNexus as a bidder would look something like this:
 
 ```


### PR DESCRIPTION
Add recommendation to set API for Open Measurement if available
Clean-up formatting issues in video ad unit reference
Add links to the video ad unit reference
Update outstream doc to place all video parameters on the ad unit

Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

## 🏷 Type of documentation

- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [x] enhancement (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist

- [ N/A] Related pull requests in prebid.js or server are linked
- [ N/A] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
