### PR TITLE
Add working outstream with mediaType renderer example

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -1731,6 +1731,14 @@
   subgroup: 1
 
 - sbSecId: 4
+  title: 'No Server (Specify Renderer)'
+  link: /examples/video/outstream/pb-ve-outstream-no-server-specify-renderer.html
+  isHeader: 0
+  isSectionHeader: 0
+  sectionTitle:
+  subgroup: 1
+
+- sbSecId: 4
   title: "Long-Form (Ad Pods)"
   link:
   isHeader: 0

--- a/_includes/video/pb-os-nas-renderer.html
+++ b/_includes/video/pb-os-nas-renderer.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en" class="html--no-js">
+
+<head>
+{% include head--common.html %}
+    <!--production version of prebid.js-->
+    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+
+    <!--pbjs and player code -->
+    <script>
+        var pbjs = pbjs || {};
+        pbjs.que = pbjs.que || [];
+
+        var adUnits = [{
+            code: 'video1',
+            mediaTypes: {
+                video: {
+                    context: 'outstream',
+                    playerSize: [640, 480],
+                    mimes: ['video/mp4'],
+                    protocols: [1, 2, 3, 4, 5, 6, 7, 8],
+                    playbackmethod: [2],
+                    skip: 1,
+                    renderer: {
+                        render: function (bid) {
+                            ANOutstreamVideo.renderAd({
+                                targetId: bid.adUnitCode,
+                                adResponse: bid.adResponse,
+                            });
+                        },
+                        url: "https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js"
+                    },
+                }
+            },
+            bids: [{
+                bidder: 'appnexus',
+                params: {
+                    placementId: 13232385
+                }
+            }]
+        }];
+
+        pbjs.que.push(function() {
+            pbjs.addAdUnits(adUnits);
+            pbjs.requestBids({
+                timeout: 1000,
+                bidsBackHandler: function(bids) {
+                    var highestCpmBids = pbjs.getHighestCpmBids('video1');
+                    pbjs.renderAd(document, highestCpmBids[0].adId);
+                }
+            });
+        });
+    </script>
+</head>
+
+<body>

--- a/_includes/video/pb-os-nas-renderer.html
+++ b/_includes/video/pb-os-nas-renderer.html
@@ -1,56 +1,91 @@
 <!DOCTYPE html>
 <html lang="en" class="html--no-js">
+    <head>
+        {% include head--common.html %}
+        <!--production version of prebid.js-->
+        <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
 
-<head>
-{% include head--common.html %}
-    <!--production version of prebid.js-->
-    <script async src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
+        <!--pbjs and player code -->
+        <script>
+            var pbjs = pbjs || {};
+            pbjs.que = pbjs.que || [];
 
