### PR TITLE
PBJS: document ORTB conversion library

### DIFF
--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -184,6 +184,7 @@ Prebid recommends keeping module HTTP requests 'simple' if at all possible. The 
 If you're the type that likes to skip to the answer instead of going through a tutorial, see the <a href="#bidder-example">Full Bid Adapter Example</a> below.
 
 + [Overview](#bidder-adaptor-Overview)
++ [Note on ORTB adapters](#ortb-adapters)
 + [Building the Request](#bidder-adaptor-Building-the-Request)
 + [Interpreting the Response](#bidder-adaptor-Interpreting-the-Response)
 + [Registering User Syncs](#bidder-adaptor-Registering-User-Syncs)
@@ -237,6 +238,12 @@ export const spec = {
 registerBidder(spec);
 
 {% endhighlight %}
+
+<a id="ortb-adapters" />
+
+### Note on ORTB adapters
+
+If your adapter interfaces with an ORTB backend, you may take advantage of Prebid's [ORTB conversion library](https://github.com/prebid/Prebid.js/blob/master/libraries/ortbConverter/README.md), which provides most of the implementation for `buildRequests` and `interpretResponse`. 
 
 <a name="bidder-adaptor-Building-the-Request" />
 


### PR DESCRIPTION
Document new PBJS-ORTB conversion library - https://github.com/prebid/Prebid.js/pull/8738, or rather, point to its documentation in source.

Note that the link won't be valid until that PR is merged into master; currently the source docs can be found at  https://github.com/dgirardi/Prebid.js/blob/pbjs-ortb-squash/libraries/ortbConverter/README.md

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] new feature

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked
