### PR TITLE
Fix `modulecode` for the ATS analytics adapter

### DIFF
--- a/dev-docs/analytics/ats.md
+++ b/dev-docs/analytics/ats.md
@@ -2,7 +2,7 @@
 layout: analytics
 title: ATS Analytics
 description: ATS Prebid Analytics Adapter
-modulecode: atsAnalyticsAdapter
+modulecode: ats
 gdpr_supported: true
 usp_supported: true
 prebid_member: true


### PR DESCRIPTION
The `modulecode` for the ATS analytics adapter is incorrect, which causes errors when trying to download it from Prebid.org (https://github.com/prebid/Prebid.js/issues/8376)

## 🏷 Type of documentation

- [x] bugfix (code examples)

## 📋 Checklist

- [x] Related pull requests in prebid.js or server are linked
