### PR TITLE
PBJS: document new `storageAllowed` options

### DIFF
--- a/dev-docs/publisher-api-reference/bidderSettings.md
+++ b/dev-docs/publisher-api-reference/bidderSettings.md
@@ -46,7 +46,7 @@ Some sample scenarios where publishers may wish to alter the default settings:
 | sendStandardTargeting | adapter-specific | 0.13.0 | true | If adapter-specific targeting is specified, can be used to suppress the standard targeting for that adapter. |
 | suppressEmptyKeys | standard or adapter-specific | 0.13.0 | false | If custom adserverTargeting functions are specified that may generate empty keys, this can be used to suppress them. |
 | allowZeroCpmBids | standard or adapter-specific | 6.2.0 | false | Would allow bids with a 0 CPM to be accepted by Prebid.js and could be passed to the ad server. |
-| storageAllowed | standard or adapter-specific | 6.13.0 | true in 6.x, false after 7.0 | Allow use of cookies and local storage. |  
+| storageAllowed | standard or adapter-specific | 6.13.0 | true in 6.x, false after 7.0 | Allow use of cookies and/or local storage. |  
 | allowAlternateBidderCodes | standard or adapter-specific | 6.23.0 | true in v6.x <br /> false from v7.0| Allow adapters to bid with alternate bidder codes. |  
 | allowedAlternateBidderCodes | standard or adapter-specific | 6.23.0 | n/a | Array of bidder codes for which an adapter can bid. <br />`undefined` or `['*']` will allow adapter to bid with any bidder code. |  
 
@@ -262,7 +262,12 @@ either specific bid adapter(s) or all bid adapters the permission for these bids
 
 ##### 2.7. storageAllowed
 
-This flag defines if the bid adapter can access browser cookies and local storage.
+This setting defines if the bid adapter can access browser cookies or local storage. Allowed values are:
+
+ - an array containing either `'html5'`, `'cookie'` or both to allow specific storage methods (e.g. `['cookie']` enables cookies but not local storage)
+ - `true` to allow any storage method;
+ - `false` to disable all storage.
+ 
 <br />Default value is `true` in version 6.x
 <br />Default value is `false` in version 7.x
 


### PR DESCRIPTION
Document new options for the `bidderSettings.*.storageAllowed` setting - see https://github.com/prebid/Prebid.js/pull/9660

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] new feature

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked -> https://github.com/prebid/Prebid.js/pull/9660
