### PR TITLE
TL-34447 Add GPP Support to Prebid.org

### DIFF
--- a/dev-docs/bidders/triplelift.md
+++ b/dev-docs/bidders/triplelift.md
@@ -5,6 +5,7 @@ description: Prebid TripleLift Bidder Adapter
 biddercode: triplelift
 gdpr_supported: true
 usp_supported: true
+gpp_supported: true
 coppa_supported: true
 schain_supported: true
 floors_supported: true


### PR DESCRIPTION
## 🏷 Type of documentation
- [x] new feature

Added GPP support to Triplelift bidder page.
