### PR TITLE
IX Bid Adapter: add gpp support flag to ix bidder doc

### DIFF
--- a/dev-docs/bidders/ix.md
+++ b/dev-docs/bidders/ix.md
@@ -12,6 +12,7 @@ coppa_supported: true
 gdpr_supported: true
 floors_supported: true
 usp_supported: true
+gpp_supported: true
 media_types: banner, video, native
 fpd_supported: true
 gvl_id: 10


### PR DESCRIPTION
## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

Adds GPP support to IX bidder doc.

PBJS: https://github.com/prebid/Prebid.js/blob/master/modules/ixBidAdapter.js#L722
Prebid Server: adapter passes regs to exchange.

For more information contact shahin.rahbariasl@indexexchange.com.
