### PR TITLE
[Criteo] Add missing documentation on "publisherSubId" bid param

### DIFF
--- a/dev-docs/bidders/criteo.md
+++ b/dev-docs/bidders/criteo.md
@@ -39,6 +39,7 @@ of this value. See [Issue 6381](https://github.com/prebid/Prebid.js/issues/6381)
 | `networkId`       | required | The network ID from Criteo. Please reach out your Criteo representative for more details.                             | `456456`                                      | `integer`  |
 | `nativeCallback`  | optional | (Prebid.js only) Callback to perform render in native integrations. Please reach out your Criteo representative for more details.     | `function(payload) { console.log(payload); }` | `function` |
 | `integrationMode` | optional | (Prebid.js only) Integration mode to use for ad render (none or 'AMP'). Please reach out your Criteo representative for more details. | `'AMP'`                                       | `string`   |
+| `publisherSubId` | optional | Custom identifier for reporting. Please reach out your Criteo representative for more details. | `'adunit-1'` |  `string` |
 
 ### Video Object
 


### PR DESCRIPTION
Add documentation for missing "publisherSubId" bid param

## 🏷 Type of documentation

- [x] new feature

Address https://github.com/prebid/prebid.github.io/issues/3766