### PR TITLE
Adagio: add `BidderSettings.storageAllowed` note

### DIFF
--- a/dev-docs/bidders/adagio.md
+++ b/dev-docs/bidders/adagio.md
@@ -18,7 +18,20 @@ fpd_supported: false
 
 ### Note
 
-The Adagio bidder adaptor requires setup and approval from the Adagio team. Please reach out to [contact@adagio.io](mailto:contact@adagio.io) for more information.
+The Adagio bidder adapter requires setup and approval from the Adagio team. Please reach out to [contact@adagio.io](mailto:contact@adagio.io) for more information.
+
+### Bidder Settings
+
+The Adagio bid adapter uses browser local storage. Since Prebid.js 7.x, the access to it must be explicitly set.
+
+```js
+// https://docs.prebid.org/dev-docs/publisher-api-reference/bidderSettings.html
+pbjs.bidderSettings = {
+  adagio: {
+    storageAllowed: true
+  }
+}
+```
 
 ### Bid Params
 


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.
-->

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] update bid adapter

Add a section in Adagio related to the need to explicitly set `bidderSettings.storageAllowed: true`.