### PR TITLE
Prebid core: document new `performanceMetrics` config

### DIFF
--- a/dev-docs/publisher-api-reference/setConfig.md
+++ b/dev-docs/publisher-api-reference/setConfig.md
@@ -34,6 +34,7 @@ Core config:
 + [First Party Data](#setConfig-fpd)
 + [Caching VAST XML](#setConfig-vast-cache)
 + [Site Metadata](#setConfig-site)
++ [Disable performance metrics](#setConfig-performanceMetrics)
 + [Generic Configuration](#setConfig-Generic-Configuration)
 + [Troubleshooting configuration](#setConfig-Troubleshooting-your-configuration)
 
@@ -1277,8 +1278,18 @@ Notes:
 - The only time `waitForIt` means anything is if some modules are flagged as true and others as false. If all modules are the same (true or false), it has no effect.
 - Likewise, `waitForIt` doesn't mean anything without an auctionDelay specified.
 
-<a name="setConfig-Generic-Configuration" />
 
+
+<a id="setConfig-performanceMetrics" />
+#### Disable performance metrics
+
+Since version 7.17, Prebid collects fine-grained performance metrics and attaches them to several events for the purpose of analytics. If you find that this generates much data for your analytics provider you may disable this feature with: 
+
+```
+pbjs.setConfig({performanceMetrics: false})
+```
+
+<a name="setConfig-Generic-Configuration" />
 #### Generic setConfig Configuration
 
 Some adapters may support other options, as defined in their documentation. To set arbitrary configuration values:


### PR DESCRIPTION
Document new config option introduced by https://github.com/prebid/Prebid.js/pull/8914

The code change also introduces a new property to various event payloads that is worth documenting, but I have not found a good place to do so - I don't think we try to document their structure anywhere at the moment?

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] new feature

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked
