### PR TITLE
update docs to indicate native support

### DIFF
--- a/dev-docs/bidders/amx.md
+++ b/dev-docs/bidders/amx.md
@@ -10,7 +10,7 @@ coppa_supported: true
 userIds: britepoolId, criteo, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId, amxId
 biddercode: amx
 safeframes_ok: true
-media_types: banner, video
+media_types: banner, video, native
 pbjs: true
 pbs: true
 pbs_app_supported: true


### PR DESCRIPTION
Updating AMX bid adapter documentation to indicate support for native format. See https://github.com/prebid/prebid-server/pull/2220 for relevant code change.


