### PR TITLE
Fix wrong formatting of 33Across configuration params

### DIFF
--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -162,6 +162,7 @@ gulp build --modules=33acrossIdSystem,userId
 ```
 
 The following configuration parameters are available:
+
 {: .table .table-bordered .table-striped }
 | Param under userSync.userIds[] | Scope | Type | Description | Example |
 | --- | --- | --- | --- | --- |

--- a/download.md
+++ b/download.md
@@ -246,7 +246,7 @@ These modules may require accounts with a service provider.<br/>
 <h4>User ID Modules</h4>
 <div class="row">  
   <div class="col-md-4"><div class="checkbox">
-  <label><input type="checkbox" moduleCode="33acrossIdSystem" class="bidder-check-box"> 33Across</label>
+  <label><input type="checkbox" moduleCode="33acrossIdSystem" class="bidder-check-box"> 33Across ID</label>
   </div></div>
   <div class="col-md-4"><div class="checkbox">
   <label><input type="checkbox" moduleCode="admixerIdSystem" class="bidder-check-box"> Admixer ID</label>


### PR DESCRIPTION
Fix formatting of 33Across configuration params + Add missing ID suffix

## 🏷 Type of documentation

- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [X] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist

- [ ] Related pull requests in prebid.js or server are linked
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
