### PR TITLE
Criteo: remove disclosure on adId

### DIFF
--- a/dev-docs/bidders/criteo.md
+++ b/dev-docs/bidders/criteo.md
@@ -26,11 +26,6 @@ Criteo currently only supports getFloor if floors are in USD and if the publishe
 {: .alert.alert-warning :}
 Prebid-Server support is on alpha test and is currently a non-finished product. Activation requires setup and approval before beginning. Please reach out to your account manager or publishers@criteo.com for more details.
 
-### Disclosure
-
-This bidder sets `adId` on the bid response and hasn't responded to the Prebid.js team to confirm uniqueness
-of this value. See [Issue 6381](https://github.com/prebid/Prebid.js/issues/6381).
-
 ### Bid Params
 
 {: .table .table-bordered .table-striped }


### PR DESCRIPTION
bid.adId will no longer be set by Criteo so this pull-request aims at removing the disclosure on Criteo's documentation page.

See [#8783](https://github.com/prebid/Prebid.js/pull/8783) for the change in Prebid.js
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.
-->

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
