### PR TITLE
registerDelay of ESP is actually milliseconds

### DIFF
--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -2486,7 +2486,7 @@ Please find more details [Share encrypted signals with bidders (Beta)](https://s
 | encryptedSignalSources.sources.source | Required | Array | An array of sources for which signals needs to be registered  | `['sharedid.org','criteo.com']` |
 | encryptedSignalSources.sources.encrypt | Required | Boolean | Should be set to false by default. Please find below note | `true` or `false` |
 | encryptedSignalSources.sources.customFunc | Required | function | This function will be defined for custom sources only and called which will return the custom data set from the page  | Check below config as an example  |
-| encryptedSignalSources.registerDelay | Optional | Integer | The amount of time (in seconds) after which registering of signals will happen. Default value 0 is considered if 'registerDelay' is not provided. |  `3000`
+| encryptedSignalSources.registerDelay | Optional | Integer | The amount of time (in milliseconds) after which registering of signals will happen. Default value 0 is considered if 'registerDelay' is not provided. |  `3000`
 
 {: .alert.alert-info :}
 **NOTE:**


### PR DESCRIPTION
## 🏷 Type of documentation

- [x] text edit only (wording, typos)


The `setTimeout` method takes _milliseconds_ as a parameter, not seconds. So the docs are not correct:
https://github.com/prebid/Prebid.js/blob/ea29fa16cbea64e85cbbc4c6dab85cea2afb6e0c/modules/userId/index.js#L720-L732