### PR TITLE
VISX: Update type support for uid

### DIFF
--- a/dev-docs/bidders/visx.md
+++ b/dev-docs/bidders/visx.md
@@ -31,9 +31,9 @@ Please reach out to your account manager to enable Prebid.js for your account.
 ### Configuration: Currency
 
 {: .table .table-bordered .table-striped }
-| Name  | Scope    | Description                                                                                                                             | Example  | Type      |
-| ----- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
-| `uid` | required | The publisher's ad unit ID in VIS.X. The parameter can be either a `integer` or `string` for Prebid.js, however `integer` is preferred. | `903536` | `integer` |
+| Name  | Scope    | Description                                                                                                                              | Example  | Type      |
+| ----- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
+| `uid` | required | The publisher's ad unit ID in VIS.X. The parameter can be either an `integer` or `string` for Prebid.js, however `integer` is preferred. | `903536` | `integer` |
 
 ### Configuration
 
@@ -94,9 +94,9 @@ pbjs.setConfig({
 
 {: .table .table-bordered .table-striped }
 
-| Name  | Scope    | Description                                                                                                                             | Example  | Type      |
-| ----- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
-| `uid` | required | The publisher's ad unit ID in VIS.X. The parameter can be either a `integer` or `string` for Prebid.js, however `integer` is preferred. | `903536` | `integer` |
+| Name  | Scope    | Description                                                                                                                              | Example  | Type      |
+| ----- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
+| `uid` | required | The publisher's ad unit ID in VIS.X. The parameter can be either an `integer` or `string` for Prebid.js, however `integer` is preferred. | `903536` | `integer` |
 
 ### Media type Banner object params
 

--- a/dev-docs/bidders/visx.md
+++ b/dev-docs/bidders/visx.md
@@ -30,6 +30,13 @@ Please reach out to your account manager to enable Prebid.js for your account.
 
 ### Configuration: Currency
 
+{: .table .table-bordered .table-striped }
+| Name  | Scope    | Description                                                                                                                             | Example  | Type      |
+| ----- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
+| `uid` | required | The publisher's ad unit ID in VIS.X. The parameter can be either a `integer` or `string` for Prebid.js, however `integer` is preferred. | `903536` | `integer` |
+
+### Configuration
+
 The YOC VIS.X adapter has the ability to work in different currencies. Currently, this adapter supports `EUR`, `USD`,
 `GBP`, `PLN`. Defaults to `EUR`. If your Ad Server uses `EUR`, you don't need any additional currency settings.
 If you would like to trade with VIS.X in a currency different from `EUR`, you should implement some additional settings.
@@ -86,25 +93,26 @@ pbjs.setConfig({
 ### Bid params
 
 {: .table .table-bordered .table-striped }
-| Name  | Scope    | Description                         | Example    | Type     |
-|-------|----------|-------------------------------------|------------|----------|
-| `uid`   | required | The publisher's Ad unit ID in VIS.X. | `903536` | `integer` |
+
+| Name  | Scope    | Description                                                                                                                             | Example  | Type      |
+| ----- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
+| `uid` | required | The publisher's ad unit ID in VIS.X. The parameter can be either a `integer` or `string` for Prebid.js, however `integer` is preferred. | `903536` | `integer` |
 
 ### Media type Banner object params
 
 {: .table .table-bordered .table-striped }
-| Name  | Scope    | Description                         | Example    | Type     |
-|-------|----------|-------------------------------------|------------|----------|
-| `sizes`  | required | All sizes this ad unit can accept. | `[[300, 250], [300, 600]]` | `array of integer arrays` |
+| Name    | Scope    | Description                        | Example                    | Type                      |
+| ------- | -------- | ---------------------------------- | -------------------------- | ------------------------- |
+| `sizes` | required | All sizes this ad unit can accept. | `[[300, 250], [300, 600]]` | `array of integer arrays` |
 
 ### Media type Video object params
 
 {: .table .table-bordered .table-striped }
-| Name  | Scope    | Description                         | Example    | Type     |
-|-------|----------|-------------------------------------|------------|----------|
-| `context`     | required | The video context, only 'instream' is allowed. | `'instream'` | `string` |
-| `playerSize`  | required | The size (width, height) of the video player on the page, in pixels. | `[640, 480]` | `integer array` |
-| `mimes`       | optional | Content MIME types supported. | `['video/mp4', 'video/x-ms-wmv']` | `string array` |
+| Name         | Scope    | Description                                                          | Example                           | Type            |
+| ------------ | -------- | -------------------------------------------------------------------- | --------------------------------- | --------------- |
+| `context`    | required | The video context, only 'instream' is allowed.                       | `'instream'`                      | `string`        |
+| `playerSize` | required | The size (width, height) of the video player on the page, in pixels. | `[640, 480]`                      | `integer array` |
+| `mimes`      | optional | Content MIME types supported.                                        | `['video/mp4', 'video/x-ms-wmv']` | `string array`  |
 
 ### Example of Banner Ad unit
 


### PR DESCRIPTION
- Updated type documentation of `uid` that supports both `integer` and `string`, with `integer` being preferred.
- Synced to the latest upstream master

<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.
-->

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] update bid adapter

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked

### Related PRs
- prebid-server: https://github.com/prebid/prebid-server/pull/2501
- prebid-server-java: https://github.com/prebid/prebid-server-java/pull/2096
