### PR TITLE
Remove notes for adapters referring to versions prior to 6.x

### DIFF
--- a/dev-docs/bidders/e_volution.md
+++ b/dev-docs/bidders/e_volution.md
@@ -11,7 +11,6 @@ pbs: true
 pbs_app_supported: true
 usp_supported: true
 schain_supported: true
-pbjs_version_notes: in 6.8+
 userIds: id5Id
 ---
 

--- a/dev-docs/bidders/ias.md
+++ b/dev-docs/bidders/ias.md
@@ -4,7 +4,6 @@ title: Integral Ad Science (IAS)
 description: Prebid Integral Ad Science Bidder Adaptor
 pbjs: true
 biddercode: ias
-pbjs_version_notes: for 5.x, use the module
 ---
 
 ### Note:

--- a/dev-docs/bidders/iprom.md
+++ b/dev-docs/bidders/iprom.md
@@ -6,7 +6,6 @@ biddercode: iprom
 media_types: banner
 pbjs: true
 enable_download: true
-pbjs_version_notes: not in 5.x, in 6.2+
 ---
 
 ### Prebid Server Note:

--- a/dev-docs/bidders/luponmedia.md
+++ b/dev-docs/bidders/luponmedia.md
@@ -9,7 +9,6 @@ usp_supported: true
 coppa_supported: true
 schain_supported: true
 userIds: digitrust, identityLink, liveIntentId, pubCommonId
-pbjs_version_notes: not in 5.x, in 6.2+
 ---
 
 ### Note:

--- a/dev-docs/bidders/missena.md
+++ b/dev-docs/bidders/missena.md
@@ -6,7 +6,6 @@ biddercode: missena
 gvl_id: 867
 pbjs: true
 safeframes_ok: false
-pbjs_version_notes: not in 5.x, in 6.2+
 ---
 
 ### Note

--- a/dev-docs/bidders/open8.md
+++ b/dev-docs/bidders/open8.md
@@ -6,7 +6,6 @@ pbjs: true
 biddercode: open8
 media_types: video, banner
 enable_download: true
-pbjs_version_notes: added version 6.16
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/optimera.md
+++ b/dev-docs/bidders/optimera.md
@@ -4,7 +4,6 @@ title: Optimera
 description: Optimera Bidder Adaptor
 pbjs: true
 biddercode: optimera
-pbjs_version_notes: for 5.x, use the module
 ---
 
 ### Bid Params

--- a/dev-docs/bidders/outbrain.md
+++ b/dev-docs/bidders/outbrain.md
@@ -14,7 +14,6 @@ pbs: true
 pbs_app_supported: true
 prebid_member: true
 userIds: id5Id, identityLink
-pbjs_version_notes: v4.35 and later
 floors_supported: true
 multiformat_supported: will-bid-on-one
 ---

--- a/dev-docs/bidders/smartx.md
+++ b/dev-docs/bidders/smartx.md
@@ -11,7 +11,6 @@ schain_supported: false
 usp_supported: true
 safeframes_ok: false
 pbjs: true
-pbjs_version_notes: avoid 4.31-4.39
 floors_supported: true
 ---
 

--- a/dev-docs/bidders/talkads.md
+++ b/dev-docs/bidders/talkads.md
@@ -12,7 +12,6 @@ safeframes_ok: false
 pbjs: true
 pbs: false
 prebid_member: false
-pbjs_version_notes: v4.35 and later
 ---
 
 ### Registration

--- a/dev-docs/bidders/turktelekom.md
+++ b/dev-docs/bidders/turktelekom.md
@@ -12,7 +12,6 @@ usp_supported: true
 coppa_supported: true
 pbs_app_supported: true
 schain_supported: true
-pbjs_version_notes: v5.18+
 safeframes_ok: true
 ---
 

--- a/dev-docs/bidders/vibrantmedia.md
+++ b/dev-docs/bidders/vibrantmedia.md
@@ -9,7 +9,6 @@ usp_supported: true
 media_types: banner, video, native
 safeframes_ok: false
 pbjs: true
-pbjs_version_notes: 6.4.0 and later
 ---
 
 ### Preliminaries


### PR DESCRIPTION
Clean up the download page with notes that are outdated or no longer reference a current maintained version