### PR TITLE
Fix the command in userId to be in alert-info section 

### DIFF
--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -1240,6 +1240,7 @@ LiveIntent offers audience resolution by leveraging our next-generation identity
 Build your Prebid.js package to include the LiveIntent nonID using the standard version which allows publishers to include the module with full functionalities, like hashing email addresses and identity resolution.
 
 Add the **full** LiveIntent Identity module to your Prebid.js package with:
+
 {: .alert.alert-info :}
 gulp build --modules=userId,liveIntentIdSystem
 


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.
-->
Currently the command is shown outside of the alert-info section:
<img width="896" alt="Screenshot 2022-11-23 at 10 40 54" src="https://user-images.githubusercontent.com/3535357/203514570-1a73c852-309c-4aa2-914b-24e84d455d8d.png">

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [x] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Related pull requests in prebid.js or server are linked
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
