### PR TITLE
Triplelift: update bidder params page

### DIFF
--- a/dev-docs/bidders/triplelift.md
+++ b/dev-docs/bidders/triplelift.md
@@ -20,29 +20,103 @@ fpd_supported: true
 gvl_id: 28
 ---
 
+### Table of Contents
+
+- [Overview](#triplelift-overview)
+- [Bid Parameters](#triplelift-bid-params)
+- [Example Configuration](#triplelift-config) 
+- [First Party Data](#triplelift-first-party)
+
+<a name="triplelift-overview" />
+
+### Overview
+
+Publishers may integrate with Triplelift through our Prebid.js and/or Prebid Server adapters. See below for more information.
+
 {% capture version2 %}
 The Triplelift Prebid Server bidding adapter and user sync endpoint require setup before beginning. Please contact us at prebid@triplelift.com.
 {% endcapture %}
 {% include alerts/alert_important.html content=version2 %}
 
-### Table of Contents
-
-- [Bid Params](#triplelift-bid-params)
-- [First Party Data](#triplelift-first-party)
-
 <a name="triplelift-bid-params" />
 
 ### Bid Params
 
+#### Banner
+
 {: .table .table-bordered .table-striped }
 
-| Name            | Scope                        | Description                                                                          | Example                                    | Type     |
-|-----------------|------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------|----------|
-| `inventoryCode` | required                     | TripleLift inventory code for this ad unit (provided to you by your partner manager) | `'pubname_main_feed'`                      | `string` |
-| `floor`         | optional                     | Bid floor                                                                            | `1.00`                                     | `float`  |
-| `video`         | required for instream video  | oRTB video object                                                                    | `{ mimes: ['video/mp4'], w: 640, h: 480 }` | `object` |
-| `video.w`       | required for instream video  | oRTB video object width dimension                                                    | `640`                                      | `int`    |
-| `video.h`       | required for instream video  | oRTB video object height dimension                                                   | `480`                                      | `int`    |
+| Name            | Scope                        | Description                                                                          | Example                                     | Type     |
+|-----------------|------------------------------|--------------------------------------------------------------------------------------|---------------------------------------------|----------|
+| `inventoryCode` | required                     | TripleLift inventory code for this ad unit (provided to you by your partner manager) | `'pubname_top_banner'`                      | `string` |
+| `floor`         | optional                     | Bid floor                                                                            | `1.00`                                      | `float`  |
+
+
+#### Video
+
+The following parameters are supported for instream inventory only.
+
+{: .table .table-bordered .table-striped }
+
+| Name            | Scope                        | Description                                                                          | Example                                     | Type     |
+|-----------------|------------------------------|--------------------------------------------------------------------------------------|---------------------------------------------|----------|
+| `inventoryCode` | required                     | TripleLift inventory code for this ad unit (provided to you by your partner manager) | `'pubname_instream_1'`                      | `string` |
+| `video`         | required                     | oRTB video object                                                                    | `{ mimes: ['video/mp4'], w: 640, h: 480 }`     | `object`  |
+| `video.context`         | required             | Instream or outstream - TripleLift only supports instream.                           | `instream`                                      | `string`  |
+| `video.w`         | required                   | oRTB video object width dimension                                                    | `640`                                      | `int`  |
+| `video.h`         | required                   | oRTB video object height dimension                                                   | `480`                                      | `int`  |
+
+<a name="triplelift-config" />
+
+### Example Configuration
+
+#### Banner
+
+```
+var adUnits = [
+    {
+        code: 'top-banner',
+        mediaTypes: {
+            banner: {
+                sizes: [
+                    [728, 90],
+                    [970, 250]
+                ]
+            }
+    },
+    bids: [{
+        bidder: 'triplelift',
+        params: {
+            inv_code: 'pubname_topbanner'
+        }
+    }]
+}];
+```
+
+#### Video (Instream)
+
+```
+var videoAdUnit = {
+    code: 'video1',
+    mediaTypes: {
+        video: {
+            playerSize: [640, 480],
+            context: 'instream',
+            mimes: ['video/mp4']
+        }
+    },
+    bids: [{
+        bidder: 'triplelift',
+        params: {
+            inv_code: 'pubname_instream1',
+            video: {
+                w: 640,
+                h: 480
+            }
+        }
+    }]
+};
+```
 
 <a name="triplelift-first-party" />
 


### PR DESCRIPTION
Revamping Triplelift's bidder parameters page to be more verbose. 

## 🏷 Type of documentation

- [x] text edit only (updated Triplelift bidder parameter documentation)

## 📋 Checklist
