### PR TITLE
Improve Digital adapter: Floors module support

### DIFF
--- a/dev-docs/bidders/improvedigital.md
+++ b/dev-docs/bidders/improvedigital.md
@@ -13,6 +13,7 @@ media_types: banner, native, video
 schain_supported: true
 gvl_id: 253
 pbs_app_supported: true
+floors_supported: true
 ---
 
 <a name="improvedigital-params"></a>


### PR DESCRIPTION
## 🏷 Type of documentation
- [X] update bid adapter

Improve Digital adapter has supported the floors module for quite a while but it seems the adapter doc says otherwise. Fixing it now.