### PR TITLE
Require supply chain module in mediakeys adapter

### DIFF
--- a/dev-docs/bidders/mediakeys.md
+++ b/dev-docs/bidders/mediakeys.md
@@ -167,9 +167,9 @@ Mediakeys fully supports the following [Prebid.js Modules](https://docs.prebid.o
 |-------------------------------------------------------------------------------------------------------|-----------------------------|
 | [Consent Management - GDPR](https://docs.prebid.org/dev-docs/modules/consentManagement.html)          | Required in Europe          |
 | [Consent Management - US Privacy](https://docs.prebid.org/dev-docs/modules/consentManagementUsp.html) | Required in US - California |
+| [Supply Chain Object](https://docs.prebid.org/dev-docs/modules/schain.html)                           | Required for all traffic    |
 | [Instream Tracking](https://docs.prebid.org/dev-docs/modules/instreamTracking.html)                   | Required for Instream Video |
 | [First Party Data Enrichment](https://docs.prebid.org/dev-docs/modules/enrichmentFpdModule.html)      | Recommended for all traffic |
-| [Supply Chain Object](https://docs.prebid.org/dev-docs/modules/schain.html)                           | Recommended for all traffic |
 
 Publishers must utilize the required modules in described scope to be able to receive bid responses.
 


### PR DESCRIPTION
## 🏷 Type of documentation

- [x] new feature: supply chain is now required for receiving a response from bidder

