### PR TITLE
fix for jekyll not starting with ruby 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages', '>= 30'
+
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
Jekyll doesn't start with ruby3 . This PR adds the dependency. 

https://github.com/jekyll/jekyll/issues/8523

## 🏷 Type of documentation

- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [X ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist

- [ ] Related pull requests in prebid.js or server are linked
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
