### PR TITLE
GDPR enforcement wording update

### DIFF
--- a/dev-docs/modules/gdprEnforcement.md
+++ b/dev-docs/modules/gdprEnforcement.md
@@ -2,7 +2,7 @@
 layout: page_v2
 page_type: module
 title: GDPR Enforcement Module
-description: If you have users in Europe, you'll want this module that enforces GDPR consent
+description: If you have users in Europe, you'll want this module that takes action based on a user’s GDPR choices
 module_code : gdprEnforcement
 display_name : GDPR Enforcement
 enable_download : true
@@ -24,7 +24,7 @@ sidebarType : 1
 
 {: .alert.alert-warning :}
 This module requires the [EU GDPR consent management module](/dev-docs/modules/consentManagement.html) (the base consent module), which reads consent values from the Consent Management Platform (CMP). The GDPR Enforcement Module
-will then enforce the results. See the [base module page](/dev-docs/modules/consentManagement.html) for general background, usage, and legal disclaimers.
+will then take action based on the results. See the [base module page](/dev-docs/modules/consentManagement.html) for general background, usage, and legal disclaimers.
 
 ## Overview
 
@@ -41,7 +41,7 @@ The GDPR Enforcement Module adds the following:
 The following table details the Prebid.js activities that fall under the [Transparency and Consent Framework (TCF)](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/) scope:
 
 {: .table .table-bordered .table-striped }
-| In-Scope Activity | TCF Legal Basis Required | Enforcement Activity | Prebid.js Version |
+| In-Scope Activity | TCF Legal Basis Required | Activity | Prebid.js Version |
 | --- | --- | --- | --- |
 | Invoke usersync pixels | Purpose 1 - Store and/or access information on a device | May prevent one or more vendor usersyncs. | 3.14+ |
 | Invoke user ID modules | Purpose 1 - Store and/or access information on a device | May prevent one or more UserID modules from activating. | 3.14+ |
@@ -70,7 +70,7 @@ The following fields related to GDPR enforcement are supported in the [`consentM
 | gdpr.rules[].purpose | `String` | Supported values: "storage" (Purpose 1), "basicAds" (Purpose 2), "measurement" (Purpose 7) | "storage" |
 | gdpr.rules[].enforcePurpose | `Boolean` | Determines whether to enforce the purpose consent. The default in Prebid.js 3.x is not to enforce purposes. Prebid.js 4.0 enforces legal basis for Purposes 1 and 2 by default. | true |
 | gdpr.rules[].enforceVendor | `Boolean` | Determines whether to enforce vendor signals for this purpose. The default in Prebid.js 3.x is not to enforce vendor signals. Prebid.js 4.0 enforces legal basis for Purposes 1 and 2 by default. | true |
-| gdpr.rules[].vendorExceptions | `Array of Strings` | Defines a list of biddercodes or module names that are exempt from the enforcement of this Purpose. | ["bidderA", "userID-module-B"] |
+| gdpr.rules[].vendorExceptions | `Array of Strings` | Defines a list of biddercodes or module names that are exempt from restrictions around this Purpose. | ["bidderA", "userID-module-B"] |
 | strictStorageEnforcement | `Boolean` | If false (the default), allows some use of storage regardless of purpose 1 consent - see [note](#strictStorageEnforcement) below | true |
 
 Notes:
@@ -94,7 +94,7 @@ pbjs.setConfig({
 The following examples cover a range of use cases and show how Prebid.js supports
 configuration of different business rules.
 
-1) Enforce device access activity and basic ads. These are the default values (in Prebid.js 4.0) if the module is included in the build.
+1) Restrict device access activity and basic ads. These are the default values (in Prebid.js 4.0) if the module is included in the build.
 
 ```
 pbjs.setConfig({
@@ -120,7 +120,7 @@ pbjs.setConfig({
 });
 ```
 
-2) Enforce that the user consents to DeviceAccess as an activity and consider their per-vendor selection. However, idSystemA is a special case - the publisher has confirmed that this system obtains a user ID every auction and does not write to the local device.
+2) Restrict that the user consents to DeviceAccess as an activity and consider their per-vendor selection. However, idSystemA is a special case - the publisher has confirmed that this system obtains a user ID every auction and does not write to the local device.
 
       ...
       rules: [{
@@ -130,7 +130,7 @@ pbjs.setConfig({
         vendorExceptions: ["idSystemA"]
       }]
 
-3) Enforce legal basis for both storage and basicAds, with the exception of "firstPartyBidder", which is always allowed to run an auction. Assumes the publisher has special legal basis for this entity.
+3) Restrict for both storage and basicAds, with the exception of "firstPartyBidder", which is always allowed to run an auction. Assumes the publisher has special legal basis for this entity.
 
       ...
       rules: [{
@@ -144,7 +144,7 @@ pbjs.setConfig({
         vendorExceptions: ["firstPartyBidder"]
       }]
 
-4) Turn off enforcement of Purpose 1: don't enforce either the user's DeviceAccess consent or their per-vendor selection.
+4) Turn off restriction of Purpose 1: don't enforce either the user's DeviceAccess consent or their per-vendor selection.
 
       ...
       rules: [{
@@ -168,7 +168,7 @@ pbjs.setConfig({
 Prebid.js does not have access to the Global Vendor List (GVL), so it implements
 a "basic" form of TCF 'legal basis' validation using the supplied consent string.
 
-A goal of basic enforcement is to confirm that there's enough evidence of consent to pass data on to vendors who do have access to the GVL and can fully parse and enforce.
+A goal of 'basic enforcement' is to confirm that there's enough evidence of consent to pass data on to vendors who do have access to the GVL and can fully parse and enforce.
 
 Before allowing an activity tied to a TCF-protected Purpose for a given vendor, one of these scenarios must be true:
 


### PR DESCRIPTION
Replaced enforcement (the 'e-word') in the instances where it makes sense to do so. There are many places where it doesn't make sense to change it because that word is actually coded into the configuration.