### PR TITLE
Remove zeusPrimeRtdProvider documentation page

### DIFF
--- a/dev-docs/modules/zeusPrimeRtdProvider.md
+++ b/dev-docs/modules/zeusPrimeRtdProvider.md
@@ -9,9 +9,14 @@ module_type: rtd
 enable_download: true
 vendor_specific: true
 sidebarType: 1
+enable_download: false
 ---
 
 # Zeus Prime Real Time Data Module
+
+# NOTE: ZEUS PRIME HAS BEEN DEPRECATED!
+# THIS MODULE NO LONGER FUNCTIONS AND WILL BE REMOVED FROM A
+# FUTURE VERSION OF PREBID.
 
 The Zeus Prime RTD Provider provides integration of Zeus Prime onto sites with Prebid. This module will request information from Zeus Prime servers to add the page level targeting required for Prime into the customer's ad setup.
 


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.
-->
Removing the documentation page for the Zeus Prime RTD Module as we have deprecated the business.

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [x] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked

Prebid.js PR: prebid/Prebid.js#9358
