### PR TITLE
IX Bid Adapter: deprecate detectMissingSiez config

### DIFF
--- a/dev-docs/bidders/ix.md
+++ b/dev-docs/bidders/ix.md
@@ -349,25 +349,7 @@ pbjs.setConfig({
 ```
 
 #### The **detectMissingSizes** feature
-By default, the IX bidding adapter bids on all banner sizes available in the ad unit when configured to at least one banner size. If you want the IX bidding adapter to only bid on the banner size it’s configured to, switch off this feature using `detectMissingSizes`.
-```
-pbjs.setConfig({
-    ix: {
-        detectMissingSizes: false
-    }
-});
-```
-OR
-```
-pbjs.setBidderConfig({
-    bidders: ["ix"],
-    config: {
-        ix: {
-            detectMissingSizes: false
-        }
-    }
-});
-```
+`detectMissingSize` config is now deprecated and IX bidding adapter bids on all banner sizes available in the ad unit when configured to at least one banner size.
 
 ### 2. Include `ixBidAdapter` in your build process
 


### PR DESCRIPTION
Deprecates the usage of detectMissingSize config.

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked

prebid.js MR: https://github.com/prebid/Prebid.js/pull/8906
