### PR TITLE
Rename synacormedia adapter to imds to reflect ownership change

### DIFF
--- a/dev-docs/bidders/imds.md
+++ b/dev-docs/bidders/imds.md
@@ -1,0 +1,95 @@
+---
+layout: bidder
+title: iMedia Digital Services (iMDS)
+description: Prebid iMedia Digital Services Bidder (iMDS) Adapter
+pbjs: true
+pbs: true
+biddercode: imds
+gdpr_supported: false
+usp_supported: true
+userIds: all
+media_types: banner, video
+coppa_supported: false
+schain_supported: true
+dchain_supported: false
+safeframes_ok: true
+pbs_app_supported: true
+deals_supported: false
+floors_supported: true
+fpd_supported: false
+ortb_blocking_supported: false
+multiformat_supported: will-bid-on-any
+prebid_member: false
+gvl_id: none
+sidebarType: 1
+---
+
+### Note:
+
+The iMedia Digital Services bidder adapter requires setup and approval from iMedia Digital Services. Please reach out to your account manager for more information and to start using it.
+
+### Configuration
+
+iMedia Digital Services requires that `iframe` is used for user syncing.
+
+Example configuration:
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+    filterSettings: {
+      iframe: {
+        bidders: '*', // represents all bidders
+        filter: 'include'
+      }
+    }
+  }
+});
+```
+
+### DFP Video Creative
+To use video, setup a `VAST redirect` creative within Google AdManager (DFP) with the following VAST tag URL:
+
+```
+https://track.technoratimedia.com/openrtb/tags?ID=%%PATTERN:hb_cache_id_synacorm%%&AUCTION_PRICE=%%PATTERN:hb_pb_synacormedia%%
+```
+
+### Bid params
+
+{: .table .table-bordered .table-striped }
+| Name | Scope | Description | Example | Type |
+| ---- | ----- | ----------- | ------- | ---- |
+| `seatId` | required | The seat ID from iMedia Digital Services. This will be the same for all ad units. | `'prebid'` | `string` |
+| `tagId` | required | The placement ID or tag ID from iMedia Digital Services. | `'demo1'` | `string` |
+| `placementId` | optional | Legacy parameter replaced by `tagId` | `'demo1'` | `string` |
+| `bidfloor` | optional | Legacy parameter for floor price for the request. Replaced by [Price Floors Module](/dev-docs/modules/floors.html) | `0.1` | `float` |
+
+### Example Ad Unit
+```javascript
+var adUnits = [{
+    "code": "test-div",
+    "mediaTypes": {
+        "video": {
+            "pos": 1,
+            "playerSize": [300, 250],
+            "context": "instream",
+            "mimes": ["video/mp4"],
+            "protocols": [2, 3, 5, 6, 7, 8],
+            "playbackmethod": [2],
+            "skip": 0,
+            "minduration": 15,
+            "maxduration": 30,
+            "startdelay": 0,
+            "linearity": 1
+        }
+    },
+    "bids": [{
+        "bidder": "imds",
+        "params": {
+            "seatId": "prebid",
+            "tagId": "demo1",
+            "bidfloor": 0.20
+        }
+    }]
+}]
+```

--- a/dev-docs/bidders/synacormedia.md
+++ b/dev-docs/bidders/synacormedia.md
@@ -1,97 +1,30 @@
 ---
 layout: bidder
 title: Synacor Media
-description: Prebid Synacor Media Bidder Adapter
+description: Prebid Synacor Media Bidder Adapter (replaced by "imds")
 pbjs: true
 pbs: true
 biddercode: synacormedia
-media_types: banner, video
-userIds: identityLink, verizonMediaId, pubCommonId
+aliasCode: imds
 gdpr_supported: false
-schain_supported: true
 usp_supported: true
+userIds: all
+media_types: banner, video
+coppa_supported: false
+schain_supported: true
+dchain_supported: false
+safeframes_ok: true
 pbs_app_supported: true
+deals_supported: false
+floors_supported: true
+fpd_supported: false
+ortb_blocking_supported: false
+multiformat_supported: will-bid-on-any
+prebid_member: false
+gvl_id: none
 sidebarType: 1
 ---
 
 ### Note:
 
-The Synacor Media bidder adapter requires setup and approval from Synacor. Please reach out to your account manager for more information and to start using it.
-
-### Configuration
-
-Synacor Media requires that iframe is used for user syncing.
-
-Example configuration:
-
-```javascript
-pbjs.setConfig({
-  userSync: {
-    filterSettings: {
-      iframe: {
-        bidders: '*', // represents all bidders
-        filter: 'include'
-      }
-    }
-  }
-});
-```
-
-### DFP Video Creative
-To use video, setup a `VAST redirect` creative within Google AdManager (DFP) with the following VAST tag URL:
-
-```
-https://track.technoratimedia.com/openrtb/tags?ID=%%PATTERN:hb_cache_id_synacorm%%&AUCTION_PRICE=%%PATTERN:hb_pb_synacormedia%%
-```
-
-### Bid params
-
-{: .table .table-bordered .table-striped }
-| Name | Scope | Description | Example | Type |
-| ---- | ----- | ----------- | ------- | ---- |
-| `seatId` | required | The seat ID from Synacor Media. This will be the same for all ad units. | `'prebid'` | `string` |
-| `tagId` | required | The placement or tag ID from Synacor Media. | `'demo1'` | `string` |
-| `bidfloor` | optional | The floor price for the request. | `0.1` | `float` |
-| `pos` | optional | The position of the placement on the page, see Open RTB spec v2.5. | `0` | `int` |
-| `video` | optional | Optional properties specific to video, see next table | `{ }` | Object |
-
-### Example Ad Unit
-```javascript
-var adUnits = [{
-    "code": "test-div",
-    "mediaTypes": {
-        "video": {
-            "playerSize": [300, 250],
-            "context": "instream",
-            "minduration": 15,
-            "maxduration": 30,
-            "startdelay": 1,
-            "linearity": 1
-        }
-    },
-    "bids": [{
-        "bidder": "synacormedia",
-        "params": {
-            "seatId": "prebid",
-            "tagId": "demo1",
-            "bidfloor": 0.20,
-            "pos": 1
-        }
-    }]
-}]
-```
-
-### Video Parameters (see openrtb 2.5 spec)
-
-{: .table .table-bordered .table-striped }
-| Name | Scope | Description | Default | Type |
-| ---- | ----- | ----------- | ------- | ---- |
-| `minduration` | optional | Minimum ad duration in seconds | `2` | `int` |
-| `maxduration` | optional | Maximum ad duration in seconds | `60` | `int` |
-| `startdelay` | optional | Indicates the start delay in seconds for pre-roll, mid-roll, or post-roll ad placements.  | `0` | `int` |
-| `placement` | optional | Placement type for the impression. | `null` | `int` |
-| `linearity` | optional | Indicates if the impression must be linear, nonlinear, etc. | `1` | `int` |
-| `mimes` | optional | Content MIME types supported. | `["video/mp4", "application/javascript"]` | Array(`String`) |
-| `protocols` | optional | Array of supported video protocols. | `[1,2,3,4,5,6,7]` | Array(`int`) |
-| `api` | optional | List of supported API frameworks for this impression. | `[1,2]` | Array(`int`) |
-| `playbackmethod` | optional | Single element array with supported playback methods for this video impression. If multiple values are supplied, first element will be used. | `[1]` | Array(`int`) |
+The Synacor Media bidder adapter has been renamed to the [iMedia Digital Services (iMDS)](/dev-docs/bidders/imds.html) adapter, using an bidder code of `imds`. Please update your implementation accordingly.


### PR DESCRIPTION
This renames the `synacormedia` adapter to `imds` while allowing existing implementations to continue using `synacormedia`. This also updates the features in the documentation to reflect what's already supported in the current master.


## 🏷 Type of documentation
- [x] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [x] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked
- [x] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)

https://github.com/prebid/prebid-server/pull/2508
https://github.com/prebid/Prebid.js/pull/9381