### PR TITLE
Magnite adapter GVL ID update

### DIFF
--- a/dev-docs/bidders/slimcut.md
+++ b/dev-docs/bidders/slimcut.md
@@ -6,7 +6,7 @@ pbjs: true
 biddercode: slimcut
 media_types: video, banner
 gdpr_supported: true
-gvl_id: 52
+gvl_id: 102
 ---
 
 ### Overview

--- a/dev-docs/bidders/spotx.md
+++ b/dev-docs/bidders/spotx.md
@@ -11,7 +11,7 @@ schain_supported: true
 usp_supported: true
 safeframes_ok: false
 pbjs: true
-gvl_id: 52
+gvl_id: 165
 floors_supported: true
 ---
 

--- a/dev-docs/bidders/telaria.md
+++ b/dev-docs/bidders/telaria.md
@@ -16,7 +16,7 @@ safeframes_ok: false
 deals_supported: false
 pbs_app_supported: false
 fpd_supported: false
-gvl_id: 52
+gvl_id: 202
 ---
 
 ### Registration


### PR DESCRIPTION
Docs for https://github.com/prebid/Prebid.js/pull/8501

At this point, the various Magnite exchanges are not in fact able to use the same GVL ID.