### PR TITLE
remove reference to installedmodules returning an empty array

### DIFF
--- a/dev-docs/publisher-api-reference/installedModules.md
+++ b/dev-docs/publisher-api-reference/installedModules.md
@@ -13,6 +13,3 @@ gulp build --modules=a,b,c
 ```
 
 pbjs.installedModules would have the value ['a','b','c'].
-
-If you happen to compile in all 400+ modules (not a good idea!), the value of pbjs.installedModules will be an empty array.
-


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.
-->

Per discussion on Slack, this removes the outdated documentation that if all modules are included, an empty array is returned. In modern Prebid.js, all modules will be returned from the API. 

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [x] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->

