### PR TITLE
PubWise PWBID Video Update Correction

### DIFF
--- a/dev-docs/bidders/pwbid.md
+++ b/dev-docs/bidders/pwbid.md
@@ -5,7 +5,7 @@ description: PubWise Bidder Adaptor
 pbjs: true
 biddercode: pwbid
 aliasCode: pubwise
-media_types: banner, native
+media_types: banner, native, video
 gdpr_supported: true
 usp_supported: true
 schain_supported: true


### PR DESCRIPTION
In the previous update we modified instructions for integration but missed the needed update to the "media_types" line. This update corrects that.