### PR TITLE
Fix download page module name for userID modules

### DIFF
--- a/dev-docs/modules/userid-submodules/33across.md
+++ b/dev-docs/modules/userid-submodules/33across.md
@@ -2,7 +2,7 @@
 layout: userid
 title: 33Across ID
 description: 33Across ID User ID sub-module
-useridmodule: 33across
+useridmodule: 33acrossIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/33across.md
+++ b/dev-docs/modules/userid-submodules/33across.md
@@ -2,7 +2,7 @@
 layout: userid
 title: 33Across ID
 description: 33Across ID User ID sub-module
-useridmodule: 33acrossId
+useridmodule: 33across
 ---
 
 
@@ -49,5 +49,3 @@ pbjs.setConfig({
   }
 });
 ```
-
-

--- a/dev-docs/modules/userid-submodules/admixer.md
+++ b/dev-docs/modules/userid-submodules/admixer.md
@@ -2,7 +2,7 @@
 layout: userid
 title: AdmixerID
 description: AdmixerID User ID sub-module
-useridmodule: admixer
+useridmodule: admixerIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/admixer.md
+++ b/dev-docs/modules/userid-submodules/admixer.md
@@ -2,7 +2,7 @@
 layout: userid
 title: AdmixerID
 description: AdmixerID User ID sub-module
-useridmodule: admixerId
+useridmodule: admixer
 ---
 
 
@@ -50,4 +50,3 @@ gulp build --modules=admixerIdSystem
        }
    });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/adquery.md
+++ b/dev-docs/modules/userid-submodules/adquery.md
@@ -2,7 +2,7 @@
 layout: userid
 title: adQuery QiD
 description: adQuery QiD User ID sub-module
-useridmodule: qid
+useridmodule: adquery
 ---
 
 
@@ -40,4 +40,3 @@ This will add a `userId.qid` property to all bidRequests. This will be read by t
   qid: 'p9v2dpnuckkzhuc92i'
 }
 ```
-

--- a/dev-docs/modules/userid-submodules/adquery.md
+++ b/dev-docs/modules/userid-submodules/adquery.md
@@ -2,7 +2,7 @@
 layout: userid
 title: adQuery QiD
 description: adQuery QiD User ID sub-module
-useridmodule: adquery
+useridmodule: adqueryIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/adtelligent.md
+++ b/dev-docs/modules/userid-submodules/adtelligent.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Adtelligent
 description: Adtelligent User ID sub-module
-useridmodule: adtelligent
+useridmodule: adtelligentIdSystem
 ---
 
 
@@ -46,4 +46,3 @@ Example with a short storage for ~10 minutes and refresh in 5 minutes:
         }
     });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/amxrtb.md
+++ b/dev-docs/modules/userid-submodules/amxrtb.md
@@ -2,7 +2,7 @@
 layout: userid
 title: AMX RTB ID
 description: AMX RTB ID User ID sub-module
-useridmodule: amx
+useridmodule: amxIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/amxrtb.md
+++ b/dev-docs/modules/userid-submodules/amxrtb.md
@@ -2,7 +2,7 @@
 layout: userid
 title: AMX RTB ID
 description: AMX RTB ID User ID sub-module
-useridmodule: amxId
+useridmodule: amx
 ---
 
 

--- a/dev-docs/modules/userid-submodules/audienceone.md
+++ b/dev-docs/modules/userid-submodules/audienceone.md
@@ -2,7 +2,7 @@
 layout: userid
 title: AudienceOne ID by DAC
 description: AudienceOne ID by DAC User ID sub-module
-useridmodule: dac
+useridmodule: dacIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/audienceone.md
+++ b/dev-docs/modules/userid-submodules/audienceone.md
@@ -2,7 +2,7 @@
 layout: userid
 title: AudienceOne ID by DAC
 description: AudienceOne ID by DAC User ID sub-module
-useridmodule: dacId
+useridmodule: dac
 ---
 
 
@@ -37,4 +37,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/britepool.md
+++ b/dev-docs/modules/userid-submodules/britepool.md
@@ -2,7 +2,7 @@
 layout: userid
 title: BritePool
 description: BritePool User ID sub-module
