### PR TITLE
Closed fenced code block

### DIFF
--- a/dev-docs/analytics/kargo.md
+++ b/dev-docs/analytics/kargo.md
@@ -20,3 +20,4 @@ pbjs.enableAnalytics({
       sampling: 100 // value out of 100
   }
 });
+```


### PR DESCRIPTION
A fenced code block missing its closing backticks was breaking the layout of https://docs.prebid.org/overview/analytics.html.

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [x] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples


