### PR TITLE
Publisher API Reference: Added doc page for pbjs.aliasRegistry

### DIFF
--- a/dev-docs/publisher-api-reference/aliasRegistry.md
+++ b/dev-docs/publisher-api-reference/aliasRegistry.md
@@ -6,18 +6,19 @@ sidebarType: 1
 ---
 
 
-Exposes the aliasRegistry:
+Exposes the aliasRegistry. It can be used to fetch the entire aliasRegistry object or an individual adapter code by alias name.
 
 {% highlight js %}
 
-pbjs.aliasRegistry;
-
-or
-
-pbjs.aliasRegistry[aliasName];
+pbjs.aliasRegistry; or pbjs.aliasRegistry[aliasName];
 
 {% endhighlight %}
 
-Can be used to fetch the entire aliasRegistry object or an individual adapter code by alias name.
+{: .alert.alert-warning :}
+Note that by default, the alias registry will be made public.  If you would like the registry to be private, you can utilize the `setConfig` option below:
+
+```
+pbjs.setConfig({aliasRegistry: 'private'})
+```
 
 <hr class="full-rule" />

--- a/dev-docs/publisher-api-reference/aliasRegistry.md
+++ b/dev-docs/publisher-api-reference/aliasRegistry.md
@@ -1,0 +1,23 @@
+---
+layout: api_prebidjs
+title: pbjs.aliasRegistry
+description:
+sidebarType: 1
+---
+
+
+Exposes the aliasRegistry:
+
+{% highlight js %}
+
+pbjs.aliasRegistry;
+
+or
+
+pbjs.aliasRegistry[aliasName];
+
+{% endhighlight %}
+
+Can be used to fetch the entire aliasRegistry object or an individual adapter code by alias name.
+
+<hr class="full-rule" />

--- a/dev-docs/publisher-api-reference/setConfig.md
+++ b/dev-docs/publisher-api-reference/setConfig.md
@@ -39,6 +39,7 @@ Core config:
 + [Caching VAST XML](#setConfig-vast-cache)
 + [Site Metadata](#setConfig-site)
 + [Disable performance metrics](#setConfig-performanceMetrics)
++ [Setting alias registry to private](#setConfig-aliasRegistry)
 + [Generic Configuration](#setConfig-Generic-Configuration)
 + [Troubleshooting configuration](#setConfig-Troubleshooting-your-configuration)
 
@@ -1459,6 +1460,21 @@ Since version 7.17, Prebid collects fine-grained performance metrics and attache
 
 ```
 pbjs.setConfig({performanceMetrics: false})
+```
+
+<a id="setConfig-aliasRegistry" />
+#### Setting alias registry to private
+
+The alias registry is made public by default during an auction.  It can be referenced in the following way:
+
+```
+pbjs.aliasRegistry or pbjs.aliasRegistry[aliasName];
+```
+
+Inversely, if you wish for the alias registry to be private you can do so by using the option below (causing `pbjs.aliasRegistry` to return undefined): 
+
+```
+pbjs.setConfig({aliasRegistry: 'private'})
 ```
 
 <a name="setConfig-Generic-Configuration" />


### PR DESCRIPTION
Added doc page for pbjs.aliasRegistry

## 🏷 Type of documentation
- [x] new feature

## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked
