### PR TITLE
appnexus First Party Data updates

### DIFF
--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -26,6 +26,7 @@ gvl_id: 32
 - [Custom Targeting keys](#custom-targeting-keys)
 - [Auction Level Keywords](#appnexus-auction-keywords)
 - [Passing Keys Without Values](#appnexus-no-value)
+- [First Party Data](#appnexus-fpd)
 - [User Sync in AMP](#appnexus-amp)
 - [Debug Auction](#appnexus-debug-auction)
 
@@ -179,6 +180,15 @@ keywords: {
   otherKeyword: ['']
 }
 ```
+
+<a name="appnexus-fpd" />
+
+#### First Party Data
+
+Publisher's should use the `ortb2` method of setting [First Party Data](https://docs.prebid.org/features/firstPartyData.html).
+
+At this time however, the `appnexus` bidder only reads the First Party Data when using the Prebid Server and Prebid Server Premium endpoints.  The client-side version of the `appnexus` bidder does not use the values from the First Party Data fields.
+
 
 <a name="appnexus-amp" />
 

--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -185,7 +185,7 @@ keywords: {
 
 #### First Party Data
 
-Publisher's should use the `ortb2` method of setting [First Party Data](https://docs.prebid.org/features/firstPartyData.html).
+Publishers should use the `ortb2` method of setting [First Party Data](https://docs.prebid.org/features/firstPartyData.html).
 
 At this time however, the `appnexus` bidder only reads the First Party Data when using the Prebid Server and Prebid Server Premium endpoints.  The client-side version of the `appnexus` bidder does not use the values from the First Party Data fields.
 

--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -189,6 +189,8 @@ Publishers should use the `ortb2` method of setting [First Party Data](https://d
 
 At this time however, the `appnexus` bidder only reads the First Party Data when using the Prebid Server and Prebid Server Premium endpoints.  The client-side version of the `appnexus` bidder does not use the values from the First Party Data fields.
 
+PBS/PSP supports all first party data fields: site, user, segments, and imp-level first party data.
+
 
 <a name="appnexus-amp" />
 


### PR DESCRIPTION
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

## 🏷 Type of documentation

- [x] update bid adapter


## 📋 Checklist

Related to #3444

Adds a clarifying note to the appnexus bidder file that clarifies when First Party Data is supported by the bidder.
