### PR TITLE
trustx: update PBS support

### DIFF
--- a/dev-docs/bidders/trustxstandalone.md
+++ b/dev-docs/bidders/trustxstandalone.md
@@ -3,7 +3,6 @@ layout: bidder
 title: TrustX (standalone)
 description: Prebid TrustX Bidder Adaptor
 pbjs: true
-pbs: true
 biddercode: trustx
 media_types: banner, video
 multiformat_supported: will-bid-on-any


### PR DESCRIPTION
removing the PBS flag from the 'standalone' docs file, which was intended for PBJS only
