### PR TITLE
Remove notice of support of custom clientID

### DIFF
--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -1392,7 +1392,7 @@ pbjs.setConfig({
 
 Lotame’s Panorama ID module sends information from the request to its identity graph in order to successfully generate a Panorama ID. For more information on how the Panorama ID works, please visit [https://www.lotame.com/panorama/id/](https://www.lotame.com/panorama/id/).
 
-**Ease of Implementation**: Deployment of the Lotame Panorama ID module has been optimized for ease by not requiring any registration to utilize. Simply add the generic module to start producing the Panorama ID across your inventory. Clients who would like the advantage of additional options can register to receive their own client ID. Reach out to [PanoramaID@lotame.com](mailto:PanoramaID@lotame.com) to learn more about the optional registration.
+**Ease of Implementation**: Deployment of the Lotame Panorama ID module has been optimized for ease by not requiring any registration to utilize. Simply add the generic module to start producing the Panorama ID across your inventory.
 
 Lotame's privacy policy related to the Panorama ID and the collection of data and how data is used is available at [https://www.lotame.com/about-lotame/privacy/lotames-products-services-privacy-policy/](https://www.lotame.com/about-lotame/privacy/lotames-products-services-privacy-policy/). Consult with your legal counsel to determine the appropriate user disclosures with respect to use of the Lotame Panorama ID module.
 
@@ -1416,17 +1416,12 @@ NOTE: For optimal performance, the Lotame Panorama Id module should be called at
 | Param under userSync.userIds[] | Scope | Type | Description | Example |
 | --- | --- | --- | --- | --- |
 | name | Required | String | The name of the module | "lotamePanoramaId" |
-| params | Optional | Object | Configuration options for the Lotame Panorama ID Module | |
-| params.clientId | Optional | String | The Lotame Panorama Client ID | "1001" |
 
 {% highlight javascript %}
 pbjs.setConfig({
     userSync: {
         userIds: [{
             name: "lotamePanoramaId",
-            params: {
-                clientId: "Optional - See your Lotame Representative"
-            }
         }]
     }
 });


### PR DESCRIPTION
Removing the documentation nothing support of a custom ClientID to prevent any new implementations from using it.

## 🏷 Type of documentation

- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [ X ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist

- [ ] Related pull requests in prebid.js or server are linked
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
