### PR TITLE
Disable openxoutstream download

### DIFF
--- a/dev-docs/bidders/openxoutstream.md
+++ b/dev-docs/bidders/openxoutstream.md
@@ -8,6 +8,7 @@ media_types: native
 prebid_member: true
 coppa_supported: true
 gvl_id: 69
+enable_download: false
 sidebarType: 1
 ---
 


### PR DESCRIPTION
There is no downloadable module with this bidder code.