### PR TITLE
Auto select modules with URL param

### DIFF
--- a/dev-docs/modules/idLibrary.md
+++ b/dev-docs/modules/idLibrary.md
@@ -3,7 +3,7 @@ layout: page_v2
 page_type: module
 title: ID Import Library
 description: Retrieve user ids deployed on your site, and return them to a configurable endpoint for ID Graphing.
-module_code : currency
+module_code : idImportLibrary
 display_name : ID Import Library
 enable_download : true
 sidebarType : 1

--- a/download.md
+++ b/download.md
@@ -198,18 +198,51 @@ function get_form_data() {
 }
 
 function setPrepickedModules() {
-    var modules = searchParams.get('modules');
-    if (modules) {
-        document.querySelectorAll('input[modulecode]').forEach(function(checkbox) {
+    var moduleCheckboxes = document.querySelectorAll('input[modulecode], input[analyticscode]');
+    var modules = [];
+    var modulesParam = searchParams.get('modules');
+    if (modulesParam) {
+        modules = modulesParam.split(',');
+    }
+    if (modules && modules.length) {
+        moduleCheckboxes.forEach(function(checkbox) {
             checkbox.checked = false;
         });
-        modules.split(',').forEach(function(module) {
+        modules.forEach(function(module) {
             var checkbox = document.getElementById(module);
             if (checkbox) {
                 checkbox.checked = true;
             }
         });
     }
+
+    var getModuleCode = function(checkbox) {
+        return checkbox.getAttribute('modulecode') || checkbox.getAttribute('analyticscode');
+    };
+    moduleCheckboxes.forEach(function(checkbox) {
+        if (checkbox.checked) {
+            var module = getModuleCode(checkbox);
+            if (!modules.includes(module)) {
+                modules.push(module);
+            }
+        }
+        checkbox.addEventListener('change', function(event) {
+            var module = getModuleCode(event.target);
+            if (event.target.checked) {
+                modules.push(module);
+            } else {
+                modules = modules.filter(function(m) {
+                    return m !== module;
+                });
+            }
+            if (modules.length) {
+                searchParams.set('modules', modules.join(','));
+            } else {
+                searchParams.delete('modules');
+            }
+            window.history.replaceState(null, '', window.location.pathname + '?' + searchParams.toString());
+        });
+    });
 }
 
 function setPrepickedVersion() {
@@ -219,6 +252,14 @@ function setPrepickedVersion() {
         if (versionOption) {
             versionOption.selected = true;
         }
+    }
+    var versionSelector = document.getElementById('version_selector');
+    if (versionSelector) {
+        versionSelector.addEventListener('change', function(event) {
+            var version = event.target.value;
+            searchParams.set('version', version);
+            window.history.replaceState(null, '', window.location.pathname + '?' + searchParams.toString());
+        });
     }
 }
 

--- a/download.md
+++ b/download.md
@@ -35,9 +35,9 @@ a.tip:hover span {
 <script src="https://cdn.firebase.com/js/client/2.4.2/firebase.js"></script>
 
 <script>
-var searchParams = new URL(window.location).searchParams;
+var currentUrl = new URL(window.location);
+var searchParams = currentUrl.searchParams;
 
-    setPrepickedModules()
   getVersionList();
 
 $(function(){
@@ -52,6 +52,7 @@ $(function(){
 
   // show all adapters
   $('.adapters .col-md-4').show();
+  setPrepickedModules()
 });
 
 function getVersionList() {
@@ -240,7 +241,7 @@ function setPrepickedModules() {
             } else {
                 searchParams.delete('modules');
             }
-            window.history.replaceState(null, '', window.location.pathname + '?' + searchParams.toString());
+            window.history.replaceState(null, '', currentUrl);
         });
     });
 }

--- a/download.md
+++ b/download.md
@@ -302,7 +302,7 @@ Prebid.js is open source software that is offered for free as a convenience. Whi
 <div class="col-md-4">
  <div class="checkbox">
   <label>
-  {% if page.filename %} <input type="checkbox" id="{{ page.filename }}" moduleCode="{{ page.filename }}" {% elsif page.aliasCode %} <input type="checkbox" id="{{ page.aliasCode }}BidAdapter" moduleCode="{{ page.aliasCode }}BidAdapter" {% else %} <input type="checkbox" id="{{ page.biddercode }}BidAdapter" moduleCode="{{ page.biddercode }}BidAdapter" {% endif %} class="bidder-check-box"><a href="{{page.url}}"> {{ page.title }}</a>
+  {% if page.filename %} <input type="checkbox" id="{{ page.filename }}" moduleCode="{{ page.filename }}" {% elsif page.aliasCode %} <input type="checkbox" id="{{ page.biddercode }}BidAdapter" moduleCode="{{ page.aliasCode }}BidAdapter" {% else %} <input type="checkbox" id="{{ page.biddercode }}BidAdapter" moduleCode="{{ page.biddercode }}BidAdapter" {% endif %} class="bidder-check-box"><a href="{{page.url}}"> {{ page.title }}</a>
   {% if page.pbjs_version_notes %}<br/><div style="font-size:80%">{{page.pbjs_version_notes}}</div>{% endif %}
   </label>
 </div>

--- a/download.md
+++ b/download.md
@@ -199,7 +199,7 @@ function get_form_data() {
 }
 
 function setPrepickedModules() {
-    var moduleCheckboxes = document.querySelectorAll('input[modulecode], input[analyticscode]');
+    var moduleCheckboxes = document.querySelectorAll('.module-check-box');
     var modules = [];
     var modulesParam = searchParams.get('modules');
     if (modulesParam) {
@@ -217,18 +217,15 @@ function setPrepickedModules() {
         });
     }
 
-    var getModuleCode = function(checkbox) {
-        return checkbox.getAttribute('modulecode') || checkbox.getAttribute('analyticscode');
-    };
     moduleCheckboxes.forEach(function(checkbox) {
         if (checkbox.checked) {
-            var module = getModuleCode(checkbox);
+            var module = checkbox.id;
             if (!modules.includes(module)) {
                 modules.push(module);
             }
         }
         checkbox.addEventListener('change', function(event) {
-            var module = getModuleCode(event.target);
+            var module = event.target.id;
             if (event.target.checked) {
                 modules.push(module);
             } else {
@@ -302,7 +299,7 @@ Prebid.js is open source software that is offered for free as a convenience. Whi
 <div class="col-md-4">
  <div class="checkbox">
   <label>
-  {% if page.filename %} <input type="checkbox" id="{{ page.filename }}" moduleCode="{{ page.filename }}" {% elsif page.aliasCode %} <input type="checkbox" id="{{ page.biddercode }}BidAdapter" moduleCode="{{ page.aliasCode }}BidAdapter" {% else %} <input type="checkbox" id="{{ page.biddercode }}BidAdapter" moduleCode="{{ page.biddercode }}BidAdapter" {% endif %} class="bidder-check-box"><a href="{{page.url}}"> {{ page.title }}</a>
+  {% if page.filename %} <input type="checkbox" id="{{ page.filename }}" moduleCode="{{ page.filename }}" {% elsif page.aliasCode %} <input type="checkbox" id="{{ page.biddercode }}BidAdapter" moduleCode="{{ page.aliasCode }}BidAdapter" {% else %} <input type="checkbox" id="{{ page.biddercode }}BidAdapter" moduleCode="{{ page.biddercode }}BidAdapter" {% endif %} class="bidder-check-box module-check-box"><a href="{{page.url}}"> {{ page.title }}</a>
   {% if page.pbjs_version_notes %}<br/><div style="font-size:80%">{{page.pbjs_version_notes}}</div>{% endif %}
   </label>
 </div>
@@ -314,31 +311,31 @@ Prebid.js is open source software that is offered for free as a convenience. Whi
 <br>
 <h4>Analytics Adapters</h4>
 <div class="row">
-{% for page in analytics_pages %}{% if page.enable_download == false %}{% continue %}{% endif %}<div class="col-md-4"><div class="checkbox"><label><input type="checkbox" id="{{ page.modulecode }}" analyticscode="{{ page.modulecode }}" class="analytics-check-box"><a href="{{page.url}}"> {{ page.title }}</a></label></div></div>{% endfor %}
+{% for page in analytics_pages %}{% if page.enable_download == false %}{% continue %}{% endif %}<div class="col-md-4"><div class="checkbox"><label><input type="checkbox" id="{{ page.modulecode }}" analyticscode="{{ page.modulecode }}" class="analytics-check-box module-check-box"><a href="{{page.url}}"> {{ page.title }}</a></label></div></div>{% endfor %}
 </div>
 <br/>
 <h4>Recommended Modules</h4>
 Prebid.org highly recommends that publishers utilize the following modules:
 <br/>
-{% for page in module_pages %}{% if page.recommended == true %}<div class="row"><div class="checkbox" style="background-color: #e1fce2;"><label> <input type="checkbox" CHECKED id="{{ page.module_code }}" moduleCode="{{ page.module_code }}" class="bidder-check-box"> <a href="{{page.url}}" class="tip"><strong>{{ page.display_name }}</strong></a> - {{page.description}}</label></div></div>{% endif %}{% endfor %}
+{% for page in module_pages %}{% if page.recommended == true %}<div class="row"><div class="checkbox" style="background-color: #e1fce2;"><label> <input type="checkbox" CHECKED id="{{ page.module_code }}" moduleCode="{{ page.module_code }}" class="bidder-check-box module-check-box"> <a href="{{page.url}}" class="tip"><strong>{{ page.display_name }}</strong></a> - {{page.description}}</label></div></div>{% endif %}{% endfor %}
 <br/>
 <h4>General Modules</h4>
 <div class="row">
  {% for page in module_pages %}{% if page.enable_download == false or page.recommended == true or page.vendor_specific == true %}{% continue %}{% endif %}<div class="col-md-4"><div class="checkbox">
-  <label> <input type="checkbox" id="{{ page.module_code }}" moduleCode="{{ page.module_code }}" class="bidder-check-box"> <a href="{{page.url}}" class="tip">{{ page.display_name }}<span>{{page.description}}</span></a></label>
+  <label> <input type="checkbox" id="{{ page.module_code }}" moduleCode="{{ page.module_code }}" class="bidder-check-box module-check-box"> <a href="{{page.url}}" class="tip">{{ page.display_name }}<span>{{page.description}}</span></a></label>
 </div></div>{% endfor %}
 </div>
 
 <h4>Vendor-Specific Modules</h4>
 These modules may require accounts with a service provider.<br/>
 <div class="row">
- {% for page in module_pages %}{% if page.enable_download == false or page.recommended == true %}{% continue %}{% endif %}{% if page.vendor_specific == true %}<div class="col-md-4"><div class="checkbox"><label> <input type="checkbox" id="{{ page.module_code }}" moduleCode="{{ page.module_code }}" class="bidder-check-box"> <a href="{{page.url}}" class="tip">{{ page.display_name }}<span>{{page.description}}</span></a></label>
+ {% for page in module_pages %}{% if page.enable_download == false or page.recommended == true %}{% continue %}{% endif %}{% if page.vendor_specific == true %}<div class="col-md-4"><div class="checkbox"><label> <input type="checkbox" id="{{ page.module_code }}" moduleCode="{{ page.module_code }}" class="bidder-check-box module-check-box"> <a href="{{page.url}}" class="tip">{{ page.display_name }}<span>{{page.description}}</span></a></label>
 </div></div>{% endif %}{% endfor %}
 </div>
 
 <h4>User ID Modules</h4>
 <div class="row">
- {% for page in userid_pages %}{% if page.enable_download == false %}{% continue %}{% endif %}<div class="col-md-4"><div class="checkbox"><label> <input type="checkbox" id="{{ page.useridmodule }}" moduleCode="{{ page.useridmodule }}" class="bidder-check-box"> <a href="{{page.url}}">{{ page.title }}</a></label>{% if page.pbjs_version_notes %}<br/><div style="font-size:80%">{{page.pbjs_version_notes}}</div>{% endif %}
+ {% for page in userid_pages %}{% if page.enable_download == false %}{% continue %}{% endif %}<div class="col-md-4"><div class="checkbox"><label> <input type="checkbox" id="{{ page.useridmodule }}" moduleCode="{{ page.useridmodule }}" class="bidder-check-box module-check-box"> <a href="{{page.url}}">{{ page.title }}</a></label>{% if page.pbjs_version_notes %}<br/><div style="font-size:80%">{{page.pbjs_version_notes}}</div>{% endif %}
 </div></div>{% endfor %}
 </div>
 

--- a/download.md
+++ b/download.md
@@ -35,7 +35,9 @@ a.tip:hover span {
 <script src="https://cdn.firebase.com/js/client/2.4.2/firebase.js"></script>
 
 <script>
+var searchParams = new URL(window.location).searchParams;
 
+    setPrepickedModules()
   getVersionList();
 
 $(function(){
@@ -78,6 +80,7 @@ function getVersionList() {
           }
         }
       });
+      setPrepickedVersion();
     }
     catch(e) {
       console.log(e);
@@ -192,6 +195,31 @@ function get_form_data() {
     form_data['removedModules'] = removedModules;
 
     return form_data;
+}
+
+function setPrepickedModules() {
+    var modules = searchParams.get('modules');
+    if (modules) {
+        document.querySelectorAll('input[modulecode]').forEach(function(checkbox) {
+            checkbox.checked = false;
+        });
+        modules.split(',').forEach(function(module) {
+            var checkbox = document.getElementById(module);
+            if (checkbox) {
+                checkbox.checked = true;
+            }
+        });
+    }
+}
+
+function setPrepickedVersion() {
+    var version = searchParams.get('version');
+    if (version) {
+        var versionOption = document.querySelector('#version_selector option[value="' + version + '"]');
+        if (versionOption) {
+            versionOption.selected = true;
+        }
+    }
 }
 
 </script>


### PR DESCRIPTION
This adds some JavaScript code to the download page which automatically selects the modules based on the URL parameter, to allow sharing or storing a link with a custom list of preselected modules.
If I want to add or remove a module from prebid, I can skip the step of selecting all current modules, which can be quite tedious with many modules.

Additionally, the download page URL is being changed to the selected modules.

Example link: https://docs.prebid.org/download.html?modules=appnexusBidAdapter%2CconnectadBidAdapter%2CconsentManagement%2Ccurrency%2Cid5IdSystem%2CixBidAdapter%2CmedianetBidAdapter%2CpriceFloors%2CrubiconBidAdapter%2CsharedIdSystem%2CstroeerCoreBidAdapter%2CteadsBidAdapter%2CtripleliftBidAdapter%2CuserId&version=7.34.0