### PR TITLE
Fix for TOC issue

### DIFF
--- a/dev-docs/integrate-with-the-prebid-analytics-api.md
+++ b/dev-docs/integrate-with-the-prebid-analytics-api.md
@@ -22,6 +22,8 @@ The Prebid Analytics API provides a way to get analytics data from `Prebid.js` a
 
 + Since this API separates your analytics provider's code from `Prebid.js`, the upgrade and maintenance of the two systems are separate.  If you want to upgrade your analytics library, there is no need to upgrade or test the core of `Prebid.js`.
 
+[//]: # (This comment is a separator that allows the list above and the TOC to be rendered at the same time)
+
 * TOC
 {:toc }
 


### PR DESCRIPTION
There's an issue in `integrate-with-the-prebid-analytics-api.md` that causes the list of benefits of integrating with the Prebid Analytics API to not be rendered in the HTML, probably because of the instruction used to generate the table of contents. This is how the page looks on all the browsers on which I tested:

![bild](https://user-images.githubusercontent.com/29439179/216994318-5e0bf2a1-8010-4532-9004-6f4ff667cad0.png)

The proposed fix is to separate the list and the TOC by introducing some text that will not be rendered in the HTML. This is how the page looks with the proposed fix:

![bild](https://user-images.githubusercontent.com/29439179/216994671-c3e2a73e-6819-4fb2-8ce8-f89af72ac62a.png)

## 🏷 Type of documentation
- text edit only (wording, typos)