-    <!--pbjs and player code -->
-    <script>
-        var pbjs = pbjs || {};
-        pbjs.que = pbjs.que || [];
+            function callANRenderer(bid, ad) {
+              const adResponse = {
+                  ad: {
+                      video: {
+                          content: ad,
+                          player_width: 640,
+                          player_height: 480,
+                      }
+                  }
+              }
 
-        var adUnits = [{
-            code: 'video1',
-            mediaTypes: {
-                video: {
-                    context: 'outstream',
-                    playerSize: [640, 480],
-                    mimes: ['video/mp4'],
-                    protocols: [1, 2, 3, 4, 5, 6, 7, 8],
-                    playbackmethod: [2],
-                    skip: 1,
-                    renderer: {
-                        render: function (bid) {
-                            ANOutstreamVideo.renderAd({
-                                targetId: bid.adUnitCode,
-                                adResponse: bid.adResponse,
-                            });
+              bid.renderer.push(() => {
+                  window.ANOutstreamVideo.renderAd({
+                      targetId: bid.adUnitCode,
+                      adResponse,
+                  });
+              });
+            }
+
+            function render(bid) {
+                let ad = bid.ad || bid.vastXml;
+
+                if (ad) {
+                    callANRenderer(bid, ad)
+                } else {
+                    if (bid.vastUrl) {
+                      (async () => {
+                          ad = await fetch(resp).then(resp => resp.text());
+
+                          if (typeof ad === 'string') {
+                              callANRenderer(bid, ad);
+                          } else {
+                              console.log('Invalid VAST');
+                          }
+                      })();
+                    } else {
+                        console.log('Invalid ad');
+                    }
+                }
+            }
+
+            const adUnits = [{
+                code: 'video1',
+                mediaTypes: {
+                    video: {
+                        context: 'outstream',
+                        playerSize: [640, 480],
+                        mimes: ['video/mp4'],
+                        protocols: [1, 2, 3, 4, 5, 6, 7, 8],
+                        playbackmethod: [2],
+                        skip: 1,
+                        renderer: {
+                            render,
+                            url: "https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js"
                         },
-                        url: "https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js"
-                    },
-                }
-            },
-            bids: [{
-                bidder: 'appnexus',
-                params: {
-                    placementId: 13232385
-                }
-            }]
-        }];
+                    }
+                },
+                bids: [{
+                    bidder: 'appnexus',
+                    params: {
+                        placementId: 13232385
+                    }
+                }]
+            }];
 
-        pbjs.que.push(function() {
-            pbjs.addAdUnits(adUnits);
-            pbjs.requestBids({
-                timeout: 1000,
-                bidsBackHandler: function(bids) {
-                    var highestCpmBids = pbjs.getHighestCpmBids('video1');
-                    pbjs.renderAd(document, highestCpmBids[0].adId);
-                }
+            pbjs.que.push(function() {
+                pbjs.addAdUnits(adUnits);
+                pbjs.requestBids({
+                    timeout: 1000,
+                    bidsBackHandler: function(bids) {
+                        const highestCpmBids = pbjs.getHighestCpmBids('video1');
+                        pbjs.renderAd(document, highestCpmBids[0].adId);
+                    }
+                });
             });
-        });
-    </script>
-</head>
-
-<body>
+        </script>
+    </head>
+    <body>
+</html>

--- a/_layouts/video_sample.html
+++ b/_layouts/video_sample.html
@@ -44,6 +44,8 @@
 	{% include /video/pb-os-app.html %}
 {% elsif page.videoType == "pb-os-nas" %}
 	{% include /video/pb-os-nas.html %}
+{% elsif page.videoType == "pb-os-nas-renderer" %}
+	{% include /video/pb-os-nas-renderer.html %}
 {% elsif page.videoType == "pb-lf-fw" %}
 	{% include /video/pb-lf-fw.html %}
 {% elsif page.videoType == "pb-cp-fp" %}

--- a/examples/video/outstream/pb-ve-outstream-no-server-specify-renderer.html
+++ b/examples/video/outstream/pb-ve-outstream-no-server-specify-renderer.html
@@ -1,0 +1,123 @@
+---
+layout: video_sample
+title: Prebid Video | Video Outstream Example with No Ad Server using Specified Renderer
+description: An example of an outstream video with a pre-roll ad using Prebid.js and no ad server but with a specified renderer.
+videoType: pb-os-nas-renderer
+isVideo: true
+sidebarType: 4
+---
+
+
+
+<div class="container">
+	<div class="row">
+		<div class="vidHeader" style="width:75vw;">
+			<h1>{{ page.title }}</h1>
+			<p>{{page.description }}</p>
+		</div>
+
+		<!--video warning-->
+		<div class="pb-alert pb-alert-important">
+			<p style="color:#85720f"><b>Important:</b>
+			This example uses a test version of Prebid.js hosted on our CDN that is not recommended for production use. It includes all available adapters. Production implementations should build from source or customize the build using the Download page to make sure only the necessary bidder adapters are included.</p>
+		</div>
+
+		<div>
+
+			<div>
+
+				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+			</div>
+
+			<div id='video1'>
+				<p>Prebid Outstream Video Ad</p>
+            </div>
+
+	        <div>
+	            <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?</p>
+            </div>
+		</div>
+
+
+
+
+		<!--video code fencing-->
+
+		<!--header code example-->
+		<div class="pb-alert pb-alert-warning">
+			<p style="color:#a94443"><b>Warning:</b>
+			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
+		</div>
+
+    <h4>Place this code in the page header.</h4>
+		<div class="pb-code-hl-wrap">
+      <pre class="pb-code-hl">
+<!--put javascript code here-->
+&lt;script&gt;
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
+
+    var adUnits = [{
+        code: 'video1',
+        mediaTypes: {
+            video: {
+                context: 'outstream',
+                playerSize: [640, 480],
+                mimes: ['video/mp4'],
+                protocols: [1, 2, 3, 4, 5, 6, 7, 8],
+                playbackmethod: [2],
+                skip: 1,
+                renderer: {
+                    render: function (bid) {
+                        ANOutstreamVideo.renderAd({
+                            targetId: bid.adUnitCode,
+                            adResponse: bid.adResponse,
+                        });
+                    },
+                    url: "https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js"
+                },
+            }
+        },
+        bids: [{
+            bidder: 'appnexus',
+            params: {
+                placementId: 13232385
+            }
+        }]
+    }];
+
+    pbjs.que.push(function() {
+        pbjs.addAdUnits(adUnits);
+        pbjs.requestBids({
+            timeout: 1000,
+            bidsBackHandler: function(bids) {
+                var highestCpmBids = pbjs.getHighestCpmBids('video1');
+                pbjs.renderAd(document, highestCpmBids[0].adId);
+            }
+        });
+    });
+
+&lt;/script&gt;
+
+      </pre>
+    </div>
+
+			<h4>Place this code in the page body.</h4>
+      <div class="pb-code-hl-wrap">
+        <!--body code example-->
+        <pre class="pb-code-hl">
+<!--put body html and javascript here-->
+&lt;div id='video1'&gt;
+  &lt;p&gt;Prebid Outstream Video Ad&lt;/p&gt;
+&lt;/div&gt;
+        </pre>
+		</div>
+	</div>
+</div>
+
+<!--video player code-->
+<div id='video1'>
+	<p>Prebid Outstream Video Ad<p>
+</div>
+
+<script type="text/javascript" src="/assets/js/video/pb-code-highlight.js"></script>

--- a/examples/video/outstream/pb-ve-outstream-no-server-specify-renderer.html
+++ b/examples/video/outstream/pb-ve-outstream-no-server-specify-renderer.html
@@ -1,7 +1,7 @@
 ---
 layout: video_sample
 title: Prebid Video | Video Outstream Example with No Ad Server using Specified Renderer
-description: An example of an outstream video with a pre-roll ad using Prebid.js and no ad server but with a specified renderer.
+description: An example of an outstream video ad using Prebid.js and no ad server but with a specified renderer.
 videoType: pb-os-nas-renderer
 isVideo: true
 sidebarType: 4
@@ -57,7 +57,48 @@ sidebarType: 4
     var pbjs = pbjs || {};
     pbjs.que = pbjs.que || [];
 
-    var adUnits = [{
+    function callANRenderer(bid, ad) {
+      const adResponse = {
+          ad: {
+              video: {
+                  content: ad,
+                  player_width: 640,
+                  player_height: 480,
+              }
+          }
+      }
+
+      bid.renderer.push(() => {
+          window.ANOutstreamVideo.renderAd({
+              targetId: bid.adUnitCode,
+              adResponse,
+          });
+      });
+    }
+
+    function render(bid) {
+        let ad = bid.ad || bid.vastXml;
+
+        if (ad) {
+            callANRenderer(bid, ad)
+        } else {
+            if (bid.vastUrl) {
+              (async () => {
+                  ad = await fetch(resp).then(resp => resp.text());
+
+                  if (typeof ad === 'string') {
+                      callANRenderer(bid, ad);
+                  } else {
+                      console.log('Invalid VAST');
+                  }
+              })();
+            } else {
+                console.log('Invalid ad');
+            }
+        }
+    }
+
+    const adUnits = [{
         code: 'video1',
         mediaTypes: {
             video: {
@@ -68,12 +109,7 @@ sidebarType: 4
                 playbackmethod: [2],
                 skip: 1,
                 renderer: {
-                    render: function (bid) {
-                        ANOutstreamVideo.renderAd({
-                            targetId: bid.adUnitCode,
-                            adResponse: bid.adResponse,
-                        });
-                    },
+                    render,
                     url: "https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js"
                 },
             }
@@ -91,12 +127,11 @@ sidebarType: 4
         pbjs.requestBids({
             timeout: 1000,
             bidsBackHandler: function(bids) {
-                var highestCpmBids = pbjs.getHighestCpmBids('video1');
+                const highestCpmBids = pbjs.getHighestCpmBids('video1');
                 pbjs.renderAd(document, highestCpmBids[0].adId);
             }
         });
     });
-
 &lt;/script&gt;
 
       </pre>
@@ -113,11 +148,6 @@ sidebarType: 4
         </pre>
 		</div>
 	</div>
-</div>
-
-<!--video player code-->
-<div id='video1'>
-	<p>Prebid Outstream Video Ad<p>
 </div>
 
 <script type="text/javascript" src="/assets/js/video/pb-code-highlight.js"></script>

--- a/examples/video/outstream/pb-ve-outstream-no-server-specify-renderer.html
+++ b/examples/video/outstream/pb-ve-outstream-no-server-specify-renderer.html
@@ -10,48 +10,41 @@ sidebarType: 4
 
 
 <div class="container">
-	<div class="row">
-		<div class="vidHeader" style="width:75vw;">
-			<h1>{{ page.title }}</h1>
-			<p>{{page.description }}</p>
-		</div>
+    <div class="row">
+        <div class="vidHeader" style="width:75vw;">
+            <h1>{{ page.title }}</h1>
+            <p>{{page.description }}</p>
+        </div>
 
-		<!--video warning-->
-		<div class="pb-alert pb-alert-important">
-			<p style="color:#85720f"><b>Important:</b>
-			This example uses a test version of Prebid.js hosted on our CDN that is not recommended for production use. It includes all available adapters. Production implementations should build from source or customize the build using the Download page to make sure only the necessary bidder adapters are included.</p>
-		</div>
+        <!--video warning-->
+        <div class="pb-alert pb-alert-important">
+            <p style="color:#85720f"><b>Important:</b>
+            This example uses a test version of Prebid.js hosted on our CDN that is not recommended for production use. It includes all available adapters. Production implementations should build from source or customize the build using the Download page to make sure only the necessary bidder adapters are included.</p>
+        </div>
 
-		<div>
-
-			<div>
-
-				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-			</div>
-
-			<div id='video1'>
-				<p>Prebid Outstream Video Ad</p>
+        <div>
+            <div>
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             </div>
 
-	        <div>
-	            <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?</p>
+            <div id='video1'>
+                <p>Prebid Outstream Video Ad</p>
             </div>
-		</div>
 
+            <div>
+                <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?</p>
+            </div>
+        </div>
 
+        <!--header code example-->
+        <div class="pb-alert pb-alert-warning">
+            <p style="color:#a94443"><b>Warning:</b>
+            Do not forget to exchange the placementId in the code examples with your own placementId!</p>
+        </div>
 
-
-		<!--video code fencing-->
-
-		<!--header code example-->
-		<div class="pb-alert pb-alert-warning">
-			<p style="color:#a94443"><b>Warning:</b>
-			Do not forget to exchange the placementId in the code examples with your own placementId!</p>
-		</div>
-
-    <h4>Place this code in the page header.</h4>
-		<div class="pb-code-hl-wrap">
-      <pre class="pb-code-hl">
+        <h4>Place this code in the page header.</h4>
+        <div class="pb-code-hl-wrap">
+            <pre class="pb-code-hl">
 <!--put javascript code here-->
 &lt;script&gt;
     var pbjs = pbjs || {};
@@ -133,21 +126,20 @@ sidebarType: 4
         });
     });
 &lt;/script&gt;
+            </pre>
+        </div>
 
-      </pre>
-    </div>
-
-			<h4>Place this code in the page body.</h4>
-      <div class="pb-code-hl-wrap">
-        <!--body code example-->
-        <pre class="pb-code-hl">
+        <h4>Place this code in the page body.</h4>
+        <div class="pb-code-hl-wrap">
+            <!--body code example-->
+            <pre class="pb-code-hl">
 <!--put body html and javascript here-->
 &lt;div id='video1'&gt;
   &lt;p&gt;Prebid Outstream Video Ad&lt;/p&gt;
 &lt;/div&gt;
-        </pre>
-		</div>
-	</div>
+            </pre>
+        </div>
+    </div>
 </div>
 
 <script type="text/javascript" src="/assets/js/video/pb-code-highlight.js"></script>


### PR DESCRIPTION
This adds an example of a working outstream video implementation.

It would be great to start using more modern javascript in our examples like arrow functions and `const` etc. Please don't merge this until we have a chance to chat about it at our docs meeting.

Hoping to resolve prebid/Prebid.js#4699

It would help to have an open source and up-to-date renderer instead of the appnexus one. Hopefully we can add something like that in the future.

## 🏷 Type of documentation
- [ ✓] new examples

