### PR TITLE
Underdog Media Bid Adapter: Add support for user ids and product id

### DIFF
--- a/dev-docs/bidders/underdogmedia.md
+++ b/dev-docs/bidders/underdogmedia.md
@@ -6,7 +6,7 @@ pbjs: true
 biddercode: underdogmedia
 gdpr_supported: true
 usp_supported: true
-userIds: pubCommonId, unifiedId
+userIds: 33acrossId, pubCommonId, unifiedId
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/underdogmedia.md
+++ b/dev-docs/bidders/underdogmedia.md
@@ -6,6 +6,7 @@ pbjs: true
 biddercode: underdogmedia
 gdpr_supported: true
 usp_supported: true
+userIds: pubCommonId, unifiedId
 sidebarType: 1
 ---
 
@@ -15,3 +16,4 @@ sidebarType: 1
 | Name     | Scope    | Description | Example | Type     |
 |----------|----------|-------------|---------|----------|
 | `siteId` | required |             |         | `string` |
+| `productId` | optional | UDM Product ID `'standard'` or `'sticky'`, defaults to `'standard'` | `'standard'`   | `string` |


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.
-->
- Added support for user ids: 33acrossId, pubCommonId, unifiedId
- Added optional param: productId

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] update bid adapter

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked -> https://github.com/prebid/Prebid.js/pull/9547
