### PR TITLE
fix FPD content keywords example

### DIFF
--- a/features/firstPartyData.md
+++ b/features/firstPartyData.md
@@ -279,7 +279,7 @@ pbjs.setConfig({
                 url: "http://foo_url.de",
                 cat: ["IAB1-1", "IAB1-2", "IAB2-10"],
                 context: "7",
-                keywords: ["k1", "k2"],
+                keywords: "k1,k2",
                 live: "0"
             }
         }


### PR DESCRIPTION

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] text edit only (wording, typos)

When reviewing the documentation for the First Party Data feature, in the **Supplying OpenRTB Content Data** example I noticed that the `keywords` value had an array of strings, which was different to the other keyword fields in other parts of the ortb2 examples.

I checked the ORTB2.5 [spec](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf) and confirmed that the keywords field in this area should be a comma separated string.  I made this PR to fix the type in the example.