### PR TITLE
Fix #3327 add multiformat_supported field

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ Before submitting a pull request, you should run the site locally to make sure y
 
 To get started editing the site and seeing your changes, clone this repo and enter the following commands in your terminal:
 
-- `cd path/to/prebid.github.io`
-- `export JEKYLL_ENV=production`
-- `bundle exec jekyll serve`
+```bash
+$ JEKYLL_ENV=production bundle exec jekyll serve --watch --incremental
+```
+
 
 You should see output that looks something like this:
 

--- a/_layouts/bidder.html
+++ b/_layouts/bidder.html
@@ -98,6 +98,12 @@
                     <th class="pbTh">First Party Data Support</th>
                     <td class="pbTd">{% if page.fpd_supported == true %}yes{% elsif page.fpd_supported == false %}no{% else %}check with bidder{% endif %}</td>
                   </tr>
+                  <tr>
+                    <th class="pbTh">Multi Format Support</th>
+                    <td class="pbTd">{% if page.multiformat_supported %}{{page.multiformat_supported}}{% else %}check with bidder{% endif %}</td>
+                    <th class="pbTh"></th>
+                    <td class="pbTd"></td>
+                  </tr>
                 </table>
 
                 <h3>"Send All Bids" Ad Server Keys</h3>

--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -1165,6 +1165,7 @@ fpd_supported: true/false
 pbjs: true/false
 pbs: true/false
 prebid_member: true/false
+multiformat_supported: will-bid-on-any, will-bid-on-one, will-not-bid
 ---
 ### Note:
 

--- a/dev-docs/bidders/rubicon.md
+++ b/dev-docs/bidders/rubicon.md
@@ -18,6 +18,7 @@ pbs: true
 pbs_app_supported: true
 fpd_supported: true
 gvl_id: 52
+multiformat_supported: will-bid-on-one
 ---
 
 ### Registration

--- a/dev-docs/pbs-bidders.md
+++ b/dev-docs/pbs-bidders.md
@@ -52,6 +52,7 @@ You can also download the full <a href="/dev-docs/bidder-data.csv" download>CSV 
 | **Supports Deals** | {% if page.deals_supported and page.deals_supported == false %}no{% else %}yes{% endif %} | **Prebid.js Adapter** | {% if page.pbjs == true %}yes{% else %}no{% endif %} |
 | **Mobile App Support** | {% if page.pbs_app_supported and page.pbs_app_supported == false %}no{% elsif page.pbs_app_supported and page.pbs_app_supported == true %}yes{% else %}check with bidder{% endif %} | **Prebid Server Adapter** | yes |
 | **Floors Support** | {% if page.floors_supported == false %}no{% elsif page.floors_supported == true %}yes{% else %}check with bidder{% endif %} | **First Party Data Support** | {% if page.fpd_supported == true %}yes{% elsif page.fpd_supported == false %}no{% else %}check with bidder{% endif %} |
+| **Multi Format Support** | {% if page.multiformat_supported %}{{page.multiformat_supported}}{% else %}check with bidder{% endif %} | | |
 
 
 <h3>"Send All Bids" Ad Server Keys</h3>

--- a/prebid-server/developers/add-new-bidder-go.md
+++ b/prebid-server/developers/add-new-bidder-go.md
@@ -1175,6 +1175,7 @@ pbjs: true/false
 pbs: true/false
 pbs_app_supported: true/false
 prebid_member: true/false
+multiformat_supported: will-bid-on-any, will-bid-on-one, will-not-bid
 ---
 
 ### Note:

--- a/prebid-server/developers/add-new-bidder-java.md
+++ b/prebid-server/developers/add-new-bidder-java.md
@@ -1144,6 +1144,7 @@ pbjs: true/false
 pbs: true/false
 pbs_app_supported: true/false
 prebid_member: true/false
+multiformat_supported: will-bid-on-any, will-bid-on-one, will-not-bid
 ---
 
 ### Note:


### PR DESCRIPTION
Adds a new field `multiformat_supported` to the bidder table, which indicates the behaviour of a bid adapter when more than one media type (`banner`, `native`, `video`) is being requested.

Possible values are

* `will-bid-on-any` - bidder will bid on any media type
* `will-bid-on-one` - bidder will prioritize one media type and ignores the others
* `will-not-bid` - bidder will not bid at all

## 🏷 Type of documentation

- [x] new feature
