### PR TITLE
Improve Digital adapter: adding publisherId param

### DIFF
--- a/dev-docs/bidders/improvedigital.md
+++ b/dev-docs/bidders/improvedigital.md
@@ -24,6 +24,7 @@ floors_supported: true
 | Name           | Scope    | Description                                                                                                                | Example                                                                | Type      |
 |----------------|----------|----------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------|-----------|
 | `placementId`  | required | The placement ID from Improve Digital.                                                                                     | `1234567`                                                              | `integer` |
+| `publisherId`  | required | The publisher ID from Improve Digital.                                                                                     | `4567`                                                              | `integer` |
 | `keyValues`    | optional | Contains one or more key-value pairings for key-value targeting                                                            | `{ testKey1: ['testValueA'], testKey2: ['testValueB', 'testValueC'] }` | `object`  |
 | `bidFloor`  | optional | Bid floor price | `0.01` | `float` |
 | `bidFloorCur`  | optional | Bid floor price currency. Supported values: USD (default), EUR, GBP, AUD, DKK, SEK, CZK, CHF, NOK | `'USD'` | `string` |


### PR DESCRIPTION
Improve Digital adapter: adding publisherId param. The param is marked as "required" which would be a breaking change for our customers and so for an interim period our adapter won't enforce it. Making it mandatory is our longer term plan.

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] update bid adapter

