### PR TITLE
Support consent mode for google analytics

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,6 +9,7 @@
       </div>
     </div>
   </div>
+  <div id="prebid-google-analytics-consent" style="display: none;"></div>
 </footer>
   <!-- / copyrights -->
 
@@ -30,7 +31,7 @@
   // use the global variable provided in the head-common to wait for onetrust
   window.onetrustLoaded.then(() => {
     // grant consent if one trust says so. We use the callback to update gtag consent status
-    OneTrust.InsertHtml('<span display:"none">google analytics</span>', 'body', function() {
+    OneTrust.InsertHtml('<span>given</span>', 'prebid-google-analytics-consent', function() {
       gtag('consent', 'update', {'ad_storage': 'granted','analytics_storage': 'granted'});
     }, {}, 'C0002');
   });

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -27,10 +27,14 @@
   // new google analytics v4 property
   gtag('config', 'G-GM972HCTEB');
 
-  // grant consent if one trust says so. We use the callback to update gtag consent status
-  OneTrust.InsertHtml('<span display:"none">google analytics</span>', 'body', function() {
-    gtag('consent', 'update', {'ad_storage': 'granted','analytics_storage': 'granted'});
-  }, {}, 'C0002');
+  // use the global variable provided in the head-common to wait for onetrust
+  window.onetrustLoaded.then(() => {
+    // grant consent if one trust says so. We use the callback to update gtag consent status
+    OneTrust.InsertHtml('<span display:"none">google analytics</span>', 'body', function() {
+      gtag('consent', 'update', {'ad_storage': 'granted','analytics_storage': 'granted'});
+    }, {}, 'C0002');
+  });
+
 </script>
 
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,15 +15,22 @@
 <!-- Global tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-GM972HCTEB"></script>
 <script>
+  window['gtag_enable_tcf_support'] = true;
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-
-  // old universal analytics
-  gtag('config', 'UA-130832561-2');
+  gtag('consent', 'default', {'ad_storage': 'denied','analytics_storage': 'denied'});
+  gtag("config", "G-GM972HCTEB", {
+      anonymize_ip: true
+  });
 
   // new google analytics v4 property
   gtag('config', 'G-GM972HCTEB');
+
+  // grant consent if one trust says so. We use the callback to update gtag consent status
+  OneTrust.InsertHtml('<span display:"none">google analytics</span>', 'body', function() {
+    gtag('consent', 'update', {'ad_storage': 'granted','analytics_storage': 'granted'});
+  }, {}, 'C0002');
 </script>
 
 

--- a/_includes/head--common.html
+++ b/_includes/head--common.html
@@ -17,6 +17,7 @@
     {% if jekyll.environment == "production" %}
       <!-- OneTrust Cookies Consent Notice start for docs.prebid.org -->
       <script type="text/javascript">
+        window.addEventListener('consent.onetrust', console.log)
         // Global Promise we can check to make sure OneTrust is loaded.
         let resolveOneTrust;
         window.onetrustLoaded = new Promise((resolve) => resolveOnetrust = resolve);

--- a/_includes/head--common.html
+++ b/_includes/head--common.html
@@ -17,7 +17,6 @@
     {% if jekyll.environment == "production" %}
       <!-- OneTrust Cookies Consent Notice start for docs.prebid.org -->
       <script type="text/javascript">
-        window.addEventListener('consent.onetrust', console.log)
         // Global Promise we can check to make sure OneTrust is loaded.
         let resolveOneTrust;
         window.onetrustLoaded = new Promise((resolve) => resolveOnetrust = resolve);


### PR DESCRIPTION
## 🏷 Type of documentation

Use google analytics with consent

## Description

This PR adds consent support for google analytics. I wasn't able to test this locally as the callback never fired. I will test this with the preview build

## Related

- https://support.google.com/analytics/answer/10022331?hl=de
- https://community.cookiepro.com/s/article/UUID-d8291f61-aa31-813a-ef16-3f6dec73d643?language=en_US