-useridmodule: britepoolId
+useridmodule: britepool
 ---
 
 
@@ -56,4 +56,3 @@ The BritePool privacy policy is at [https://britepool.com/services-privacy-notic
        }
    });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/britepool.md
+++ b/dev-docs/modules/userid-submodules/britepool.md
@@ -2,7 +2,7 @@
 layout: userid
 title: BritePool
 description: BritePool User ID sub-module
-useridmodule: britepool
+useridmodule: britepoolIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/cpexid.md
+++ b/dev-docs/modules/userid-submodules/cpexid.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Czech Publisher Exchange ID (CPExID)
 description: Czech Publisher Exchange ID (CPExID) User ID sub-module
-useridmodule: cpexId
+useridmodule: cpex
 ---
 
 
@@ -29,4 +29,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/cpexid.md
+++ b/dev-docs/modules/userid-submodules/cpexid.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Czech Publisher Exchange ID (CPExID)
 description: Czech Publisher Exchange ID (CPExID) User ID sub-module
-useridmodule: cpex
+useridmodule: cpexIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/criteo.md
+++ b/dev-docs/modules/userid-submodules/criteo.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Criteo ID for Exchanges
 description: Criteo ID for Exchanges User ID sub-module
-useridmodule: criteo
+useridmodule: criteoIdSystem
 ---
 
 
@@ -35,4 +35,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/deepintent.md
+++ b/dev-docs/modules/userid-submodules/deepintent.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Deepintent
 description: Deepintent User ID sub-module
-useridmodule: deepintent
+useridmodule: deepintentIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/deepintent.md
+++ b/dev-docs/modules/userid-submodules/deepintent.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Deepintent
 description: Deepintent User ID sub-module
-useridmodule: deepintentId
+useridmodule: deepintent
 ---
 
 
