### PR TITLE
PBJS: add example on setting custom transactionId

### DIFF
--- a/features/firstPartyData.md
+++ b/features/firstPartyData.md
@@ -155,7 +155,7 @@ pbjs.addAdUnits({
     },
     ortb2Imp: {
         ext: {
-	    data: {
+	        data: {
                 pbadslot: "homepage-top-rect",
                 adUnitSpecificAttribute: "123"
             }
@@ -163,6 +163,24 @@ pbjs.addAdUnits({
     },
     ...
 });
+{% endhighlight %}
+
+You may also specify adUnit-specific transaction IDs using `ortb2Imp.ext.tid`, and Prebid will use them instead of generating random new ones. This is useful if you are auctioning the same slots through multiple header bidding libraries. Note that you should take care to not re-use the same transaction IDs across different ad units or auctions. For example:  
+
+{% highlight js %}
+const tid = crypto.randomUUID();
+pbjs.requestBids({
+   adUnits: [{
+    code: 'test-div',
+    // ...
+    ortb2Imp: {
+        ext: {
+          tid
+        }
+    }
+   }]
+});
+// reuse `tid` when auctioning `test-div` through some other header bidding wrapper   
 {% endhighlight %}
 
 {: .alert.alert-info :}

--- a/features/firstPartyData.md
+++ b/features/firstPartyData.md
@@ -165,7 +165,7 @@ pbjs.addAdUnits({
 });
 {% endhighlight %}
 
-You may also specify adUnit-specific transaction IDs using `ortb2Imp.ext.tid`, and Prebid will use them instead of generating random new ones. This is useful if you are auctioning the same slots through multiple header bidding libraries. Note that you should take care to not re-use the same transaction IDs across different ad units or auctions. For example:  
+You may also specify adUnit-specific transaction IDs using `ortb2Imp.ext.tid`, and Prebid will use them instead of generating random new ones. This is useful if you are auctioning the same slots through multiple header bidding libraries. Note: you must take care to not re-use the same transaction IDs across different ad units or auctions. Here's a simplified example passing a tid through the [requestBids](/dev-docs/publisher-api-reference/requestBids.html) function:
 
 {% highlight js %}
 const tid = crypto.randomUUID();
@@ -175,7 +175,7 @@ pbjs.requestBids({
     // ...
     ortb2Imp: {
         ext: {
-          tid
+          tid: tid
         }
     }
    }]


### PR DESCRIPTION
Add an example of setting `ortb2Imp.ext.tid`, followup to https://github.com/prebid/Prebid.js/issues/8807


## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked
