### PR TITLE
Adkernel: consistent zoneId parameter type across aliases

### DIFF
--- a/dev-docs/bidders/adbite.md
+++ b/dev-docs/bidders/adbite.md
@@ -31,4 +31,4 @@ The adbite Bidding adaptor requires setup and approval before beginning. Please 
 | Name     | Scope    | Description           | Example                   | Type     |
 |----------|----------|-----------------------|---------------------------|----------|
 | `host`   | required | Our Host | `'cpm.adbite.com'` | `string` |
-| `zoneId` | required | Example RTB zone id           | `'12345'`| `string` |
+| `zoneId` | required | Example RTB zone id           | `12345`| `integer` |

--- a/dev-docs/bidders/adkernel.md
+++ b/dev-docs/bidders/adkernel.md
@@ -31,4 +31,4 @@ The Adkernel Bidding adaptor requires setup and approval before beginning. Pleas
 | Name     | Scope    | Description           | Example                   | Type     |
 |----------|----------|-----------------------|---------------------------|----------|
 | `host`   | required | Ad network's RTB host | `'cpm.metaadserving.com'` | `string` |
-| `zoneId` | required | RTB zone id           | `'30164'`                 | `string` |
+| `zoneId` | required | RTB zone id           | `30164`                 | `integer` |

--- a/dev-docs/bidders/adsolut.md
+++ b/dev-docs/bidders/adsolut.md
@@ -31,4 +31,4 @@ The adsolut Bidding adaptor requires setup and approval before beginning. Please
 | Name     | Scope    | Description           | Example                   | Type     |
 |----------|----------|-----------------------|---------------------------|----------|
 | `host`   | required | Ad network's RTB host | `'cpm.adsolut.in'` | `string` |
-| `zoneId` | required | RTB zone id           | `'30164'`                 | `string` |
+| `zoneId` | required | RTB zone id           | `30164`                 | `integer` |

--- a/dev-docs/bidders/audiencemedia.md
+++ b/dev-docs/bidders/audiencemedia.md
@@ -27,4 +27,4 @@ sidebarType: 1
 | Name     | Scope    | Description           | Example                   | Type     |
 |----------|----------|-----------------------|---------------------------|----------|
 | `host`   | required | Ad network's RTB host | `'cpm.audience.media'` | `string` |
-| `zoneId` | required | Zone ID           | `'76156'`                 | `string` |
+| `zoneId` | required | Zone ID           | `76156`                 | `integer` |

--- a/dev-docs/bidders/bcm.md
+++ b/dev-docs/bidders/bcm.md
@@ -32,4 +32,4 @@ The BCM adapter requires approval and setup. Please reach out to contact@bcm.ltd
 | Name     | Scope    | Description           | Example                   | Type     |
 |----------|----------|-----------------------|---------------------------|----------|
 | `host`   | required | Our Host  - Do Not Change   | `'serve.datacygnal.io'`   | `string` |
-| `zoneId` | required | Example RTB zone id   |         `'12345'`         | `string` |
+| `zoneId` | required | Example RTB zone id   |         `12345`         | `integer` |

--- a/dev-docs/bidders/headbidding.md
+++ b/dev-docs/bidders/headbidding.md
@@ -33,7 +33,7 @@ sidebarType: 1
 {: .table .table-bordered .table-striped }
 | Name     | Scope    | Description | Example | Type     |
 |----------|----------|-------------|---------|----------|
-| `zoneId` | required |             |         | `string` |
+| `zoneId` | required |             |         | `integer` |
 | `host`   | required |             |         | `string` |
 
 Head Bidding is an aliased bidder for AdKernel

--- a/dev-docs/bidders/houseofpubs.md
+++ b/dev-docs/bidders/houseofpubs.md
@@ -32,4 +32,4 @@ Please contact info@houseofpubs.com for any questions or for information about o
 | Name     | Scope    | Description           | Example                   | Type     |
 |----------|----------|-----------------------|---------------------------|----------|
 | `host`   | required | Our Host              | `'cpm.houseofpubs.com'`   | `string` |
-| `zoneId` | required | Example RTB zone id   |         `'12345'`         | `string` |
+| `zoneId` | required | Example RTB zone id   |         `12345`         | `integer` |

--- a/dev-docs/bidders/rtbdemand_com.md
+++ b/dev-docs/bidders/rtbdemand_com.md
@@ -31,4 +31,4 @@ The RtbDemand.com bidding adaptor requires setup and approval before beginning. 
 | Name     | Scope    | Description           | Example                   | Type     |
 |----------|----------|-----------------------|---------------------------|----------|
 | `host`   | required | Our Host | `' cpm.rtbdemand.com'` | `string` |
-| `zoneId` | required | Example RTB zone id           | `'12345'`                 | `string` |
+| `zoneId` | required | Example RTB zone id           | `12345`                 | `integer` |

--- a/dev-docs/bidders/sonic_twist.md
+++ b/dev-docs/bidders/sonic_twist.md
@@ -31,4 +31,4 @@ The Sonic Twist Media Bidding adaptor requires setup and approval before beginni
 | Name     | Scope    | Description           | Example                   | Type     |
 |----------|----------|-----------------------|---------------------------|----------|
 | `host`   | required | Our Host | `'cpm.andbeyond.media'` | `string` |
-| `zoneId` | required | Example RTB zone id           | `'12345'`                 | `string` |
+| `zoneId` | required | Example RTB zone id           | `12345`                 | `integer` |

--- a/dev-docs/bidders/waardex_ak.md
+++ b/dev-docs/bidders/waardex_ak.md
@@ -31,4 +31,4 @@ The WaardeX Bidding adaptor requires setup and approval before beginning. Please
 | Name     | Scope    | Description           | Example                   | Type     |
 |----------|----------|-----------------------|---------------------------|----------|
 | `host`   | required | Ad network's RTB host | `'cpm.webtradingspot.com'` | `string` |
-| `zoneId` | required | RTB zone id           | `'30164'`                 | `string` |
+| `zoneId` | required | RTB zone id           | `30164`                 | `integer` |


### PR DESCRIPTION
## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples
