### PR TITLE
re-adding cleanmedianet

### DIFF
--- a/dev-docs/bidders/cleanmedianet.md
+++ b/dev-docs/bidders/cleanmedianet.md
@@ -1,0 +1,19 @@
+---
+layout: bidder
+title: Clean Media Net
+description: Clean Media Bidder Adapter
+top_nav_section: dev_docs
+nav_section: reference
+biddercode: cleanmedianet
+pbjs: true
+prebid_1_0_supported: true
+media_types: banner, video
+gdpr_supported: true
+---
+
+### Bid params
+
+{: .table .table-bordered .table-striped }
+| Name | Scope | Description | Example | Type |
+|-------------------+----------+--------------------------------------------------------+-------------------------+---------|
+| `supplyPartnerId` | required | The supply account's ID in your Clean Media dashboard. | `"1253"`, `"1254"`, etc | string |

--- a/dev-docs/bidders/cleanmedianet.md
+++ b/dev-docs/bidders/cleanmedianet.md
@@ -5,7 +5,20 @@ description: Clean Media Bidder Adapter
 biddercode: cleanmedianet
 pbjs: true
 media_types: banner, video
-gdpr_supported: true
+gdpr_supported: false
+usp_supported: true
+coppa_supported: false
+schain_supported: true
+floors_supported: true
+userIds:
+prebid_member: false
+safeframes_ok: true
+deals_supported: false
+pbs_app_supported: false
+fpd_supported: false
+ortb_blocking_supported: false
+gvl_id:
+multiformat_supported: will-bid-on-any
 ---
 
 ### Bid params

--- a/dev-docs/bidders/cleanmedianet.md
+++ b/dev-docs/bidders/cleanmedianet.md
@@ -2,11 +2,8 @@
 layout: bidder
 title: Clean Media Net
 description: Clean Media Bidder Adapter
-top_nav_section: dev_docs
-nav_section: reference
 biddercode: cleanmedianet
 pbjs: true
-prebid_1_0_supported: true
 media_types: banner, video
 gdpr_supported: true
 ---


### PR DESCRIPTION
Per issue https://github.com/prebid/prebid.github.io/issues/4448

This was removed a couple of years ago as part of an alias cleanup, and is still needed.

@cleanmedianet - please review. Prebid publishers want more information about the capabilities of bidders. Please supply as many of the following fields as you can as described in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter

gdpr_supported:
usp_supported:
coppa_supported:
schain_supported:
floors_supported:
userIds:
prebid_member:
safeframes_ok:
deals_supported:
pbs_app_supported:
fpd_supported:
ortb_blocking_supported:
gvl_id:
multiformat_supported: