### PR TITLE
Vidazoo Bid Adapter - bidFloor changed from required to optional param

### DIFF
--- a/dev-docs/bidders/vidazoo.md
+++ b/dev-docs/bidders/vidazoo.md
@@ -18,5 +18,5 @@ sidebarType: 1
 |------------|----------|------------------------------------------------------------------------------------------|------------------------------|----------|
 | `cId`      | required | The connection ID from Vidazoo.                                                          | `'562524b21b1c1f08117fc7f9'` | `string` |
 | `pId`      | required | The publisher ID from Vidazoo.                                                           | `'59ac17c192832d0011283fe3'` | `string` |
-| `bidFloor` | required | The minimum bid value desired. Vidazoo will not respond with bids lower than this value. | `0.90`                       | `float`  |
+| `bidFloor` | optional | The minimum bid value desired. Vidazoo will not respond with bids lower than this value. | `0.90`                       | `float`  |
 | `subDomain`| optional | Sets the server subdomain, default: 'prebid'.                                            | `'prebid'`                     | `string` |


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.
-->

This PR updates the docs params list with optional flag for the `bidFloor` param.

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] text edit only (wording, typos)
