### PR TITLE
MobileFuse Adapter: native support added to docs

### DIFF
--- a/dev-docs/bidders/mobilefuse.md
+++ b/dev-docs/bidders/mobilefuse.md
@@ -3,7 +3,7 @@ layout: bidder
 title: MobileFuse
 pbs: true
 pbjs: false
-media_types: banner, video
+media_types: banner, video, native
 gdpr_supported: true
 schain_supported: true
 usp_supported: true


### PR DESCRIPTION
Added "native" under media_types to reflect the support of native that was added to the MobileFuse Adapter, 
pull request: (https://github.com/prebid/prebid-server/pull/2517)

## 🏷 Type of documentation
- [x] new feature
- [x] text edit only (wording, typos) 

## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked