### PR TITLE
Add 33Across user id sub-module

### DIFF
--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -83,7 +83,7 @@ The table below has the options that are common across ID systems. See the secti
 {: .table .table-bordered .table-striped }
 | Param under userSync.userIds[] | Scope | Type | Description | Example |
 | --- | --- | --- | --- | --- |
-| name | Required | String | May be: `"admixerId"`, `"qid"`, `"adtelligentId"`, `"akamaiDAPId"`, `"amxId"`, `"britepoolId"`, `"criteo"`, `"fabrickId"`, `"flocId"`, `"hadronId"`, `"id5id"`, `identityLink`, `"idx"`, `"intentIqId"`, `"justId"`, `"liveIntentId"`, `"lotamePanoramaId"`, `"merkleId"`, `"naveggId"`, `"mwOpenLinkId"`, `"netId"`, `"novatiqId"`, `"parrableId"`, `"quantcastId"`, `"pubProvidedId"`, `"sharedId"`, `"tapadId"`, `"unifiedId"`,`"uid2"`, `"verizonMediaId"`, `"zeotapIdPlus"` | `"unifiedId"`
+| name | Required | String | May be: `"33acrossId"`, "admixerId"`, `"qid"`, `"adtelligentId"`, `"akamaiDAPId"`, `"amxId"`, `"britepoolId"`, `"criteo"`, `"fabrickId"`, `"flocId"`, `"hadronId"`, `"id5id"`, `identityLink`, `"idx"`, `"intentIqId"`, `"justId"`, `"liveIntentId"`, `"lotamePanoramaId"`, `"merkleId"`, `"naveggId"`, `"mwOpenLinkId"`, `"netId"`, `"novatiqId"`, `"parrableId"`, `"quantcastId"`, `"pubProvidedId"`, `"sharedId"`, `"tapadId"`, `"unifiedId"`,`"uid2"`, `"verizonMediaId"`, `"zeotapIdPlus"` | `"unifiedId"`
 | params | Based on User ID sub-module | Object | | |
 | bidders | Optional | Array of Strings | An array of bidder codes to which this user ID may be sent. | `['bidderA', 'bidderB']` |
 | storage | Optional | Object | The publisher can specify some kind of local storage in which to store the results of the call to get the user ID. This can be either cookie or HTML5 storage. This is not needed when `value` is specified or the ID system is managing its own storage | |
@@ -148,6 +148,53 @@ The Rubicon bid adapter would then receive
 ```
 
 ## User ID Sub-Modules
+
+### 33Across User ID Module
+
+The 33Across User ID Module is a way for publishers to monetize their cookieless inventory across multiple supply-side platforms via Prebid.JS. The module provides publishers with addressability for their open marketplace cookieless inventory and access to cookieless demand. The 33Across User ID Module enables publishers to match cookieless browser users to demand platforms without any reliance on traditional cookie matching methodologies. 33Across User ID Module utilizes Lexicon technology to connect Publishers to Demand partners via proprietary technologies in a probabilistic and privacy-safe manner.
+
+#### 33Across User ID Module Configuration
+
+Please make sure to add the 33across User ID module to your Prebid.js package with:
+
+```shell
+gulp build --modules=33acrossIdSystem,userId
+```
+
+The following configuration parameters are available:
+{: .table .table-bordered .table-striped }
+| Param under userSync.userIds[] | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| name | Required | String | The name of this module | "33acrossId" |
+| params ||| Details for the module initialization ||
+| params.pid | Required | String | Partner ID (PID) | Please reach out to [PrebidUIM@33across.com](mailto:PrebidUIM@33across.com) and request your PID |
+| storage |||||
+| storage.name | Required | String | The name of the cookie or html5 local storage key | "33acrossId" (recommended) |
+| storage.type | Required | String | This is where the results of the 33across user ID will be stored | "html5" (recommended) or "cookie" |
+| storage.expires | Strongly Recommended | Number | How long (in days) the user ID information will be stored | 90 (recommended) |
+| storage.refreshInSeconds | Strongly Recommended | Number | How many seconds until the ID is refreshed | 28800 (recommended) |
+
+#### 33Across User ID Module Example
+```
+pbjs.setConfig({
+  userSync: {
+    userIds: [{
+      name: "33acrossId",
+    params: {
+        pid: "0010b00002GYU4eBAH" // Example ID
+      },
+      storage: {
+        name: "33acrossId",
+        type: "html5",
+        expires: 90,
+        refreshInSeconds: 8 * 3600
+      }
+    }]
+  }
+});
+```
+
+Please contact [PrebidUIM@33across.com](mailto:PrebidUIM@33across.com) to get your PID authorization process started.
 
 ### AkamaiDAPId
 

