### PR TITLE
PBJS: update analytics adapter guide with new file paths

### DIFF
--- a/dev-docs/integrate-with-the-prebid-analytics-api.md
+++ b/dev-docs/integrate-with-the-prebid-analytics-api.md
@@ -91,10 +91,10 @@ The best way to get started is to look at some of the existing AnalyticsAdapter.
 Here's a skeleton outline:
 
 {% highlight js %}
-import {ajax} from 'src/ajax';
-import adapter from 'src/AnalyticsAdapter';
-import CONSTANTS from 'src/constants.json';
-import adaptermanager from 'src/adaptermanager';
+import {ajax} from '../src/ajax.js';
+import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
+import CONSTANTS from '../src/constants.json';
+import adaptermanager from '../src/adaptermanager.js';
 
 const analyticsType = 'endpoint';
 const url = 'URL_TO_SERVER_ENDPOINT';


### PR DESCRIPTION
With https://github.com/prebid/Prebid.js/pull/8599, analytics adapters need to import the base adapter from a different place - this updates the guide to reflect that.


## 🏷 Type of documentation

- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist

- [x] Related pull requests in prebid.js or server are linked
