### PR TITLE
fix video module code for download page

### DIFF
--- a/dev-docs/modules/video.md
+++ b/dev-docs/modules/video.md
@@ -4,7 +4,7 @@ title: Module - Video Module
 display_name: Prebid Video Module
 description: The Prebid Video Module allows Prebid to directly integrate with a Video Player.
 page_type: module
-module_code : video
+module_code : videoModule
 enable_download : true
 vendor_specific: false
 sidebarType : 1


### PR DESCRIPTION

## 🏷 Type of documentation
- [x] bugfix (code examples)

I received an internal report of trouble with the prebid.org download page when making prebid.js build that included the Prebid Video Module.

While debugging the build command, it seemed that the wrong value was set for the module code; it was `video` when it should be `videoModule` (based on the Prebid.js naming convention of the files).

This PR should hopefully fix the issue.
