### PR TITLE
BetweenBidAdapter: default cur is USD

### DIFF
--- a/dev-docs/bidders/between.md
+++ b/dev-docs/bidders/between.md
@@ -20,6 +20,7 @@ safeframes_ok: false
 | Name          | Scope    | Description | Example | Type     |
 |---------------|----------|-------------|---------|----------|
 | `s` | required |  Section ID from Between SSP control panel | 999999 | `integer` |
+| `cur` | optional | 3-letter ISO 4217 code defining the currency of the bid (currently support USD and EUR), default is USD | `'USD'` | `string` |
 
 ### Prebid-Server Bid Params
 


### PR DESCRIPTION
## 🏷 Type of documentation
- [x] update bid adapter
- [x] new examples

## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked: https://github.com/prebid/Prebid.js/pull/8870

