### PR TITLE
Added config property instructions to enable Blocking Module in PBS Java

### DIFF
--- a/prebid-server/pbs-modules/ortb2-blocking.md
+++ b/prebid-server/pbs-modules/ortb2-blocking.md
@@ -817,6 +817,17 @@ For PBS-Go
     }
 }
 ```
+
+### Enable for Spring Boot
+In order to allow the module to be picked up by Prebid Server, a Spring Boot configuration property `hooks.ortb2-blocking.enabled` must be set to `true`.
+
+Here's an example of how your PBS configuration YAML should look like:
+```YAML
+hooks:
+  ortb2-blocking:
+    enabled: true
+```
+
 ## Analytics Tags
 
 There's only one analytics activity defined by this module: "enforce-blocking".


### PR DESCRIPTION
## Description
In the code for the oRTB Blocking Module configuration, there is [a condition](https://github.com/prebid/prebid-server-java/blob/d1459aa1888f02fbb92d767e78ebb0ad9fe23192/extra/modules/ortb2-blocking/src/main/java/org/prebid/server/hooks/modules/ortb2/blocking/spring/config/Ortb2BlockingModuleConfiguration.java#L10) for the `hooks.ortb2-blocking.enabled` to be set to `true` in order for the module to be loaded. 

<img width="903" alt="image" src="https://github.com/prebid/prebid.github.io/assets/109094234/d9dc33c7-9755-4c8c-a1d8-768c434c5a65">


This appears to not be mentioned in the existing documentation for the module.

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [x] bugfix (code examples)
- [x] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
