### PR TITLE
CWire: Introduce prebid server adapter

### DIFF
--- a/dev-docs/bidders/cwire.md
+++ b/dev-docs/bidders/cwire.md
@@ -8,7 +8,7 @@ biddercode: cwire
 gdpr_supported: false
 usp_supported: false
 schain_supported: false
-userIds: uid2Id
+userIds: none
 enable_download: true
 media_types: banner
 sidebarType: 1

--- a/dev-docs/bidders/cwire.md
+++ b/dev-docs/bidders/cwire.md
@@ -33,3 +33,4 @@ Additionally, the following parameters can be passed by URL parameters for testi
 | `cwcreative` | optional |   C-WIRE creative id to force    |       `&cwcreative=1234`        | `string` |
 | `cwgroups`   | optional |    C-WIRE group name to force    |     `&cwgroups=test-group`      | `string` |
 | `cwfeatures` | optional | Comma separated list of features | `&cwfeatures=feature1,feature2` | `string` |
+| `cwdebug`    | optional |            Debug flag            |         `&cwdebug=true`         | `string` |

--- a/dev-docs/bidders/cwire.md
+++ b/dev-docs/bidders/cwire.md
@@ -13,14 +13,23 @@ enable_download: true
 media_types: banner
 sidebarType: 1
 ---
+---
 
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
-| Name          | Scope    | Description           | Example   | Type      |
-|---------------|----------|-----------------------|-----------|-----------|
-| `pageId`      | required | C-WIRE page id        | `2453`    | `integer` |
-| `placementId` | required | C-WIRE placement id   | `113244`  | `integer` |
-| `cwcreative` | required | C-WIRE creative id to force   | `42`  | `integer` |
-| `refgroups` | required | C-WIRE group name to force   | `'test-user'`  | `string` |
-| `cwapikey` | required | C-WIRE API key for integration testing   | `'xxx-yyy-some-uuid'`  | `string` |
+| Name          |  Scope   |     Description     | Example  |   Type    |
+|---------------|:--------:|:-------------------:|:--------:|:---------:|
+| `pageId`      | required |   C-WIRE page id    |  `2453`  | `integer` |
+| `placementId` | required | C-WIRE placement id | `113244` | `integer` |
+
+### URL parameters
+
+Additionally, the following parameters can be passed by URL parameters for testing.
+
+{: .table .table-bordered .table-striped }
+| Name         |  Scope   |           Description            |             Example             |   Type   |
+|--------------|:--------:|:--------------------------------:|:-------------------------------:|:--------:|
+| `cwcreative` | optional |   C-WIRE creative id to force    |       `&cwcreative=1234`        | `string` |
+| `cwgroups`   | optional |    C-WIRE group name to force    |     `&cwgroups=test-group`      | `string` |
+| `cwfeatures` | optional | Comma separated list of features | `&cwfeatures=feature1,feature2` | `string` |

--- a/dev-docs/bidders/cwire.md
+++ b/dev-docs/bidders/cwire.md
@@ -3,6 +3,7 @@ layout: bidder
 title: C-WIRE
 description: C-WIRE Prebid Bidder Adapter
 pbjs: true
+pbs: true
 biddercode: cwire
 gdpr_supported: false
 usp_supported: false

--- a/dev-docs/bidders/cwire.md
+++ b/dev-docs/bidders/cwire.md
@@ -9,7 +9,7 @@ usp_supported: false
 schain_supported: false
 userIds: uid2Id
 enable_download: true
-media_types: banner, video
+media_types: banner
 sidebarType: 1
 ---
 


### PR DESCRIPTION
New CWire prebid server adapter supporting ORTB2 protocol.

## 🏷 Type of documentation
- new bid adapter

## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked
- [x] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