@@ -59,4 +59,3 @@ pbjs.setConfig({
   }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/dmd.md
+++ b/dev-docs/modules/userid-submodules/dmd.md
@@ -2,7 +2,7 @@
 layout: userid
 title: DMD ID by DMD Marketing Corp
 description: DMD ID by DMD Marketing Corp User ID sub-module
-useridmodule: dmd
+useridmodule: dmdIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/dmd.md
+++ b/dev-docs/modules/userid-submodules/dmd.md
@@ -2,7 +2,7 @@
 layout: userid
 title: DMD ID by DMD Marketing Corp
 description: DMD ID by DMD Marketing Corp User ID sub-module
-useridmodule: dmdId
+useridmodule: dmd
 ---
 
 
@@ -44,4 +44,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/fabrick.md
+++ b/dev-docs/modules/userid-submodules/fabrick.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Fabrick ID by Neustar
 description: Fabrick ID by Neustar User ID sub-module
-useridmodule: fabrick
+useridmodule: fabrickIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/fabrick.md
+++ b/dev-docs/modules/userid-submodules/fabrick.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Fabrick ID by Neustar
 description: Fabrick ID by Neustar User ID sub-module
-useridmodule: fabrickId
+useridmodule: fabrick
 ---
 
 
@@ -81,4 +81,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/floc.md
+++ b/dev-docs/modules/userid-submodules/floc.md
@@ -2,7 +2,7 @@
 layout: userid
 title: FLoC ID
 description: FLoC ID User ID sub-module
-useridmodule: floc
+useridmodule: flocIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/floc.md
+++ b/dev-docs/modules/userid-submodules/floc.md
@@ -2,7 +2,7 @@
 layout: userid
 title: FLoC ID
 description: FLoC ID User ID sub-module
-useridmodule: flocId
+useridmodule: floc
 ---
 
 
@@ -25,5 +25,3 @@ A3dHTSoNUMjjERBLlrvJSelNnwWUCwVQhZ5tNQ+sll7y+LkPPVZXtB77u2y7CweRIxiYaGw
 GXNlW1/dFp8VMEgIAAAB+eyJvcmlnaW4iOiJodHRwczovL3NoYXJlZGlkLm9yZzo0NDMiLC
 JmZWF0dXJlIjoiSW50ZXJlc3RDb2hvcnRBUEkiLCJleHBpcnkiOjE2MjYyMjA3OTksImlzU
 3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWV9
-
-

--- a/dev-docs/modules/userid-submodules/ftrack.md
+++ b/dev-docs/modules/userid-submodules/ftrack.md
@@ -2,7 +2,7 @@
 layout: userid
 title: FTrack ID from Flashtalking By Mediaocean
 description: FTrack ID from Flashtalking By Mediaocean User ID sub-module
-useridmodule: ftrack
+useridmodule: ftrackIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/ftrack.md
+++ b/dev-docs/modules/userid-submodules/ftrack.md
@@ -2,7 +2,7 @@
 layout: userid
 title: FTrack ID from Flashtalking By Mediaocean
 description: FTrack ID from Flashtalking By Mediaocean User ID sub-module
-useridmodule: FTrack
+useridmodule: ftrack
 ---
 
 
@@ -56,4 +56,3 @@ pbjs.setConfig({
 | storage.name | Required | String | The name of the local storage where the user ID will be stored. FTrack **requires** `"FTrackId"`. | `"FTrackId"` |
 | storage.expires | Optional | Integer | How long (in days) the user ID information will be stored. FTrack recommends `90`. | `90` |
 | storage.refreshInSeconds | Optional | Integer | How many seconds until the FTrack ID will be refreshed. FTrack strongly recommends 8 hours between refreshes | `8*3600` |
-

--- a/dev-docs/modules/userid-submodules/gravito.md
+++ b/dev-docs/modules/userid-submodules/gravito.md
@@ -2,7 +2,7 @@
 layout: userid
 title: GRAVITO ID by Gravito Ltd.
 description: GRAVITO ID by Gravito Ltd. User ID sub-module
-useridmodule: gravitompId
+useridmodule: gravito
 ---
 
 
@@ -32,4 +32,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/gravito.md
+++ b/dev-docs/modules/userid-submodules/gravito.md
@@ -2,7 +2,7 @@
 layout: userid
 title: GRAVITO ID by Gravito Ltd.
 description: GRAVITO ID by Gravito Ltd. User ID sub-module
-useridmodule: gravito
+useridmodule: gravitoIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/growthcode.md
+++ b/dev-docs/modules/userid-submodules/growthcode.md
@@ -2,7 +2,7 @@
 layout: userid
 title: GrowthCode
 description: GrowthCode User ID sub-module
-useridmodule: growthCode
+useridmodule: growthCodeIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/growthcode.md
+++ b/dev-docs/modules/userid-submodules/growthcode.md
@@ -2,7 +2,7 @@
 layout: userid
 title: GrowthCode
 description: GrowthCode User ID sub-module
-useridmodule: growthCodeId
+useridmodule: growthCode
 ---
 
 
@@ -45,4 +45,3 @@ The following configuration parameters are available:
 | params.url | Optional | String | Custom URL for server | |
 | params.publisher_id | Optional | String | Name if the variable that holds your publisher ID | `"_sharedID"` |
 | params.publisher_id_storage | Optional | String | Publisher ID storage (cookie, html5) | `"html5"` |
-

--- a/dev-docs/modules/userid-submodules/hadron.md
+++ b/dev-docs/modules/userid-submodules/hadron.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Hadron ID from Audigent
 description: Hadron ID from Audigent User ID sub-module
-useridmodule: hadronId
+useridmodule: hadron
 ---
 
 
@@ -49,4 +49,3 @@ The following configuration parameters are available:
 | params.url | Optional | String | Set an alternate GET url for HadronId with this parameter |
 | params.urlArg | Optional | Object | Optional url parameter for params.url |
 | params.partnerId | Required | Number | This is the Audigent Partner ID obtained from Audigent. |
-

--- a/dev-docs/modules/userid-submodules/hadron.md
+++ b/dev-docs/modules/userid-submodules/hadron.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Hadron ID from Audigent
 description: Hadron ID from Audigent User ID sub-module
-useridmodule: hadron
+useridmodule: hadronIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/id5.md
+++ b/dev-docs/modules/userid-submodules/id5.md
@@ -2,7 +2,7 @@
 layout: userid
 title: ID5 Universal ID
 description: ID5 Universal ID User ID sub-module
-useridmodule: id5
+useridmodule: id5IdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/id5.md
+++ b/dev-docs/modules/userid-submodules/id5.md
@@ -2,7 +2,7 @@
 layout: userid
 title: ID5 Universal ID
 description: ID5 Universal ID User ID sub-module
-useridmodule: id5Id
+useridmodule: id5
 ---
 
 
@@ -76,4 +76,3 @@ pbjs.setConfig({
   }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/idplus.md
+++ b/dev-docs/modules/userid-submodules/idplus.md
@@ -2,7 +2,7 @@
 layout: userid
 title: ID+
 description: ID+ User ID sub-module
-useridmodule: zeotapIdPlus
+useridmodule: zeotapIdPlusIdSystem
 ---
 
 
@@ -34,5 +34,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-
-

--- a/dev-docs/modules/userid-submodules/idx.md
+++ b/dev-docs/modules/userid-submodules/idx.md
@@ -2,7 +2,7 @@
 layout: userid
 title: IDx
 description: IDx User ID sub-module
-useridmodule: idx
+useridmodule: idxIdSystem
 ---
 
 
@@ -39,4 +39,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/imuid.md
+++ b/dev-docs/modules/userid-submodules/imuid.md
@@ -2,7 +2,7 @@
 layout: userid
 title: IM-UID by Intimate Merger
 description: IM-UID by Intimate Merger User ID sub-module
-useridmodule: imuid
+useridmodule: imu
 ---
 
 IM-UID, provided by [Intimate Merger](https://corp.intimatemerger.com/), is a universal identifier that designed for publishers, platforms and advertisers to perform segmentation and targeting even in environments where 3rd party cookies are not available. IM-UID is currently only available in Japan.
@@ -42,4 +42,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/imuid.md
+++ b/dev-docs/modules/userid-submodules/imuid.md
@@ -2,7 +2,7 @@
 layout: userid
 title: IM-UID by Intimate Merger
 description: IM-UID by Intimate Merger User ID sub-module
-useridmodule: imu
+useridmodule: imuIdSystem
 ---
 
 IM-UID, provided by [Intimate Merger](https://corp.intimatemerger.com/), is a universal identifier that designed for publishers, platforms and advertisers to perform segmentation and targeting even in environments where 3rd party cookies are not available. IM-UID is currently only available in Japan.

--- a/dev-docs/modules/userid-submodules/intentiq.md
+++ b/dev-docs/modules/userid-submodules/intentiq.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Intent IQ ID
 description: Intent IQ ID User ID sub-module
-useridmodule: intentIqId
+useridmodule: intentIq
 ---
 
 
@@ -116,4 +116,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/intentiq.md
+++ b/dev-docs/modules/userid-submodules/intentiq.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Intent IQ ID
 description: Intent IQ ID User ID sub-module
-useridmodule: intentIq
+useridmodule: intentIqIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/just.md
+++ b/dev-docs/modules/userid-submodules/just.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Just ID
 description: Just ID User ID sub-module
-useridmodule: just
+useridmodule: justIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/just.md
+++ b/dev-docs/modules/userid-submodules/just.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Just ID
 description: Just ID User ID sub-module
-useridmodule: justId
+useridmodule: just
 ---
 
 
@@ -61,4 +61,3 @@ pbjs.setConfig({
 ## Just ID  Disclosure
 
 This module in `COMBINED` mode loads external JavaScript to generate optimal quality user ID. It is possible to retrieve user ID, without loading additional script by this module in `BASIC` mode.
-

--- a/dev-docs/modules/userid-submodules/kinesso.md
+++ b/dev-docs/modules/userid-submodules/kinesso.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Kinesso ID
 description: Kinesso ID User ID sub-module
-useridmodule: kpuid
+useridmodule: kinesso
 ---
 
 
@@ -38,4 +38,3 @@ The Kinesso ID privacy policy is covered under the [Kinesso Privacy Notice](http
 | name | Required | String | The name of this module. | `'kpuid'` |
 | params | Required | Object | Details for KinessoId initialization | |
 | params.accountid | Required | Int | Your SSP Account Id | 123 |
-

--- a/dev-docs/modules/userid-submodules/kinesso.md
+++ b/dev-docs/modules/userid-submodules/kinesso.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Kinesso ID
 description: Kinesso ID User ID sub-module
-useridmodule: kinesso
+useridmodule: kinessoIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/liveintent.md
+++ b/dev-docs/modules/userid-submodules/liveintent.md
@@ -2,7 +2,7 @@
 layout: userid
 title: LiveIntent nonID
 description: LiveIntent nonID User ID sub-module
-useridmodule: liveIntentId
+useridmodule: liveIntent
 ---
 
 
@@ -167,4 +167,3 @@ pbjs.setConfig({
     }
 })
 ```
-

--- a/dev-docs/modules/userid-submodules/liveintent.md
+++ b/dev-docs/modules/userid-submodules/liveintent.md
@@ -2,7 +2,7 @@
 layout: userid
 title: LiveIntent nonID
 description: LiveIntent nonID User ID sub-module
-useridmodule: liveIntent
+useridmodule: liveIntentIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/lotame.md
+++ b/dev-docs/modules/userid-submodules/lotame.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Lotame Panorama ID
 description: Lotame Panorama ID User ID sub-module
-useridmodule: lotamePanorama
+useridmodule: lotamePanoramaIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/lotame.md
+++ b/dev-docs/modules/userid-submodules/lotame.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Lotame Panorama ID
 description: Lotame Panorama ID User ID sub-module
-useridmodule: lotamePanoramaId
+useridmodule: lotamePanorama
 ---
 
 
@@ -44,4 +44,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/mediawallah.md
+++ b/dev-docs/modules/userid-submodules/mediawallah.md
@@ -2,7 +2,7 @@
 layout: userid
 title: MediaWallah OpenLinkID
 description: MediaWallah OpenLinkID User ID sub-module
-useridmodule: mwOpenLink
+useridmodule: mwOpenLinkIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/mediawallah.md
+++ b/dev-docs/modules/userid-submodules/mediawallah.md
@@ -2,7 +2,7 @@
 layout: userid
 title: MediaWallah OpenLinkID
 description: MediaWallah OpenLinkID User ID sub-module
-useridmodule: mwOpenLinkId
+useridmodule: mwOpenLink
 ---
 
 
@@ -46,4 +46,3 @@ pbjs.setConfig({
     }
 })
 ```
-

--- a/dev-docs/modules/userid-submodules/merkle.md
+++ b/dev-docs/modules/userid-submodules/merkle.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Merkle ID
 description: Merkle IDUser ID sub-module
-useridmodule: merkle
+useridmodule: merkleIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/merkle.md
+++ b/dev-docs/modules/userid-submodules/merkle.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Merkle ID
 description: Merkle IDUser ID sub-module
-useridmodule: merkleId
+useridmodule: merkle
 ---
 
 
@@ -30,4 +30,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/navegg.md
+++ b/dev-docs/modules/userid-submodules/navegg.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Navegg ID
 description: Navegg ID User ID sub-module
-useridmodule: navegg
+useridmodule: naveggIdSystem
 ---
 
 [Navegg](https://www.navegg.com) enables publishers, advertisers and agencies to use their own first party data together to activate media in a cookie-less way across several Ad Tech platforms. Navegg has one of the largest data networks in Latin America which also allows the enhancement of data with unique categories.

--- a/dev-docs/modules/userid-submodules/navegg.md
+++ b/dev-docs/modules/userid-submodules/navegg.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Navegg ID
 description: Navegg ID User ID sub-module
-useridmodule: naveggId
+useridmodule: navegg
 ---
 
 [Navegg](https://www.navegg.com) enables publishers, advertisers and agencies to use their own first party data together to activate media in a cookie-less way across several Ad Tech platforms. Navegg has one of the largest data networks in Latin America which also allows the enhancement of data with unique categories.
@@ -20,4 +20,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/netid.md
+++ b/dev-docs/modules/userid-submodules/netid.md
@@ -2,7 +2,7 @@
 layout: userid
 title: netID
 description: netID User ID sub-module
-useridmodule: netId
+useridmodule: net
 ---
 
 
@@ -26,4 +26,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/netid.md
+++ b/dev-docs/modules/userid-submodules/netid.md
@@ -2,7 +2,7 @@
 layout: userid
 title: netID
 description: netID User ID sub-module
-useridmodule: net
+useridmodule: netIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/novatiq.md
+++ b/dev-docs/modules/userid-submodules/novatiq.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Novatiq Hyper ID
 description: Novatiq Hyper ID User ID sub-module
-useridmodule: novatiq
+useridmodule: novatiqIdSystem
 ---
 
 
@@ -93,5 +93,3 @@ pbjs.setConfig({
 
 
 If you have any questions, please reach out to us at [prebid@novatiq.com](mailto:prebid@novatiq.com)
-
-

--- a/dev-docs/modules/userid-submodules/onekey.md
+++ b/dev-docs/modules/userid-submodules/onekey.md
@@ -2,7 +2,7 @@
 layout: userid
 title: OneKey IDs & Preferences
 description: OneKey IDs & Preferences User ID sub-module
-useridmodule: oneKeyData
+useridmodule: oneKey
 ---
 
 
@@ -48,4 +48,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/onekey.md
+++ b/dev-docs/modules/userid-submodules/onekey.md
@@ -2,7 +2,7 @@
 layout: userid
 title: OneKey IDs & Preferences
 description: OneKey IDs & Preferences User ID sub-module
-useridmodule: oneKey
+useridmodule: oneKeyIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/parrable.md
+++ b/dev-docs/modules/userid-submodules/parrable.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Parrable ID
 description: Parrable ID User ID sub-module
-useridmodule: parrableId
+useridmodule: parrable
 ---
 
 
@@ -75,4 +75,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/parrable.md
+++ b/dev-docs/modules/userid-submodules/parrable.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Parrable ID
 description: Parrable ID User ID sub-module
-useridmodule: parrable
+useridmodule: parrableIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/publisherlink.md
+++ b/dev-docs/modules/userid-submodules/publisherlink.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Publisher Link
 description: Publisher Link User ID sub-module
-useridmodule: publink
+useridmodule: publinkIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/publisherlink.md
+++ b/dev-docs/modules/userid-submodules/publisherlink.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Publisher Link
 description: Publisher Link User ID sub-module
-useridmodule: publinkId
+useridmodule: publink
 ---
 
 
@@ -51,4 +51,3 @@ In addition to the parameters documented above in the Basic Configuration sectio
        }
    });
 ```
-

--- a/dev-docs/modules/userid-submodules/pubprovided.md
+++ b/dev-docs/modules/userid-submodules/pubprovided.md
@@ -2,7 +2,7 @@
 layout: userid
 title: PubProvided ID
 description: PubProvided ID User ID sub-module
-useridmodule: pubProvided
+useridmodule: pubProvidedIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/pubprovided.md
+++ b/dev-docs/modules/userid-submodules/pubprovided.md
@@ -2,7 +2,7 @@
 layout: userid
 title: PubProvided ID
 description: PubProvided ID User ID sub-module
-useridmodule: pubProvidedId
+useridmodule: pubProvided
 ---
 
 
@@ -86,4 +86,3 @@ gulp build --modules=pubProvidedIdSystem
 | params.eidsFunction | Optional | function | any function that exists in the page | getIdsFn() |
 | uids.atype | optional | int | ADCOM - Type of user agent the match is from | `"1"` |
 | uids.ext.stype | Optional | String | Description of how the id was generated and by whom ('ppuid','DMP','other') | `DMP` |
-

--- a/dev-docs/modules/userid-submodules/quantcast.md
+++ b/dev-docs/modules/userid-submodules/quantcast.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Quantcast ID
 description: Quantcast ID User ID sub-module
-useridmodule: quantcastId
+useridmodule: quantcast
 ---
 
 The Prebid Quantcast ID module stores a Quantcast ID in a first party cookie. The ID is then made available in the bid request. The ID from the cookie added in the bidstream allows Quantcast to more accurately bid on publisher inventories without third party cookies, which can result in better monetization across publisher sites from Quantcast. And, it’s free to use! For easier integration, you can work with one of our SSP partners, like PubMatic, who can facilitate the legal process as well as the software integration for you.
@@ -43,6 +43,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-
-
-

--- a/dev-docs/modules/userid-submodules/quantcast.md
+++ b/dev-docs/modules/userid-submodules/quantcast.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Quantcast ID
 description: Quantcast ID User ID sub-module
-useridmodule: quantcast
+useridmodule: quantcastIdSystem
 ---
 
 The Prebid Quantcast ID module stores a Quantcast ID in a first party cookie. The ID is then made available in the bid request. The ID from the cookie added in the bidstream allows Quantcast to more accurately bid on publisher inventories without third party cookies, which can result in better monetization across publisher sites from Quantcast. And, it’s free to use! For easier integration, you can work with one of our SSP partners, like PubMatic, who can facilitate the legal process as well as the software integration for you.

--- a/dev-docs/modules/userid-submodules/ramp.md
+++ b/dev-docs/modules/userid-submodules/ramp.md
@@ -2,7 +2,7 @@
 layout: userid
 title: RampID
 description: RampID User ID sub-module
-useridmodule: identityLink
+useridmodule: identityLinkIdSystem
 ---
 
 
@@ -84,4 +84,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/sharedid.md
+++ b/dev-docs/modules/userid-submodules/sharedid.md
@@ -2,7 +2,7 @@
 layout: userid
 title: SharedID
 description: SharedID User ID sub-module
-useridmodule: shared
+useridmodule: sharedIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/sharedid.md
+++ b/dev-docs/modules/userid-submodules/sharedid.md
@@ -2,7 +2,7 @@
 layout: userid
 title: SharedID
 description: SharedID User ID sub-module
-useridmodule: sharedId
+useridmodule: shared
 ---
 
 
@@ -102,4 +102,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/tapad.md
+++ b/dev-docs/modules/userid-submodules/tapad.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Tapad ID
 description: Tapad ID User ID sub-module
-useridmodule: tapadId
+useridmodule: tapad
 ---
 
 
@@ -48,4 +48,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/tapad.md
+++ b/dev-docs/modules/userid-submodules/tapad.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Tapad ID
 description: Tapad ID User ID sub-module
-useridmodule: tapad
+useridmodule: tapadIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/teads.md
+++ b/dev-docs/modules/userid-submodules/teads.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Teads ID
 description: Teads ID User ID sub-module
-useridmodule: teadsId
+useridmodule: teads
 pbjs_version_notes: please avoid using v7.20.0 and v7.21.0
 ---
 
@@ -50,5 +50,3 @@ This will add a `userId.teadsId` property to all bidRequests. This will be read 
   teadsId: '2e3a00de-3800-11ed-a261-0242ac120002'
 }
 ```
-
-

--- a/dev-docs/modules/userid-submodules/teads.md
+++ b/dev-docs/modules/userid-submodules/teads.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Teads ID
 description: Teads ID User ID sub-module
-useridmodule: teads
+useridmodule: teadsIdSystem
 pbjs_version_notes: please avoid using v7.20.0 and v7.21.0
 ---
 

--- a/dev-docs/modules/userid-submodules/trustpid.md
+++ b/dev-docs/modules/userid-submodules/trustpid.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Trustpid
 description: Trustpid User ID sub-module
-useridmodule: trustpid
+useridmodule: trustp
 ---
 
 
@@ -51,4 +51,3 @@ pbjs.setConfig({
 ## Truspid onboarding
 
 If you wish to find out more about Trustpid, please contact onboarding@trustpid.com
-

--- a/dev-docs/modules/userid-submodules/trustpid.md
+++ b/dev-docs/modules/userid-submodules/trustpid.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Trustpid
 description: Trustpid User ID sub-module
-useridmodule: trustp
+useridmodule: trustpidSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/unified.md
+++ b/dev-docs/modules/userid-submodules/unified.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Unified ID
 description: Unified ID User ID sub-module
-useridmodule: unifiedId
+useridmodule: unified
 ---
 
 
@@ -93,4 +93,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/unified.md
+++ b/dev-docs/modules/userid-submodules/unified.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Unified ID
 description: Unified ID User ID sub-module
-useridmodule: unified
+useridmodule: unifiedIdSystem
 ---
 
 

--- a/dev-docs/modules/userid-submodules/unified2.md
+++ b/dev-docs/modules/userid-submodules/unified2.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Unified ID 2.0
 description: Unified ID 2.0 User ID sub-module
-useridmodule: uid2
+useridmodule: uid2IdSystem
 ---
 
 
@@ -84,4 +84,3 @@ pbjs.setConfig({
     }
 });
 {% endhighlight %}
-

--- a/dev-docs/modules/userid-submodules/yahoo.md
+++ b/dev-docs/modules/userid-submodules/yahoo.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Yahoo ConnectID
 description: Yahoo ConnectID User ID sub-module
-useridmodule: connect
+useridmodule: connectIdSystem
 ---
 
 Yahoo ConnectID is a person based ID and does not depend on 3rd party cookies. It enables ad tech platforms to recognize and match users consistently across the open web. Built on top of Yahoo’s robust and proprietary ID Graph it delivers a higher find rate of audiences on publishers’ sites user targeting that respects privacy.

--- a/dev-docs/modules/userid-submodules/yahoo.md
+++ b/dev-docs/modules/userid-submodules/yahoo.md
@@ -2,7 +2,7 @@
 layout: userid
 title: Yahoo ConnectID
 description: Yahoo ConnectID User ID sub-module
-useridmodule: connectId
+useridmodule: connect
 ---
 
 Yahoo ConnectID is a person based ID and does not depend on 3rd party cookies. It enables ad tech platforms to recognize and match users consistently across the open web. Built on top of Yahoo’s robust and proprietary ID Graph it delivers a higher find rate of audiences on publishers’ sites user targeting that respects privacy.
@@ -106,4 +106,3 @@ pbjs.setConfig({
     }
 })
 ```
-

--- a/download.md
+++ b/download.md
@@ -268,7 +268,7 @@ These modules may require accounts with a service provider.<br/>
 
 <h4>User ID Modules</h4>
 <div class="row">
- {% for page in userid_pages %}{% if page.enable_download == false %}{% continue %}{% endif %}<div class="col-md-4"><div class="checkbox"><label> <input type="checkbox" id="{{ page.useridmodule }}IdSystem" moduleCode="{{ page.useridmodule }}IdSystem" class="bidder-check-box"> <a href="{{page.url}}">{{ page.title }}</a></label>{% if page.pbjs_version_notes %}<br/><div style="font-size:80%">{{page.pbjs_version_notes}}</div>{% endif %}
+ {% for page in userid_pages %}{% if page.enable_download == false %}{% continue %}{% endif %}<div class="col-md-4"><div class="checkbox"><label> <input type="checkbox" id="{{ page.useridmodule }}" moduleCode="{{ page.useridmodule }}" class="bidder-check-box"> <a href="{{page.url}}">{{ page.title }}</a></label>{% if page.pbjs_version_notes %}<br/><div style="font-size:80%">{{page.pbjs_version_notes}}</div>{% endif %}
 </div></div>{% endfor %}
 </div>
 


### PR DESCRIPTION
After https://github.com/prebid/prebid.github.io/pull/4262 the download page stopped working for a bunch of userID modules.

Related: https://github.com/prebid/Prebid.js/issues/9424

