### PR TITLE
PBS bidder specific guidelines

### DIFF
--- a/prebid-server/endpoints/pbs-endpoint-cookieSync.md
+++ b/prebid-server/endpoints/pbs-endpoint-cookieSync.md
@@ -60,7 +60,7 @@ The client code is responsible for taking the `url` response parameter and invok
 | gdpr | optional | flag indicating whether the request is in-scope for GDPR processing | 1 | 0 or 1 |
 | gdpr_consent | optional | GDPR consent string from the CMP | | string |
 | limit | optional | number indicating the max number of sync URLs to return | 5 | integer |
-| coopSync | optional | (PBS-Java only) Cooperative syncing is a way for publishers to help each other by allowing PBS to sync bidders beyond those specified by the `bidders` argument. See below for details. The default depends on PBS host company settings. | true | boolean |
+| coopSync | optional | Cooperative syncing is a way for publishers to help each other by allowing PBS to sync bidders beyond those specified by the `bidders` argument. See below for details. The default depends on PBS host company settings. | true | boolean |
 | filterSettings | optional | object defining which types of syncs are allowed for which bidders. Modeled after the similar Prebid.js feature. | | object |
 | filterSettings.iframe | optional | define the filter settings for iframe syncs | | object |
 | filterSettings.image | optional | define the filter settings for redirect syncs | | object |

--- a/prebid-server/hosting/bidder-specific-guidelines.md
+++ b/prebid-server/hosting/bidder-specific-guidelines.md
@@ -1,0 +1,67 @@
+---
+layout: page_v2
+title: Bidder-Specific Guidelines for PBS Host Companies
+description: Bidder-Specific Guidelines for PBS Host Companies
+pid: 0
+sidebarType: 5
+---
+
+# Bidder-Specific Guidelines for PBS Host Companies
+{:.no_toc}
+
+* TOC
+{:toc}
+
+## Setting up a Bid Adapter
+
+In general, a PBS host company may want to run only the server-side bid adapters they require.
+
+PBS-Go enables most bidders by default, while PBS-Java doesn't
+enable any bidders out of the box.
+
+### PBS-Go
+
+You might want to consider disabling bid adapters that you're not 
+going to utilize in order to control which bidders get into the [/cookie_sync](/prebid-server/endpoints/pbs-endpoint-cookieSync.html) response when you're running the `coopSync` flag.
+
+TBD: how would a host company disable bidders?
+
+### PBS-Java
+
+To enable a bid adapter, in your main YAML file, set:
+
+```
+adapters:
+  BIDDERCODE:
+    enabled: true
+```
+
+If the bidder supports different endpoints per geography, you can deploy different
+config in each of your datacenters:
+
+```
+adapters:
+  BIDDERCODE:
+    enabled: true
+    endpoint: REGION_SPECIFIC_ENDPOINT
+```
+
+## Bidders
+
+### Rubicon
+
+If you'd like to run the [rubicon](/dev-docs/bidders/rubicon.html) Prebid Server adapter, here's the process:
+
+1. Contact globalsupport@magnite.com explaining who you are and that you'd like to set up a Prebid Server that utilizes the rubicon adapter.
+2. They will ask you a bunch of questions and hopefully approve your application.
+3. If they do approve, you'll be given a login and password to place in your configuration. Please do not share this with anyone else. You'll also be provided a usersync URL.
+4. The Magnite XAPI has several regional endpoints that you can utilize. Note that the default endpoint in the open source config is for US-East, which may not perform as well for you as the other regional options if your datacenters are in Europe or Asia.
+
+- US-East: https://exapi-rpprebidserver-us-east.rubiconproject.com/a/api/exchange?tk_sdc=us-east
+- US-West: https://exapi-rpprebidserver-us-west.rubiconproject.com/a/api/exchange?tk_sdc=us-west
+- Asia: https://exapi-rpprebidserver-apac.rubiconproject.com/a/api/exchange?tk_sdc=apac
+- Europe: https://exapi-rpprebidserver-eu.rubiconproject.com/a/api/exchange?tk_sdc=eu
+
+## Related Reading
+
+- [Hosting a Prebid Server Cluster](/prebid-server/hosting/pbs-hosting.html)

--- a/prebid-server/hosting/bidder-specific-guidelines.md
+++ b/prebid-server/hosting/bidder-specific-guidelines.md
@@ -1,12 +1,12 @@
 ---
 layout: page_v2
-title: Bidder-Specific Guidelines for PBS Host Companies
-description: Bidder-Specific Guidelines for PBS Host Companies
+title: Bidder-Specific Hosting Guidelines
+description: Bidder-Specific Hosting Guidelines
 pid: 0
 sidebarType: 5
 ---
 
-# Bidder-Specific Guidelines for PBS Host Companies
+# Bidder-Specific Hosting Guidelines
 {:.no_toc}
 
 * TOC
@@ -16,15 +16,29 @@ sidebarType: 5
 
 In general, a PBS host company may want to run only the server-side bid adapters they require.
 
-PBS-Go enables most bidders by default, while PBS-Java doesn't
-enable any bidders out of the box.
+PBS-Go enables most bidders by default. PBS-Java doesn't enable any bidders by default.
 
 ### PBS-Go
 
 You might want to consider disabling bid adapters that you're not 
 going to utilize in order to control which bidders get into the [/cookie_sync](/prebid-server/endpoints/pbs-endpoint-cookieSync.html) response when you're running the `coopSync` flag.
 
-TBD: how would a host company disable bidders?
+To disable a bid adapter, in your main pbs.yaml file, set:
+
+```
+adapters:
+  BIDDERCODE:
+    disabled: true
+```
+
+If the bidder supports different endpoints per geography, you can deploy different
+config in each of your datacenters:
+
+```
+adapters:
+  BIDDERCODE:
+    endpoint: REGION_SPECIFIC_ENDPOINT
+```
 
 ### PBS-Java
 

--- a/prebid-server/hosting/pbs-hosting.md
+++ b/prebid-server/hosting/pbs-hosting.md
@@ -119,3 +119,4 @@ email list at any time just by emailing us again at prebid-server@prebid.org.
 - [Prebid Server Database](/prebid-server/hosting/pbs-database.html)
 - [PBS-Go](/prebid-server/versions/pbs-versions-go.html)
 - [PBS-Java](/prebid-server/versions/pbs-versions-java.html)
+- [Bidder-specific setup guidelines](/prebid-server/hosting/bidder-specific-guidelines.html)


### PR DESCRIPTION
Added a page where bidders can place instructions to PBS host companies

This is a draft - need @SyntaxNode to comment on how host companies could disable bidders if they wish.