### PR TITLE
Smaato: accept geolocation data also from ortb2

### DIFF
--- a/dev-docs/bidders/smaato.md
+++ b/dev-docs/bidders/smaato.md
@@ -211,6 +211,8 @@ Publishers should use the `ortb2` method of setting First Party Data. The follow
 - ortb2.user.yob
 - ortb2.user.gender
 - ortb2.user.ext.eids
+- ortb2.device.geo
+- ortb2.device.ifa
 
 The IAB standard taxonomies are not supported.
 
@@ -230,6 +232,13 @@ pbjs.setConfig({
             keywords: "a,b", 
             gender: "M", 
             yob: 1984
+        },
+        device: {
+            ifa: "identifier",
+            geo: {
+                lat: 53.5488,
+                lon: 9.9872
+            }
         }
     }
 });


### PR DESCRIPTION
As described in prebid/Prebid.js#9676 adapters should also accept geolocation from ortb2
## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked -> prebid/Prebid.js#9725
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