--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -83,7 +83,7 @@ The table below has the options that are common across ID systems. See the secti
 {: .table .table-bordered .table-striped }
 | Param under userSync.userIds[] | Scope | Type | Description | Example |
 | --- | --- | --- | --- | --- |
-| name | Required | String | May be: `"33acrossId"`, "admixerId"`, `"qid"`, `"adtelligentId"`, `"akamaiDAPId"`, `"amxId"`, `"britepoolId"`, `"criteo"`, `"fabrickId"`, `"flocId"`, `"hadronId"`, `"id5id"`, `identityLink`, `"idx"`, `"intentIqId"`, `"justId"`, `"liveIntentId"`, `"lotamePanoramaId"`, `"merkleId"`, `"naveggId"`, `"mwOpenLinkId"`, `"netId"`, `"novatiqId"`, `"parrableId"`, `"quantcastId"`, `"pubProvidedId"`, `"sharedId"`, `"tapadId"`, `"unifiedId"`,`"uid2"`, `"verizonMediaId"`, `"zeotapIdPlus"` | `"unifiedId"`
+| name | Required | String | May be: `"33acrossId"`, `"admixerId"`, `"qid"`, `"adtelligentId"`, `"akamaiDAPId"`, `"amxId"`, `"britepoolId"`, `"criteo"`, `"fabrickId"`, `"flocId"`, `"hadronId"`, `"id5id"`, `identityLink`, `"idx"`, `"intentIqId"`, `"justId"`, `"liveIntentId"`, `"lotamePanoramaId"`, `"merkleId"`, `"naveggId"`, `"mwOpenLinkId"`, `"netId"`, `"novatiqId"`, `"parrableId"`, `"quantcastId"`, `"pubProvidedId"`, `"sharedId"`, `"tapadId"`, `"unifiedId"`,`"uid2"`, `"verizonMediaId"`, `"zeotapIdPlus"` | `"unifiedId"`
 | params | Based on User ID sub-module | Object | | |
 | bidders | Optional | Array of Strings | An array of bidder codes to which this user ID may be sent. | `['bidderA', 'bidderB']` |
 | storage | Optional | Object | The publisher can specify some kind of local storage in which to store the results of the call to get the user ID. This can be either cookie or HTML5 storage. This is not needed when `value` is specified or the ID system is managing its own storage | |
@@ -149,13 +149,13 @@ The Rubicon bid adapter would then receive
 
 ## User ID Sub-Modules
 
-### 33Across User ID Module
+### 33Across ID
 
-The 33Across User ID Module is a way for publishers to monetize their cookieless inventory across multiple supply-side platforms via Prebid.JS. The module provides publishers with addressability for their open marketplace cookieless inventory and access to cookieless demand. The 33Across User ID Module enables publishers to match cookieless browser users to demand platforms without any reliance on traditional cookie matching methodologies. 33Across User ID Module utilizes Lexicon technology to connect Publishers to Demand partners via proprietary technologies in a probabilistic and privacy-safe manner.
+The 33Across User ID sub-module is a way for publishers to monetize their cookieless inventory across multiple supply-side platforms via Prebid.JS. The sub-module provides publishers with addressability for their open marketplace cookieless inventory and access to cookieless demand. The 33Across User ID sub-module utilizes Lexicon technology to connect Publishers to Demand partners via proprietary technologies in a probabilistic and privacy-safe manner. Please contact [PrebidUIM@33across.com](mailto:PrebidUIM@33across.com) to get your authorization process started.
 
-#### 33Across User ID Module Configuration
+#### 33Across ID Configuration
 
-Please make sure to add the 33across User ID module to your Prebid.js package with:
+Please make sure to add the 33across user ID sub-module to your Prebid.js package with:
 
 ```shell
 gulp build --modules=33acrossIdSystem,userId
