### PR TITLE
Alert on ortb convesion and move up wording

### DIFF
--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -183,8 +183,11 @@ Prebid recommends keeping module HTTP requests 'simple' if at all possible. The 
 {: .alert.alert-success :}
 If you're the type that likes to skip to the answer instead of going through a tutorial, see the <a href="#bidder-example">Full Bid Adapter Example</a> below.
 
+{: .alert.alert-warning :}
+### Note on ORTB adapters
+If your adapter interfaces with an ORTB backend, you may take advantage of Prebid's [ORTB conversion library](https://github.com/prebid/Prebid.js/blob/master/libraries/ortbConverter/README.md), which provides most of the implementation for `buildRequests` and `interpretResponse`. 
+
 + [Overview](#bidder-adaptor-Overview)
-+ [Note on ORTB adapters](#ortb-adapters)
 + [Building the Request](#bidder-adaptor-Building-the-Request)
 + [Interpreting the Response](#bidder-adaptor-Interpreting-the-Response)
 + [Registering User Syncs](#bidder-adaptor-Registering-User-Syncs)

--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -185,6 +185,7 @@ If you're the type that likes to skip to the answer instead of going through a t
 
 {: .alert.alert-warning :}
 ### Note on ORTB adapters
+
 {: .alert.alert-warning :}
 If your adapter interfaces with an ORTB backend, you may take advantage of Prebid's [ORTB conversion library](https://github.com/prebid/Prebid.js/blob/master/libraries/ortbConverter/README.md), which provides most of the implementation for `buildRequests` and `interpretResponse`. 
 

--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -185,6 +185,7 @@ If you're the type that likes to skip to the answer instead of going through a t
 
 {: .alert.alert-warning :}
 ### Note on ORTB adapters
+{: .alert.alert-warning :}
 If your adapter interfaces with an ORTB backend, you may take advantage of Prebid's [ORTB conversion library](https://github.com/prebid/Prebid.js/blob/master/libraries/ortbConverter/README.md), which provides most of the implementation for `buildRequests` and `interpretResponse`. 
 
 + [Overview](#bidder-adaptor-Overview)


### PR DESCRIPTION
This adds an alert and makes more prominent the ORTB library when creating a new bid adapter.