### PR TITLE
Add new google analytics v4 tag

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,14 +12,18 @@
 </footer>
   <!-- / copyrights -->
 
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-130832561-2"></script>
+<!-- Global tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-GM972HCTEB"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
+  // old universal analytics
   gtag('config', 'UA-130832561-2');
+
+  // new google analytics v4 property
+  gtag('config', 'G-GM972HCTEB');
 </script>
 
 


### PR DESCRIPTION
I created a Google Analytics v4 property, which is linked to the old universal property. 
It seems to work without any code changes. However I would merge this once we see that the data matches.

And then ultimately remove the `UA-130832561-2` universal analytics property.