@@ -165,22 +165,22 @@ The following configuration parameters are available:
 {: .table .table-bordered .table-striped }
 | Param under userSync.userIds[] | Scope | Type | Description | Example |
 | --- | --- | --- | --- | --- |
-| name | Required | String | The name of this module | "33acrossId" |
-| params ||| Details for the module initialization ||
+| name | Required | String | The name of this sub-module | `"33acrossId"` |
+| params ||| Details for the sub-module initialization ||
 | params.pid | Required | String | Partner ID (PID) | Please reach out to [PrebidUIM@33across.com](mailto:PrebidUIM@33across.com) and request your PID |
 | storage |||||
-| storage.name | Required | String | The name of the cookie or html5 local storage key | "33acrossId" (recommended) |
-| storage.type | Required | String | This is where the results of the 33across user ID will be stored | "html5" (recommended) or "cookie" |
-| storage.expires | Strongly Recommended | Number | How long (in days) the user ID information will be stored | 90 (recommended) |
-| storage.refreshInSeconds | Strongly Recommended | Number | How many seconds until the ID is refreshed | 28800 (recommended) |
+| storage.name | Required | String | The name of the cookie or html5 local storage key | `"33acrossId"` (recommended) |
+| storage.type | Required | String | This is where the 33across user ID will be stored | `"html5"` (recommended) or `"cookie"` |
+| storage.expires | Strongly Recommended | Number | How long (in days) the user ID information will be stored | `90` (recommended) |
+| storage.refreshInSeconds | Strongly Recommended | Number | How many seconds until the ID is refreshed | `8 * 3600` (recommended) |
 
-#### 33Across User ID Module Example
+#### 33Across ID Example
 ```
 pbjs.setConfig({
   userSync: {
     userIds: [{
       name: "33acrossId",
-    params: {
+      params: {
         pid: "0010b00002GYU4eBAH" // Example ID
       },
       storage: {
@@ -193,8 +193,6 @@ pbjs.setConfig({
   }
 });
 ```
-
-Please contact [PrebidUIM@33across.com](mailto:PrebidUIM@33across.com) to get your PID authorization process started.
 
 ### AkamaiDAPId
 
@@ -2361,6 +2359,7 @@ Bidders that want to support the User ID module in Prebid.js, need to update the
 {: .table .table-bordered .table-striped }
 | ID System Name | ID System Host | Prebid.js Attr: bidRequest.userId. | EID Source | Example Value |
 | --- | --- | --- | --- | --- | --- | --- |
+| 33Across ID | 33Across | 33acrossId | 33across.com | "1111" |
 | Admixer ID | Admixer | admixerId | admixer.net | "1111" |
 | adQuery QiD | adQuery | qid | adquery.io | "p9v2dpnuckkzhuc..." |
 | Adtelligent ID | Adtelligent | bidRequest.userId.adtelligentId | `"1111"` |

--- a/download.md
+++ b/download.md
@@ -246,6 +246,9 @@ These modules may require accounts with a service provider.<br/>
 <h4>User ID Modules</h4>
 <div class="row">  
   <div class="col-md-4"><div class="checkbox">
+  <label><input type="checkbox" moduleCode="33acrossIdSystem" class="bidder-check-box"> 33Across</label>
+  </div></div>
+  <div class="col-md-4"><div class="checkbox">
   <label><input type="checkbox" moduleCode="admixerIdSystem" class="bidder-check-box"> Admixer ID</label>
   </div></div>
   <div class="col-md-4"><div class="checkbox">


### PR DESCRIPTION
Add documentation for a new user id sub-module: 33acrossId

## 🏷 Type of documentation

- [ ] new bid adapter
- [ ] update bid adapter
- [X] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist

- [X] Related pull requests in prebid.js or server are linked
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
