### PR TITLE
add warning note on appnexus bidder for download page

### DIFF
--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -15,6 +15,7 @@ fpd_supported: true
 pbjs: true
 pbs: true
 gvl_id: 32
+pbjs_version_notes: avoid 7.15 and 7.16
 ---
 
 ### Disclosure:


### PR DESCRIPTION
## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] update bid adapter

Related https://github.com/prebid/Prebid.js/pull/9012 (fix) and https://github.com/prebid/Prebid.js/issues/9006 (issue)

There was a bug introduced in the appnexus adapter with the 7.15.0 release of Prebid.js.  It was recently reported, and a fix was prepared for the upcoming 7.17.0 release. 

As a result, we'd like to add a warning to the appnexus bid adapter on the download page of prebid.org, to advise people to avoid using the appnexus adapter with these particular versions.
