### PR TITLE
How to add a bid adapter old doc cleanup

### DIFF
--- a/dev-docs/bidder-adapter-1.md
+++ b/dev-docs/bidder-adapter-1.md
@@ -1,9 +1,0 @@
----
-redirect_to: "/dev-docs/bidder-adaptor.html"
-layout: page_v2
-title: How to add a Prebid 1.0 Bidder Adapter
-description: Documentation on how to add a new bidder adapter
-top_nav_section: dev_docs
-nav_section: adapters
-
----

--- a/dev-docs/bidder-adapter.md
+++ b/dev-docs/bidder-adapter.md
@@ -1,7 +1,0 @@
----
-redirect_to: "/dev-docs/bidder-adaptor.html"
-layout: page_v2
-top_nav_section: dev_docs
-nav_section: adapters
-
----


### PR DESCRIPTION
In the file structure for how to create a new bid adapter there are 2 extra files. 1 has the same name as the file we use and only redirects to that file. The other is how to create a PBjs 1.0 adapter. Deleted both these as cleanup