### PR TITLE
First batch of markdownlint fixes

### DIFF
--- a/_includes/dev-docs/native-image-asset-sizes.md
+++ b/_includes/dev-docs/native-image-asset-sizes.md
@@ -2,7 +2,7 @@ There are two methods for defining sizes for image-like assets (`image` and `ico
 
 Using `mediaTypes.native.image.sizes` (or `mediaTypes.native.icon.sizes` for icons):
 
-{% highlight js %}
+```javascript
 
 mediaTypes: {
     native: {
@@ -13,11 +13,11 @@ mediaTypes: {
     }
 }
 
-{% endhighlight %}
+```
 
 Using `mediaTypes.native.image.aspect_ratios` (or `mediaTypes.native.icon.aspect_ratios` for icons):
 
-{% highlight js %}
+```javascript
 
 mediaTypes: {
     native: {
@@ -33,4 +33,4 @@ mediaTypes: {
     }
 }
 
-{% endhighlight %}
+```

--- a/adops/setting-up-prebid-with-the-appnexus-ad-server.md
+++ b/adops/setting-up-prebid-with-the-appnexus-ad-server.md
@@ -77,7 +77,7 @@ Follow the creative setup instructions in [Add Creatives](https://docs.xandr.com
 
 ![New creative]({{ site.github.url }}/assets/images/ad-ops/appnexus-setup/prebid-creative-appnexus.png) {: .pb-lg-img :}
 
-{% highlight html %}
+```html
 <script src = "https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/#{HB_FORMAT}.js"></script>
 <script>
   var ucTagData = {};
@@ -97,7 +97,7 @@ Follow the creative setup instructions in [Add Creatives](https://docs.xandr.com
     console.log(e);
   }
 </script>
-{% endhighlight %}
+```
 
 {: .alert.alert-warning :}
 **Creative Expiration**  

--- a/dev-docs/add-rtd-submodule.md
+++ b/dev-docs/add-rtd-submodule.md
@@ -76,7 +76,7 @@ Maintainer: prebid@example.com
 
 RTD provider for Example.com. Contact prebid@example.com for information.
 
-{% endhighlight %}
+```
 
 ### Step 2: Build the Module
 
@@ -106,7 +106,7 @@ export const subModuleObj = {
   init: init,
   getTargetingData: sendDataToModule
 };
-{% endhighlight %}
+```
 
 #### Register the submodule
 
@@ -114,7 +114,7 @@ Register submodule to RTD-core:
 
 {% highlight text %}
 submodule('realTimeData', subModuleObject);
-{% endhighlight %}
+```
 
 #### User Consent
 
@@ -146,7 +146,7 @@ This is the function that will allow RTD sub-modules to merge ad server targetin
       "p":0.824,  // ad server targeting variable (e.g. p) for slotB is 0.824
   }
 }
-{% endhighlight %}
+```
 
 **Code Example**
 
@@ -170,7 +170,7 @@ function returnTargetingData(adUnits, config, userConsent) {
 }
 
 submodule('realTimeData', subModuleObj);
-{% endhighlight %}
+```
 
 #### getBidRequestData
 
@@ -233,7 +233,7 @@ function alterBidRequests(reqBidsConfigObj, callback, config, userConsent) {
 }
 
 submodule('realTimeData', subModuleObj);
-{% endhighlight %}
+```
 
 #### beforeInit
 1. Use this function to take action to make sure data will be served as soon as possible (AJAX calls, pixels, etc..)
@@ -286,7 +286,7 @@ function beforeInit(){
 }
 
 beforeInit();
-{% endhighlight %}
+```
 
 
 ### Step 3: Add unit tests

--- a/dev-docs/add-video-submodule.md
+++ b/dev-docs/add-video-submodule.md
@@ -66,7 +66,7 @@ Video provider for Example Player. Contact someone@example.com for information.
 
 Your page must link the Example Player build from our CDN. Alternatively you can use npm to load the build.
 
-{% endhighlight %}
+```
 
 ### Step 2: Add a Vendor Code
 
@@ -75,7 +75,7 @@ i.e. in `vendorCodes.js`:
 
 {% highlight text %}
 export const EXAMPLE_PLAYER_VENDOR = 3;
-{% endhighlight %}
+```
 
 ### Step 3: Build the Module
 
@@ -102,7 +102,7 @@ function exampleSubmoduleFactory(videoProviderConfig) {
 
 exampleSubmoduleFactory.vendorCode = EXAMPLE_VENDOR;
 submodule('video', exampleSubmoduleFactory);
-{% endhighlight %}
+```
 
 #### The Submodule object
 
@@ -132,7 +132,7 @@ const exampleSubmodule =  {
   offEvent: offEvent,
   destroy: destroy
 };
-{% endhighlight %}
+```
 
 <a name="event-registration" />
 
@@ -166,7 +166,7 @@ In prebid.js, add your new submodule to `.submodules.json` under the `videoModul
     ]
   }
 }
-{% endhighlight %}
+```
 
 ## Shared Resources for Developers
 

--- a/dev-docs/adunit-reference.md
+++ b/dev-docs/adunit-reference.md
@@ -410,7 +410,7 @@ pbjs.addAdUnits({
 
 For an example of a multi-format ad unit, see below.  For more detailed instructions, see [Show Multi-Format Ads]({{site.baseurl}}/dev-docs/show-multi-format-ads.html).
 
-{% highlight js %}
+```javascript
 
 pbjs.addAdUnits([{
         code: 'div-banner-native',
@@ -496,7 +496,7 @@ pbjs.addAdUnits([{
     }
 ]);
 
-{% endhighlight %}
+```
 
 <a name="adUnit-twin-codes-example">
 
@@ -509,7 +509,7 @@ where bidders have different capabilities for the same spot on the page. e.g.
 - BidderA gets one size while BidderB gets another
 
 In this example, bidderA gets both banner and outstream, while bidderB gets only banner.
-{% highlight js %}
+```javascript
     var adUnits = [
            {
                code: 'test-div',
@@ -550,7 +550,7 @@ In this example, bidderA gets both banner and outstream, while bidderB gets only
                ]
            }
        ];
-{% endhighlight %}
+```
 
 In this example, bidderA receives 2 bidRequest objects while bidderB receives one. If a bidder provides more than one bid for the same AdUnit.code, Prebid.js will use the highest bid when it's
 time to set targeting.
@@ -561,7 +561,7 @@ time to set targeting.
 
 Example of an adunit-specific block of first party data:
 
-{% highlight js %}
+```javascript
 pbjs.addAdUnits({
     code: "test-div",
     mediaTypes: {
@@ -579,7 +579,7 @@ pbjs.addAdUnits({
     },
     ...
 });
-{% endhighlight %}
+```
 
 Notes:
 - Only contextual data should be added on the AdUnit; user-related data goes in the [global first party data](/dev-docs/publisher-api-reference/setConfig.html#setConfig-fpd) config.
@@ -591,7 +591,7 @@ Notes:
 
 Example of an adunit-specific interstitial signal:
 
-{% highlight js %}
+```javascript
 pbjs.addAdUnits({
     code: "test-div",
     mediaTypes: {
@@ -604,7 +604,7 @@ pbjs.addAdUnits({
     },
     ...
 });
-{% endhighlight %}
+```
 
 For more information on Interstitial ads, reference the [Interstitial feature page](/features/InterstitialAds.html). Additionally, to assist with billing optimization and interstitial ads, the triggerBilling and onBidBillable functionality can be utilized. See [pbjs.triggerBilling](/dev-docs/publisher-api-reference/triggerBilling.html) and [onBidBillable](/dev-docs/bidder-adaptor.html#registering-on-bid-billable) for more info.
 

--- a/dev-docs/analytics-ga.md
+++ b/dev-docs/analytics-ga.md
@@ -19,7 +19,7 @@ nav_section: reference
 
 ### Code Example
 
-{% highlight js %}
+```javascript
 
 // If you're using GA, this should already be in your page:
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -38,7 +38,7 @@ pbjs.que.push(function() {
     });
 });
 
-{% endhighlight %}
+```
 
 ##### A Few Requirements
 
@@ -56,7 +56,7 @@ See [this link](https://developers.google.com/analytics/devguides/collection/pro
 
 To track a lower volume of traffic in Google Analytics, you may specify a sample rate in the options. For example, to set up a 5% sample rate:
 
-{% highlight js %}
+```javascript
 pbjs.que.push(function() {
     pbjs.enableAnalytics({
         provider: 'ga',
@@ -67,7 +67,7 @@ pbjs.que.push(function() {
         }
     });
 });
-{% endhighlight %}
+```
 
 At the start of each page, Prebid chooses a random number between 0 and 1 
 and logs the analytics only if the number is less than the supplied sample rate, which defaults to 1 (100%).

--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -107,7 +107,7 @@ Module that connects to Example's demand sources
     ];
 ```
 
-{% endhighlight %}
+```
 
 <a name="bidder-adaptor-Designing-your-Bid-Params" />
 
@@ -117,7 +117,7 @@ The parameters of your ad request will be stored in the ad unit's `bid.params` o
 
 For more information about the kinds of information that can be passed using these parameters, see the example below, as well as [the existing bidder parameters]({{site.baseurl}}/dev-docs/bidders.html).
 
-{% highlight js %}
+```javascript
 
 {
     var adUnits = [{
@@ -144,7 +144,7 @@ For more information about the kinds of information that can be passed using the
         }]
     }];
 
-{% endhighlight %}
+```
 
 <a name="bidder-adaptor-HTTP-simple-requests" />
 
@@ -216,7 +216,7 @@ Compared to previous versions of Prebid, the new `BaseAdapter` model saves the a
 
 A high level example of the structure:
 
-{% highlight js %}
+```javascript
 
 import * as utils from 'src/utils';
 import { registerBidder } from 'src/adapters/bidderFactory';
@@ -241,7 +241,7 @@ export const spec = {
 }
 registerBidder(spec);
 
-{% endhighlight %}
+```
 
 <a id="ortb-adapters" />
 
@@ -258,12 +258,12 @@ When the page asks Prebid.js for bids, your module's `buildRequests` function wi
 - `validBidRequests[]` - An array of bidRequest objects, one for each AdUnit that your module is involved in. This array has been processed for special features like sizeConfig, so it's the list that you should be looping through.
 - `bidderRequest` - The master bidRequest object. This object is useful because it carries a couple of bid parameters that are global to all the bids.
 
-{% highlight js %}
+```javascript
 buildRequests: function(validBidRequests, bidderRequest) {
    ...
    return ServerRequestObjects;
 }
-{% endhighlight %}
+```
 
 Building the request will use data from several places:
 
@@ -276,7 +276,7 @@ Building the request will use data from several places:
 
 Here is a sample array entry for `validBidRequests[]`:
 
-{% highlight js %}
+```javascript
 [{
   adUnitCode: "test-div",
   auctionId: "b06c5141-fe8f-4cdf-9d7d-54415490a917",
@@ -294,7 +294,7 @@ Here is a sample array entry for `validBidRequests[]`:
   src: "client",
   transactionId: "54a58774-7a41-494e-9aaf-fa7b79164f0c"
 }]
-{% endhighlight %}
+```
 
 Retrieve your bid parameters from the `params` object.
 
@@ -312,7 +312,7 @@ Other notes:
 
 Here is a sample bidderRequest object:
 
-{% highlight js %}
+```javascript
 {
   auctionId: "b06c5141-fe8f-4cdf-9d7d-54415490a917",
   auctionStart: 1579746300522,
@@ -332,7 +332,7 @@ Here is a sample bidderRequest object:
     stack: ["http://mypage.org?pbjs_debug=true"]
   }
 }
-{% endhighlight %}
+```
 
 Notes on parameters in the bidderRequest object:
 - **auctionID** is unique per call to `requestBids()`, but is the same across ad units.
@@ -403,7 +403,7 @@ ServerRequest objects. These objects have this structure:
 
 Here's a sample block of code returning a ServerRequest object:
 
-{% highlight js %}
+```javascript
 
 return {
     method: 'POST',
@@ -411,7 +411,7 @@ return {
     data: payloadObject
 };
 
-{% endhighlight %}
+```
 
 <a name="bidder-adaptor-Interpreting-the-Response" />
 
@@ -419,7 +419,7 @@ return {
 
 The `interpretResponse` function will be called when the browser has received the response from your server. The function will parse the response and create a bidResponse object containing one or more bids. The adapter should indicate no valid bids by returning an empty array. An example showing a single bid:
 
-{% highlight js %}
+```javascript
 
     // if the bid response was empty or an error, return []
     // otherwise parse the response and return a bidResponses array
@@ -461,7 +461,7 @@ The `interpretResponse` function will be called when the browser has received th
     bidResponses.push(bidResponse);
     return bidResponses;
 
-{% endhighlight %}
+```
 
 {: .alert.alert-info :}
 Please provide as much information as possible in the `meta` object. Publishers use this
@@ -529,7 +529,7 @@ Given an array of all the responses from the server, `getUserSyncs` is used to d
 
 See below for an example implementation.  For more examples, search for `getUserSyncs` in the [modules directory in the repo](https://github.com/prebid/Prebid.js/tree/master/modules).
 
-{% highlight js %}
+```javascript
 
 {
     getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {
@@ -558,7 +558,7 @@ See below for an example implementation.  For more examples, search for `getUser
     }
 }
 
-{% endhighlight %}
+```
 
 <a name="bidder-adaptor-Registering-on-Timout" />
 
@@ -568,7 +568,7 @@ The `onTimeout` function will be called when an adapter has timed out for an auc
 
 Sample data passed to this function:
 
-{% highlight js %}
+```javascript
 [{
   "bidder": "example",
   "bidId": "51ef8751f9aead",
@@ -579,7 +579,7 @@ Sample data passed to this function:
   "timeout": 3000,
   "auctionId": "18fd8b8b0bd757"
 }]
-{% endhighlight %}
+```
 
 ### Registering on Bid Won
 
@@ -587,7 +587,7 @@ The `onBidWon` function will be called when a bid from the adapter won the aucti
 
 Sample data received by this function:
 
-{% highlight js %}
+```javascript
 {
   "bidder": "example",
   "width": 300,
@@ -606,7 +606,7 @@ Sample data received by this function:
     "hb_size": "350x250"
   }
 }
-{% endhighlight %}
+```
 
 ### Registering on Bid Billable
 
@@ -614,7 +614,7 @@ The `onBidBillable` function will be called when it deems a bid to be billable. 
 
 Sample data received by this function (same as what is recieved for onBidWon):
 
-{% highlight js %}
+```javascript
 {
   "bidder": "example",
   "width": 300,
@@ -633,7 +633,7 @@ Sample data received by this function (same as what is recieved for onBidWon):
     "hb_size": "350x250"
   }
 }
-{% endhighlight %}
+```
 
 ### Registering on Set Targeting
 
@@ -641,7 +641,7 @@ The `onSetTargeting` function will be called when the adserver targeting has bee
 
 Sample data received by this function:
 
-{% highlight js %}
+```javascript
 {
   "bidder": "example",
   "width": 300,
@@ -660,7 +660,7 @@ Sample data received by this function:
     "hb_size": "350x250"
   }
 }
-{% endhighlight %}
+```
 
 ### Registering on Bidder Error
 
@@ -668,7 +668,7 @@ The `onBidderError` function will be called when the bidder responded with an er
 
 Sample data received by this function:
 
-{% highlight js %}
+```javascript
 {
     error: XMLHttpRequest,
     bidderRequest: {
@@ -692,13 +692,13 @@ Sample data received by this function:
         }
     }
 }
-{% endhighlight %}
+```
 
 ### Adding adapter aliases
 
 Use aliases if you want to reuse your adapter using other name for your partner/client, or just a shortcut name.
 
-{% highlight js %}
+```javascript
 
 export const spec = {
     code: 'appnexus',
@@ -713,7 +713,7 @@ export const spec = {
     ...
 }
 
-{% endhighlight %}
+```
 
 spec.aliases can be an array of strings or objects.
 
@@ -748,7 +748,7 @@ Follow the steps in this section to ensure that your adapter properly supports v
 
 Add the `supportedMediaTypes` argument to the spec object, and make sure VIDEO is in the list:
 
-{% highlight js %}
+```javascript
 
 export const spec = {
     code: BIDDER_CODE,
@@ -756,7 +756,7 @@ export const spec = {
     ...
 }
 
-{% endhighlight %}
+```
 
 {: .alert.alert-info :}
 If your adapter supports banner and video media types, make sure to include `'banner'` in the `supportedMediaTypes` array as well
@@ -896,7 +896,7 @@ In both use cases, adapter is requesting bid responses for 20 placements in one 
 
 Adapter must add following new properties to bid response
 
-{% highlight js %}
+```javascript
 {
   meta: {
     primaryCatId: '<iab sub category>', // only needed if you want to ensure competitive separation
@@ -906,7 +906,7 @@ Adapter must add following new properties to bid response
     durationSeconds: 30
   }
 }
-{% endhighlight %}
+```
 
 
 Appnexus Adapter uses above explained approach. You can refer [here](https://github.com/prebid/Prebid.js/blob/master/modules/appnexusBidAdapter.js)
@@ -955,12 +955,12 @@ getIabSubCategory(bidderCode, pCategory)
 
 **Example**
 
-{% highlight js %}
+```javascript
 
 import { getIabSubCategory } from '../src/adapters/bidderFactory';
 let primaryCatId = getIabSubCategory(bidderCode, pCategory)
 
-{% endhighlight %}
+```
 
 #### Outstream Video Renderers
 
@@ -976,7 +976,7 @@ The returned VAST URL or raw VAST XML should be added into `bid.vastUrl` or `bid
 
 For example:
 
-{% highlight js %}
+```javascript
 
 function createBid(status, reqBid, response) {
     let bid = bidfactory.createBid(status, reqBid);
@@ -991,7 +991,7 @@ function createBid(status, reqBid, response) {
     return bid;
 }
 
-{% endhighlight %}
+```
 
 ### Deals in Ad Pods
 
@@ -1023,7 +1023,7 @@ The adapter code sample below fulfills requirement #2, unpacking the server's re
 1. Checking for native assets on the response.
 2. If present, filling in the `native` object with those assets.
 
-{% highlight js %}
+```javascript
 
 /* Does the bidder respond with native assets? */
 else if (FEATURES.NATIVE && rtbBid.rtb.native) {
@@ -1045,7 +1045,7 @@ else if (FEATURES.NATIVE && rtbBid.rtb.native) {
     };
 }
 
-{% endhighlight %}
+```
 
 The full list of assets your bidder can set are defined [by legacy Prebid.js](/prebid/native-implementation-legacy.html#3-prebidjs-native-adunit-overview). All assets can be returned as strings, or images can be returned as objects with attributes `url`, `height`, and `width`.
 
@@ -1097,7 +1097,7 @@ For example tests, see [the existing adapter test suites](https://github.com/pre
 
 ## Full Bid Adapter Example
 
-{% highlight js %}
+```javascript
 
 import * as utils from 'src/utils';
 import {config} from 'src/config';
@@ -1239,7 +1239,7 @@ export const spec = {
 }
 registerBidder(spec);
 
-{% endhighlight %}
+```
 
 
 ## Submitting your adapter

--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -231,9 +231,9 @@ Enabling the AppNexus Debug Auction feature should only be done for diagnosing t
 
 To understand what is happening behind the scenes during an auction, you can enable a debug auction by adding an `apn_prebid_debug` cookie with a JSON string. For example:
 
-{% highlight js %}
+```javascript
 { "enabled": true, "dongle": "QWERTY", "debug_timeout": 1000, "member_id": 958 }
-{% endhighlight %}
+```
 
 To view the results of the debug auction, add the `pbjs_debug=true` query string parameter and open your browser's developer console.
 

--- a/dev-docs/bidders/goldbach.md
+++ b/dev-docs/bidders/goldbach.md
@@ -186,9 +186,9 @@ Enabling the Goldbach Debug Auction feature should only be done for diagnosing t
 
 To understand what is happening behind the scenes during an auction, you can enable a debug auction by adding an `apn_prebid_debug` cookie with a JSON string. For example:
 
-{% highlight js %}
+```javascript
 { "enabled": true, "dongle": "QWERTY", "debug_timeout": 1000, "member_id": 958 }
-{% endhighlight %}
+```
 
 To view the results of the debug auction, add the `pbjs_debug=true` query string parameter and open your browser's developer console.
 

--- a/dev-docs/conditional-ad-units.md
+++ b/dev-docs/conditional-ad-units.md
@@ -37,7 +37,7 @@ to send them requests from display or tablets.
 
 We'll start with how to set up the labels from `sizeConfig`:
 
-{% highlight js %}
+```javascript
 
 pbjs.setConfig({
   sizeConfig: [{
@@ -55,12 +55,12 @@ pbjs.setConfig({
   }]
 });
 
-{% endhighlight %}
+```
 
 In the above `sizeConfig`, labels are applied for each of the 3 screen sizes that can later be used in
 conditional ad unit logic. Now you need to label your AdUnits to match. For example:
 
-{% highlight js %}
+```javascript
 
 var AdUnits = [{
     code: "ad-slot-1",
@@ -85,7 +85,7 @@ var AdUnits = [{
    ]
 }]
 
-{% endhighlight %}
+```
 
 How this works:
 
@@ -113,7 +113,7 @@ Assuming the same `sizeConfig` as in the first use case above, the AdUnit would 
 placements, but the conditional `labelAny` is added to them both. This will cause the bid to be fired only if one
 or more of the strings in the array matches a defined label.
 
-{% highlight js %}
+```javascript
 
 var AdUnits = [{
     code: "ad-slot-1",
@@ -139,7 +139,7 @@ var AdUnits = [{
    ]
 }]
 
-{% endhighlight %}
+```
 
 How this works:
 
@@ -153,7 +153,7 @@ How this works:
 
 Here's another way of doing the same thing as shown in the previous section:
 
-{% highlight js %}
+```javascript
 
 var AdUnits = [{
     code: "ad-slot-1",
@@ -185,7 +185,7 @@ var AdUnits = [{
    ]
 }]
 
-{% endhighlight %}
+```
 
 
 ## Some Ad Unit Auctions Should Be Skipped Entirely for Some Devices
@@ -193,7 +193,7 @@ var AdUnits = [{
 Say there's a responsive page where one of the ad units only supports larger sizes, so it doesn't make sense
 on phones. To suppress the ad unit for mobile users, we can apply conditional logic to the entire ad unit. Here's an example using the global sizeConfig approach (banner only):
 
-{% highlight js %}
+```javascript
 
 var AdUnits = [{
     code: "ad-slot-1",
@@ -221,7 +221,7 @@ var AdUnits = [{
 
 See the [Advanced Size Mapping module](/dev-docs/modules/sizeMappingV2.html) if you need to do something like this for video.
 
-{% endhighlight %}
+```
 
 ## Some Bid Requests Apply Only to Users Originating from Certain Countries
 
@@ -232,17 +232,17 @@ certain region. It's really not worth sending them bid
 requests for users outside of their geographic area. Assuming the page can figure out where the user's from,
 a label can be implemented and applied to make the bid conditional.
 
-{% highlight js %}
+```javascript
 // page logic determines the 'europeanUser' boolean
 If (europeanUser) {
     reqArgs={labels:['eur']};
 }
 pbjs.requestBids(reqArgs);
-{% endhighlight %}
+```
 
 Then this label can be applied to conditions in the AdUnit just like labels that originate from `sizeConfig`. E.g.
 
-{% highlight js %}
+```javascript
 var AdUnits = [{
     code: "ad-slot-1",
     mediaTypes: {
@@ -261,7 +261,7 @@ var AdUnits = [{
        ...
    ]
 }]
-{% endhighlight %}
+```
 
 This example shows that the 'euroMobileBidder' is only interested in receiving bids that have **both**
 labels:

--- a/dev-docs/integrate-with-the-prebid-analytics-api.md
+++ b/dev-docs/integrate-with-the-prebid-analytics-api.md
@@ -67,7 +67,7 @@ Maintainer: prebid@example.com
 
 Analytics adapter for Example.com. Contact prebid@example.com for information.
 
-{% endhighlight %}
+```
 
 ### Step 2: Add analytics source code
 
@@ -92,7 +92,7 @@ The best way to get started is to look at some of the existing AnalyticsAdapter.
 
 Here's a skeleton outline:
 
-{% highlight js %}
+```javascript
 import {ajax} from '../src/ajax.js';
 import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
 import CONSTANTS from '../src/constants.json';
@@ -121,7 +121,7 @@ adaptermanager.registerAnalyticsAdapter({
 });
 
 export default exAnalytics;
-{% endhighlight %}
+```
 
 #### Reading TCF2 enforcement actions
 

--- a/dev-docs/modules/adpod.md
+++ b/dev-docs/modules/adpod.md
@@ -75,7 +75,7 @@ To enable publishers to prioritize video deals with direct buys and over deals a
 
 ### Examples:
 
-{% highlight js %}
+```javascript
 // This will replace the cpm with dealId in cache key as well as targeting kv pair when prioritizeDeals flag is set to true.
 pbjs.setConfig({
   adpod: {
@@ -92,10 +92,10 @@ pbjs.setConfig({
     }
   }
 })
-{% endhighlight %}
+```
 If the bidder returns multiple bid, each bid can have a different priority/deal tier set. To give publishers control over the deal tier a `filterBids` option has been added to `pbjs.adServers.freewheel.getTargeting` to select certain deal bids.
 
-{% highlight js %}
+```javascript
 pbjs.adServers.freewheel.getTargeting({
 
     codes: [adUnitCode1],
@@ -103,11 +103,11 @@ pbjs.adServers.freewheel.getTargeting({
         //pass targeting to player api
     }
 });
-{% endhighlight %}
+```
 
 #### Return
 
-{% highlight js %}
+```javascript
 // Sample return targeting key value pairs
 {
   'adUnitCode-1': [
@@ -125,7 +125,7 @@ pbjs.adServers.freewheel.getTargeting({
     }
   ]
 }
-{% endhighlight %}
+```
 
 ## Further Reading
 

--- a/dev-docs/modules/bidViewable.md
+++ b/dev-docs/modules/bidViewable.md
@@ -49,7 +49,7 @@ The default logic used to find a matching Prebid.js bid for a GPT slot is
 | `bidViewability.customMatchFunction` | Optional | function(bid, slot) | this function will be used to find the matching winning bid for the GPT slot. See above for the default. |
 
 ## Example of setting module config
-{% highlight js %}
+```javascript
     pbjs.setConfig({
         bidViewability: {
             enabled: true,
@@ -60,14 +60,14 @@ The default logic used to find a matching Prebid.js bid for a GPT slot is
             }
         }
     });
-{% endhighlight %}
+```
 
 ## Example of consuming BID_VIEWABLE event
-{% highlight js %}
+```javascript
 	pbjs.onEvent('bidViewable', function(bid){
 		console.log('got bid details in bidViewable event', bid);
 	});
-{% endhighlight %}
+```
 
 ## Related Reading
 

--- a/dev-docs/modules/bidViewableIO.md
+++ b/dev-docs/modules/bidViewableIO.md
@@ -50,20 +50,20 @@ Note that there are other viewability modules in Prebid.js:
 | `bidViewabilityIO.enabled` | Required | Boolean | when set to true, the module will emit BID_VIEWABLE when applicable. Default: `false` |
 
 ## Example of setting module config
-{% highlight js %}
+```javascript
 	pbjs.setConfig({
         bidViewabilityIO: {
             enabled: true,
         }
     });
-{% endhighlight %}
+```
 
 ## Example of consuming BID_VIEWABLE event
-{% highlight js %}
+```javascript
 	pbjs.onEvent('bidViewable', function(bid){
 		console.log('got bid details in bidViewable event', bid);
 	});
-{% endhighlight %}
+```
 
 ## Related Reading
 

--- a/dev-docs/modules/consentManagement.md
+++ b/dev-docs/modules/consentManagement.md
@@ -98,7 +98,7 @@ A related parameter is `deviceAccess`, which is at the global level of Prebid.js
 
 Example 1: IAB CMP using custom timeout and setting GDPR in-scope by default.
 
-{% highlight js %}
+```javascript
      var pbjs = pbjs || {};
      pbjs.que = pbjs.que || [];
      pbjs.que.push(function() {
@@ -112,11 +112,11 @@ Example 1: IAB CMP using custom timeout and setting GDPR in-scope by default.
           }
         });
      });
-{% endhighlight %}
+```
 
 Example 2: IAB CMP using custom timeout in combination with actionTimeout and setting GDPR in-scope by default. The following will wait `500ms` for the CMP to load, if it does an additional `10000ms` will be waited for a user to provide consent (if none had yet been provided).
 
-{% highlight js %}
+```javascript
      var pbjs = pbjs || {};
      pbjs.que = pbjs.que || [];
      pbjs.que.push(function() {
@@ -131,11 +131,11 @@ Example 2: IAB CMP using custom timeout in combination with actionTimeout and se
           }
         });
      });
-{% endhighlight %}
+```
 
 Example 3: Static CMP using custom data passing.
 
-{% highlight js %}
+```javascript
      var pbjs = pbjs || {};
      pbjs.que = pbjs.que || [];
      pbjs.que.push(function() {
@@ -173,15 +173,15 @@ Example 3: Static CMP using custom data passing.
           }
         });
      });
-{% endhighlight %}
+```
 
 ## Build the Package
 
 Follow the basic build instructions in the GitHub Prebid.js repo's main [README](https://github.com/prebid/Prebid.js/blob/master/README.md). To include the consent management module, an additional option must be added to the **gulp build** command:
 
-{% highlight bash %}
+```bash
 gulp build --modules=consentManagement,bidAdapter1,bidAdapter2
-{% endhighlight %}
+```
 
 You can also use the [Prebid.js Download](/download.html) page.
 
@@ -196,7 +196,7 @@ If you are submitting changes to an adapter to support TCF v2.0, please also sub
 To find the GDPR consent information to pass along to your system, adapters should look for the `bidderRequest.gdprConsent` field in their `buildRequests()` method.
 Here is a sample of how the data is structured in the `bidderRequest` object:
 
-{% highlight js %}
+```javascript
 {
   "bidderCode": "bidderA",
   "auctionId": "e3a336ad-2222-4a1c-bbbb-ecc7c5294a34",
@@ -209,7 +209,7 @@ Here is a sample of how the data is structured in the `bidderRequest` object:
   },
   ...
 }
-{% endhighlight %}
+```
 
 **gdprConsent Data Fields**
 
@@ -236,7 +236,7 @@ One of two general approaches can be taken by the adapter to populate this field
 
 The following is an example of how the integration could look for the former option:
 
-{% highlight js %}
+```javascript
 ...
 buildRequests: function (bidRequests, bidderRequest) {
   ...
@@ -250,7 +250,7 @@ buildRequests: function (bidRequests, bidderRequest) {
   ...
 }
 ...
-{% endhighlight %}
+```
 
 The implementation of the latter option is up to the adapter, but the general premise is the same.  You would check to see if the `bidderRequest.gdprConsent.gdprApplies` field is undefined and if so, set the derived value from your independent system.
 
@@ -261,11 +261,11 @@ If neither option are taken, then there is the remote chance this field's value 
 The `gdprConsent` object is also available when registering `userSync` pixels.
 The object can be accessed by including it as an argument in the `getUserSyncs` function:
 
-{% highlight js %}
+```javascript
 getUserSyncs: function(syncOptions, responses, gdprConsent, usPrivacy) {
 ...
 }
-{% endhighlight %}
+```
 
 Depending on your needs, you could include the consent information in a query of your pixel and/or, given the consent choices, determine if you should drop the pixels at all.
 
@@ -297,7 +297,7 @@ At a high level, this could be done as follows:
 
 Below is sample code for implementing the stub functions. Sample code for formatting the consent string can be obtained [here](https://github.com/appnexus/cmp).
 
-{% highlight js %}
+```javascript
 var iabConsentData;  // build the IAB consent string
 var gdprApplies;     // true if gdpr applies to the user, else false
 var responseCode;    // false if there was an error, else true
@@ -355,7 +355,7 @@ var responseCode;    // false if there was an error, else true
         }
     }
 })(window, document);
-{% endhighlight %}
+```
 
 #### Explanation of Parameters
 

--- a/dev-docs/modules/consentManagementGpp.md
+++ b/dev-docs/modules/consentManagementGpp.md
@@ -78,7 +78,7 @@ In addition to the static approach described above, there is another means to pa
 
 Example 1: IAB CMP using a custom timeout
 
-{% highlight js %}
+```javascript
      var pbjs = pbjs || {};
      pbjs.que = pbjs.que || [];
      pbjs.que.push(function() {
@@ -91,11 +91,11 @@ Example 1: IAB CMP using a custom timeout
           }
         });
      });
-{% endhighlight %}
+```
 
 Example 2: Static CMP using custom data passing.
 
-{% highlight js %}
+```javascript
      var pbjs = pbjs || {};
      pbjs.que = pbjs.que || [];
      pbjs.que.push(function() {
@@ -115,15 +115,15 @@ Example 2: Static CMP using custom data passing.
           }
         });
      });
-{% endhighlight %}
+```
 
 ## Build the Package
 
 Follow the basic build instructions in the GitHub Prebid.js repo's main [README](https://github.com/prebid/Prebid.js/blob/master/README.md). To include the consent management module, an additional option must be added to the **gulp build** command:
 
-{% highlight bash %}
+```bash
 gulp build --modules=consentManagementGpp,bidAdapter1,bidAdapter2
-{% endhighlight %}
+```
 
 You can also use the [Prebid.js Download](/download.html) page.
 
@@ -138,7 +138,7 @@ If you are submitting changes to an adapter to support GPP, please also submit a
 To find the GPP consent information to pass along to your system, adapters should look for the `bidderRequest.gppConsent` field in their `buildRequests()` method; this field includes a copy of the full GPPData object from the CMP, in case additional information (beyond the gppString and applicableSections values) is needed.  Alternatively if only the consent string and/or the applicableSections values are needed, these two values can also be found in the `bidderRequest.ortb2.regs` field under the OpenRTB 2.6 field names (`gpp` and `gpp_sid`).
 Here is a sample of how the data is structured in the `bidderRequest` object:
 
-{% highlight js %}
+```javascript
 {
   "bidderCode": "bidderA",
   "auctionId": "e3a336ad-2222-4a1c-bbbb-ecc7c5294a34",
@@ -157,18 +157,18 @@ Here is a sample of how the data is structured in the `bidderRequest` object:
   },
   ...
 }
-{% endhighlight %}
+```
 
 ### UserSync Integration
 
 The `gppConsent` object is also available when registering `userSync` pixels.
 The object can be accessed by including it as an argument in the `getUserSyncs` function:
 
-{% highlight js %}
+```javascript
 getUserSyncs: function(syncOptions, responses, gdprConsent, usPrivacy, gppConsent) {
 ...
 }
-{% endhighlight %}
+```
 
 Depending on your needs, you could include the consent information in a query of your pixel and/or, given the consent choices, determine if you should drop the pixels at all.
 

--- a/dev-docs/modules/consentManagementUsp.md
+++ b/dev-docs/modules/consentManagementUsp.md
@@ -97,7 +97,7 @@ to the GDPR implementation, though US-Privacy doesn't specifically use that term
 
 Example 1: Support both US Privacy and GDPR
 
-{% highlight js %}
+```javascript
      var pbjs = pbjs || {};
      pbjs.que = pbjs.que || [];
      pbjs.que.push(function() {
@@ -114,11 +114,11 @@ Example 1: Support both US Privacy and GDPR
          }
        });
      });
-{% endhighlight %}
+```
 
 Example 2: Support US Privacy; timeout the api availability at zero because it is always available if it applies
 
-{% highlight js %}
+```javascript
      var pbjs = pbjs || {};
      pbjs.que = pbjs.que || [];
      pbjs.que.push(function() {
@@ -131,11 +131,11 @@ Example 2: Support US Privacy; timeout the api availability at zero because it i
          }
        });
      });
-{% endhighlight %}
+```
 
 Example 3: Static CMP using custom data passing. Placing this config call in the command queue before loading Prebid is important to ensure the string is available before Prebid begins making external calls. 
 
-{% highlight js %}
+```javascript
      var pbjs = pbjs || {};
      pbjs.que = pbjs.que || [];
      pbjs.que.push(function() {
@@ -152,11 +152,11 @@ Example 3: Static CMP using custom data passing. Placing this config call in the
           }
         });
      });
-{% endhighlight %}
+```
 
 Example 4: Static CMP with USP string set to does not apply for all fields, which may be useful to prevent excessive interaction with the `__uspapi` outside of the geographic scope. Placing this config call in the command queue before loading Prebid is important to ensure it is available early. 
 
-{% highlight js %}
+```javascript
      var pbjs = pbjs || {};
      pbjs.que = pbjs.que || [];
      pbjs.que.push(function() {
@@ -173,14 +173,14 @@ Example 4: Static CMP with USP string set to does not apply for all fields, whic
           }
         });
      });
-{% endhighlight %}
+```
 ## Build the Package
 
 Follow the basic build instructions in the GitHub Prebid.js repo's main [README](https://github.com/prebid/Prebid.js/blob/master/README.md). To include the consent management module, an additional option must be added to the the **gulp build** command:
 
-{% highlight bash %}
+```bash
 gulp build --modules=consentManagementUsp,bidAdapter1,bidAdapter2
-{% endhighlight %}
+```
 
 ## Adapter Integration
 
@@ -191,7 +191,7 @@ If you are submitting changes to an adapter to support this approach, please als
 To find the US Privacy/CCPA notice and opt-out status information to pass along to your system, adapters should look for the `bidderRequest.uspConsent` field in their `buildRequests()` method.
 Below is a sample of how the data is structured in the `bidderRequest` object:
 
-{% highlight js %}
+```javascript
 {
   "bidderCode": "bidderA",
   "auctionId": "e3a336ad-2222-4a1c-bbbb-ecc7c5554a34",
@@ -199,18 +199,18 @@ Below is a sample of how the data is structured in the `bidderRequest` object:
   "uspConsent": "1YYY",
   ...
 }
-{% endhighlight %}
+```
 
 ### UserSync Integration
 
 The `usPrivacy` object is also available when registering `userSync` pixels.
 The object can be accessed by including it as an argument in the `getUserSyncs` function:
 
-{% highlight js %}
+```javascript
 getUserSyncs: function(syncOptions, responses, gdprConsent, usPrivacy) {
 ...
 }
-{% endhighlight %}
+```
 
 Depending on your needs, you could include the US-Privacy information in a query of your pixel and/or, given the notice and opt-out status choices, determine if you should drop the pixels at all.
 

--- a/dev-docs/modules/currency.md
+++ b/dev-docs/modules/currency.md
@@ -53,7 +53,7 @@ For example, the default Prebid "low granularity" bucket is:
 The following config translates the "low granularity" bucket with a conversion rate of
 108 yen to 1 US dollar. It also defines the default conversion rate as being 110 yen to the dollar.
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     "priceGranularity": "low",
     "currency": {
@@ -62,7 +62,7 @@ pbjs.setConfig({
        "defaultRates": { "USD": { "JPY": 110 }}
     }
 });
-{% endhighlight %}
+```
 
 This results in a granularity rule that's scaled up to make sense in Yen:
 
@@ -172,7 +172,7 @@ from USD to JPY is 110.
 
 Adding the currency module to a page is done with a call to the setConfig API with one or
 more parameters. The simplest recommended implementation would be:
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     "currency": {
        "adServerCurrency": "JPY",
@@ -180,13 +180,13 @@ pbjs.setConfig({
        "defaultRates": { "USD": { "JPY": 110 }}
     }
 });
-{% endhighlight %}
+```
 
 {: .alert.alert-warning :}
 Note that the `defaultRates` attribute is optional, but recommended in case there's an issue loading the currency file.
 
 In this example, the publisher is providing their own `conversionRateFile`:
-{% highlight js %}
+```javascript
 pbjs.setConfig({
 "currency": {
       // enables currency feature
@@ -198,10 +198,10 @@ pbjs.setConfig({
       "defaultRates": { "USD": { "GPB": 0.75 }}
    }
 });
-{% endhighlight %}
+```
 And finally, here's an example where the conversion rate is specified right in the config, so
 the external file won't be loaded:
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     "currency": {
        "adServerCurrency": "JPY",
@@ -209,7 +209,7 @@ pbjs.setConfig({
        "rates": { "USD": { "JPY": 110.21 }}
     }
 });
-{% endhighlight %}
+```
 
 
 ## Building the Prebid package with Currency Support
@@ -218,9 +218,9 @@ pbjs.setConfig({
 
 Follow the basic build instructions on the Gihub repo's main README. To include the module, an additional option must be added to the the gulp build command:
 
-{% highlight js %}
+```javascript
 gulp build --modules=currency,exampleBidAdapter
-{% endhighlight %}
+```
 
 This command will build the following files:
 

--- a/dev-docs/modules/dfp_express.md
+++ b/dev-docs/modules/dfp_express.md
@@ -36,9 +36,9 @@ Definitions:
 ## Page integration
 
 Adding the module to a page is done by adding just one line of javascript:
-{% highlight js %}
+```javascript
 <script src="https://some.hosting.domain/path/prebid.js">
-{% endhighlight %}
+```
 
 The prebid.js file needs to be loaded before the GPT library loads, unless you're willing to manage the timing with additional queue functions. The examples here assume the easiest integration, which is synchronous.
 
@@ -52,7 +52,7 @@ The prebid.js file must also be constructed so that it contains:
 
 Create an AdUnits file and source control it in a separate local repository. E.g. my-prebid-config/pub123adUnits.js:
  
-{% highlight js %}
+```javascript
      var pbjs = pbjs || {};
      pbjs.que = pbjs.que || [];
      pbjs.que.push(function() {
@@ -71,7 +71,7 @@ Create an AdUnits file and source control it in a separate local repository. E.g
         });
         pbjs.express(); // activates the Google Ad Manager Express feature.
      });
-{% endhighlight %}
+```
 
 Notes:
 
@@ -84,9 +84,9 @@ Notes:
 
 Follow the basic build instructions on the Gihub repo's main README. To include the module, an additional option must be added to the the gulp build command:
  
-{% highlight js %}
+```javascript
 gulp build --modules=express
-{% endhighlight %}
+```
  
 This command will build the following files:
  
@@ -98,9 +98,9 @@ This command will build the following files:
 
 If you've chosen to append the AdUnits right to the end of the package, use the command line to concatenate the files. e.g.
 
-{% highlight js %}
+```javascript
 cat build/dist/prebid.js my-prebid-config/pub123adUnits.js >> build/dist/prebid-express-with-adunits.js
-{% endhighlight %}
+```
  
 #### Step 3: Publish the package(s) to your CDN
 
@@ -112,9 +112,9 @@ Note that there are more dynamic ways of combining these components for publishe
 
 The Google Ad Manager Express module adds one new function to Prebid:
 
-{% highlight js %}
+```javascript
 pbjs.express(AdUnits);
-{% endhighlight %}
+```
 
 This function initiates the scanning of the in-page Google Ad Manager slots, mapping them to Prebid AdUnits, kicking off the Prebid auction, and forwarding the results to Google Ad Manager.
 

--- a/dev-docs/modules/floors.md
+++ b/dev-docs/modules/floors.md
@@ -77,7 +77,7 @@ Below are some basic principles of ad unit floor definitions:
     - Values can differ between ad units
 
 
-{% highlight js %}
+```javascript
  var adUnits = [
          {
              code: 'test-div',
@@ -106,14 +106,14 @@ Below are some basic principles of ad unit floor definitions:
              ]
          }
      ];
-{% endhighlight %}
+```
 
 {: .alert.alert-info :}
-When defining floors at the adUnit level, the Price Floors Module requires the floors object to be defined in setConfig, even if the definition is an empty object as shown below: {% highlight js %}pbjs.setConfig({ floors: {} });{% endhighlight %}
+When defining floors at the adUnit level, the Price Floors Module requires the floors object to be defined in setConfig, even if the definition is an empty object as shown below: ```javascriptpbjs.setConfig({ floors: {} });```
 
 Floor definitions are set in the “values” object containing one or more rules, where the rule is the criteria that needs to be met for that given ad unit, with an associated CPM floor. In the above example, the floors are enforced when the bid from a bidder matches the “mediaType” and “size” combination. Since many bid adapters are not able to ingest floors per size, a simpler setup can be:
 
-{% highlight js %}
+```javascript
 floors: {
            currency: 'USD',
            skipRate: 5,
@@ -126,11 +126,11 @@ floors: {
                'video': 2.01
            }
        }
-{% endhighlight %}
+```
 
 For more advanced publisher setups, values can accept a “\*” to denote a catch-all when a bid comes back that the Price Floors Module does not have an exact match and for bid adapters who are not able to use a floor per size, the bid adapter will automatically receive the “\*” rule’s floor if available. Example setup can be:
 
-{% highlight js %}
+```javascript
 floors: {
    currency: 'USD',
    skipRate: 5,
@@ -147,23 +147,23 @@ floors: {
        'video|*': 2.01
    }
 }
-{% endhighlight %}
+```
 
 Alternatively, if there’s only one mediaType in the AdUnit and a single global floor, the syntax gets easier:
 
-{% highlight js %}
+```javascript
 ...
  floors: {
      default: 1.00     // default currency is USD
  },
  ...
-{% endhighlight %}
+```
 
 ### Package-Level Floors
 
 This approach is intended for scenarios where the Publisher or their Prebid managed service provider periodically appends updated floor data to the Prebid.js package. In this model, there could be more floor data present to cover AdUnits across many pages.
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     floors: {
         enforcement: {
@@ -191,13 +191,13 @@ pbjs.setConfig({
         }
     }
 });
-{% endhighlight %}
+```
 
 By defining floor data with setConfig, the Price Floors Module will map GPT ad slots to AdUnits as needed. It does this in the same way as the setTargetingForGPTAsync() function – first looking for an AdUnit.code that matches the slot name, then looking for an AdUnit.code that matches the div id of the named GPT slot.
 
 Here’s another example that includes more fields:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     floors: {
         data: {     // default if endpoint doesn't return in time
@@ -217,7 +217,7 @@ pbjs.setConfig({
         }
     }
 });
-{% endhighlight %}
+```
 
 ### Dynamic Floors
 The final method of obtaining floor data allows the publisher to delay the auction for a certain time period to obtain up-to-date floor data tailored to each page or auction context. The assumed workflow is:
@@ -228,7 +228,7 @@ The final method of obtaining floor data allows the publisher to delay the aucti
 
 Here’s an example defining a simple GET endpoint:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     floors: {
         enforcement: {
@@ -240,11 +240,11 @@ pbjs.setConfig({
         }
     }
 });
-{% endhighlight %}
+```
 
 The Price Floors Module is flexible to handle floors set in multiple locations. Like in the below example a publisher can configure Dynamic floors in addition to Package floors (in setConfig). While the Price Floors Module is only able to use one set of rules (either Package, adUnit or Dynamic) defined as a Floor Location, setting floors in the Package will be utilized when the Dynamic floors fail to return data or another error condition occurs with the Dynamic fetch.
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     floors: {
         enforcement: {
@@ -269,7 +269,7 @@ pbjs.setConfig({
         }
     }
 });
-{% endhighlight %}
+```
 
 
 ## Floors Syntax
@@ -388,7 +388,7 @@ As noted for Schema 1, when you see 'skipped' in the floors data, it indicates t
 *Example 1*
 Model weights add up to 100 and are sampled at a 25%, 25%, 50% distribution. Additionally, each model group has diffirent schema fields:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     floors: {
         enforcement: { ... },
@@ -453,7 +453,7 @@ pbjs.setConfig({
 	}
     }
 });
-{% endhighlight %}
+```
 
 *Example 2*
 Model weights do not equal 100 and are normalized. Weights will be applied in the following method: Model weight / (sum of all weights)
@@ -462,7 +462,7 @@ model2 = 50  -> 50 / (20 + 50) = 71% of auctions model 2 will be applied
 
 Additionally skipRate is supplied at model group level where model1 will skip floors 20% of times when model1 is selected, whereas model2 will skip 50% of auctions when model2 is selected.
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     floors: {
         enforcement: { ... },
@@ -511,7 +511,7 @@ pbjs.setConfig({
 	}
     }
 });
-{% endhighlight %}
+```
 
 ### Impression-Level Floor Min
 
@@ -536,7 +536,7 @@ Out of the box, the Price Floors Module only supports looking up floors by AdUni
 Create a function to allow the module to understand context of a given auction. In the below example, a lookup function provides details about what deviceType this auction is for. 
 
 e.g.
-{% highlight js %}
+```javascript
   function deviceTypes (bidRequest, bidResponse) {
       //while bidRequest and bidResponse are not required for this function, they are available for custom attribute mapping
       
@@ -550,7 +550,7 @@ e.g.
           return 'desktop'
   }
 
-{% endhighlight %}
+```
 
 
 ### Define, Set and Map Custom Schema Attributes
@@ -559,7 +559,7 @@ After defining a lookup function for the given context of the auction, the custo
 
 In the below example, `deviceType` is a custom field not currently supported by default in the Price Floors Module whose values are one of "mobile", "desktop" or "tablet".
 
-{% highlight js %}
+```javascript
 
   pbjs.setConfig({
       floors: {
@@ -589,7 +589,7 @@ In the below example, `deviceType` is a custom field not currently supported by 
       }
   });
 
-{% endhighlight %}
+```
 
 
 ## Rule Handling
@@ -646,7 +646,7 @@ Domain = www.website.com
 
 Floor provider rule definition
 
-{% highlight js %}
+```javascript
 {
   "modelVersion": "Fancy Model",
   "currency": "USD",
@@ -673,7 +673,7 @@ Floor provider rule definition
   },
   "default": 0.01
 }
-{% endhighlight %}
+```
 
 **Bidder A Bid**
 
@@ -683,7 +683,7 @@ Domain context = www.website.com
 
 The Floor module produces an internal hash table of all possible permutations of “banner”, “300x600”, “www.website.com” and “\*” with the most specific hash values up top, weighting rules priority from left column specific values to right. Each left value will weigh more than the subsequent column’s specific values. The module attempts to find the matching rule by cycling through each below possible rule (from top to bottom) against the above rule provider data set.
 
-{% highlight js %}
+```javascript
 {
     "banner|300x600|www.website.com",     //Most specific possible rule match against floor provider rule set
     "banner|300x600|*",                               
@@ -695,7 +695,7 @@ The Floor module produces an internal hash table of all possible permutations of
     "*|*|www.website.com",
     "*|*|*"                                                       
   }
-{% endhighlight %}
+```
 
 Matching rule: "banner|300x600|www.website.com"  
 Floor enforced: 3.01  
@@ -708,7 +708,7 @@ Size = 640x480
 Domain context = www.website.com  
 
 Price Floor internal possible permutations sorted by priority:
-{% highlight js %}
+```javascript
 {
     "video|640x480|www.website.com",       //Fails to match due to no video specific rule
     "video|640x480|*",                                  //Fails to match due to no video specific rule
@@ -719,7 +719,7 @@ Price Floor internal possible permutations sorted by priority:
     "*|*|www.website.com",                           //Matching rule
     "*|*|*"
   }
-{% endhighlight %}
+```
 
 Matching rule: "\*|\*|www.website.com"  
 Enforced Floor: 15.01
@@ -732,7 +732,7 @@ Size = 300x250
 Domain context = www.website.com  
 
 Price Floor internal possible permutations sorted by priority:
-{% highlight js %}
+```javascript
 {
     "video|300x250|www.website.com",       //Fails to match due to no video specific rule
     "video|300x250|*",                                  //Fails to match due to no video specific rule
@@ -743,7 +743,7 @@ Price Floor internal possible permutations sorted by priority:
     "*|*|www.website.com",
     "*|*|*"
   }
-{% endhighlight %}
+```
 
 Matching Rule "\*|300x250|www.website.com”  
 Enforced floor: 10.01  
@@ -756,7 +756,7 @@ Domain = www.website.com
 
 Floor provider rule definition
 
-{% highlight js %}
+```javascript
 {
   "modelVersion": "Fancy Model",
   "currency": "USD",
@@ -784,7 +784,7 @@ Floor provider rule definition
   },
   "defaultValue": 0.01
 }
-{% endhighlight %}
+```
 
 **Bidder A Bid**
 
@@ -792,7 +792,7 @@ mediaType = banner
 Size = 300x600  
 Domain context = www.website.com  
 
-{% highlight js %}
+```javascript
 
 {
     "banner|300x600|www.website.com",   // Fails due to website.com does not match with banner and 300x600
@@ -806,7 +806,7 @@ Domain context = www.website.com
     "*|*|*"                                                       
   }
 
-{% endhighlight %}
+```
 
 Matching rule: "banner|300x600|\*"  
 Floor enforced: 4.01  
@@ -819,7 +819,7 @@ Domain context = www.website.com.
 
 Price Floor internal possible permutations sorted by priority:
 
-{% highlight js %}
+```javascript
 
 {
     "video|640x480|www.website.com",    //Fails to match due to no video specific rule
@@ -832,7 +832,7 @@ Price Floor internal possible permutations sorted by priority:
     "*|*|*"
   }
 
-{% endhighlight %}
+```
 
 Matching rule: "video\|\*\|\*"  
 Enforced Floor: 9.01
@@ -846,7 +846,7 @@ Domain context = www.website.com
 
 Price Floor internal possible permutations sorted by priority:
 
-{% highlight js %}
+```javascript
 {
     "video|300x250|www.website.com",       //Fails to match due to no video specific rule
     "video|300x250|*",                                  //Fails to match due to no video specific rule
@@ -857,7 +857,7 @@ Price Floor internal possible permutations sorted by priority:
     "*|*|www.website.com",
     "*|*|*"
   }
-{% endhighlight %}
+```
 
 Matching Rule "\*|300x250|www.website.com”  
 Enforced floor: 10.01  
@@ -888,7 +888,7 @@ On rule creation, we recommend supplying various rules with catch-all \(“\*”
 
 #### Example Dynamic fetch
 
-{% highlight js %}
+```javascript
 
 pbjs.setConfig({
     floors: {
@@ -902,13 +902,13 @@ pbjs.setConfig({
     }
 });
 
-{% endhighlight %}
+```
 
 #### Example Dynamic Response 1 - Schema 1
 
 In this example, the floor is determined by AdUnit code and Media Type. Note that the response does not contain the 'data' object because everything in the response is merged there.
 
-{% highlight js %}
+```javascript
 
 {
     floorProvider: 'floorProviderName',
@@ -928,13 +928,13 @@ In this example, the floor is determined by AdUnit code and Media Type. Note tha
     default: 0.75
 }
 
-{% endhighlight %}
+```
 
 #### Example Response 2 - Schema 1
 
 In this example, the floor is determined by Domain, GPT Slot, Media Type and Size:
 
-{% highlight js %}
+```javascript
 
 {
     currency: 'EU',
@@ -956,14 +956,14 @@ In this example, the floor is determined by Domain, GPT Slot, Media Type and Siz
     default: 0.75
 }
 
-{% endhighlight %}
+```
 
 
 #### Example Response 3 - Schema 2
 
 In this example, the floor is determined by domain, gptSlot, mediaType, and size. Note again that dynamic floor responses are merged into the 'data' level of the schema.
 
-{% highlight js %}
+```javascript
 {
     "currency": "USD",
     "floorsSchemaVersion":2,
@@ -1007,7 +1007,7 @@ In this example, the floor is determined by domain, gptSlot, mediaType, and size
 
 }
 
-{% endhighlight %}
+```
 
 
 ### Bid Adapter Interface
@@ -1025,7 +1025,7 @@ Changes for bid adapters:
 
 getFloor() takes in a single object with the following params:
 
-{% highlight js %}
+```javascript
  if (typeof bidRequest.getFloor === 'function') {
    floorInfo = bidRequest.getFloor({
       currency: string,
@@ -1033,7 +1033,7 @@ getFloor() takes in a single object with the following params:
       size : [ w, h] OR "*"
   });
 }
-{% endhighlight %}
+```
 
 {: .alert.alert-warning :}
 Consider how floors will behave in multi-currency scenarios. A common pitfall is requesting floors without specifying currency, or specifying the wrong currency back to the bid adapter's platform. This may lead to bidders requesting one currency and bidding in an alternate currency.
@@ -1048,28 +1048,28 @@ Consider how floors will behave in multi-currency scenarios. A common pitfall is
 
 #### getFloor() Response
 
-{% highlight js %}
+```javascript
 
 {
     currency: string,
     floor: float
 }
 
-{% endhighlight %}
+```
 
 Or empty object if a floor was not found for a given input
 
-{% highlight js %}
+```javascript
 
 { }
 
-{% endhighlight %}
+```
 
 #### Example getFloor() scenarios
 
 Example rules file used for getFloor()
 
-{% highlight js %}
+```javascript
 
   {
       "data": {
@@ -1088,66 +1088,66 @@ Example rules file used for getFloor()
           }
   }
 
-{% endhighlight %}
+```
 
 **Example getFloor() 1**
 
 getFloor() for media type Banner for a bid request in GPT slot “/1111/homepage/top-rect” where the bid adapter does not support floors per size.
 
-{% highlight js %}
+```javascript
 
   getFloor({
       currency: 'USD',
       mediatype: ‘banner’,
       size: ‘*’
   });
-{% endhighlight %}
+```
 
 **Response**
 
-{% highlight js %}
+```javascript
 {
     currency: 'USD',
     floor: 1.10
 }
-{% endhighlight %}
+```
 
 To aid in the accuracy of floor selection when using size ”\*” in getFloor(), the Price Floors Module has built-in smart rule selection when an ad unit in the internal bidRequest to the bid adapters interface has one ad unit type and one size. In the above example, if the ad unit within the bidRequest object has an ad unit type of “banner” with only one size, say “300x250”, the module will intelligently select the rule with "banner\|300x250" in it, as opposed to the "banner\|\*" rule producing the following response:
 
-{% highlight js %}
+```javascript
 {
     currency: 'USD',
     floor: 0.60
 }
-{% endhighlight %}
+```
 
 
 **Example getFloor() 2**
 
 getFloor() for media type Banner for a bid requests in GPT slot “/1111/homepage/top-rect” with size of 300x600 where bid adapter does support floors per size.
 
-{% highlight js %}
+```javascript
 getFloor({
     currency: 'USD',
     size: [300,600],
     mediatype: ‘banner’
 });
-{% endhighlight %}
+```
 
 **Response**
 
-{% highlight js %}
+```javascript
 {
     currency: 'USD',
     floor: 1.78
 }
-{% endhighlight %}
+```
 
 Here are some examples of how a bid adapter may wish to configure their adapter to handle getFloor() function:
 
 For a bid adapter who does not wish to handle making a request for each size in a given bid request they can leverage the \* attribute which is meant to be a skewed average for a floor.
 
-{% highlight js %}
+```javascript
  if (typeof bidRequest.getFloor === 'function') {
       let floorInfo = bidRequest.getFloor({
         currency: 'USD',
@@ -1156,7 +1156,7 @@ For a bid adapter who does not wish to handle making a request for each size in 
       });
       data['adapter_floor'] = floorInfo.currency === 'USD' ? floorInfo.floor : undefined;
     }
-{% endhighlight %}
+```
 
 ### Analytics Adapter Interface
 
@@ -1281,31 +1281,31 @@ Example Rule:
 currency = ‘USD’,
 ‘banner|300x250’: 1.00
 
-{% highlight js %}
+```javascript
 getFloor({
   currency: ‘EUR’,
   mediaType: ‘banner’,
   size: [300, 250]
 });
-{% endhighlight %}
+```
 
 If successfully returned the requested currency:
 
-{% highlight js %}
+```javascript
 {
   floor: 0.85,
   currency: ‘EUR’
 }
-{% endhighlight %}
+```
 
 If currency conversion is unsuccessful:
 
-{% highlight js %}
+```javascript
 {
   floor:1.0,
   currency: ‘USD’
 }
-{% endhighlight %}
+```
 
 Currency conversion can fail for the following reasons:
 - Currency module is not included in the prebid bundle.

--- a/dev-docs/modules/gdprEnforcement.md
+++ b/dev-docs/modules/gdprEnforcement.md
@@ -188,9 +188,9 @@ See the [IAB TCF Consent String Format](https://github.com/InteractiveAdvertisin
 
 Follow the basic build instructions in the GitHub Prebid.js repo's main [README](https://github.com/prebid/Prebid.js/blob/master/README.md). Include the base consent management module and this enforcement module as additional options on the **gulp build** command:
 
-{% highlight bash %}
+```bash
 gulp build --modules=consentManagement,gdprEnforcement,bidAdapter1,bidAdapter2
-{% endhighlight %}
+```
 
 You can also use the [Prebid.js Download](/download.html) page.
 

--- a/dev-docs/modules/instreamTracking.md
+++ b/dev-docs/modules/instreamTracking.md
@@ -34,26 +34,26 @@ This module uses `window.performance.getEntriesByType('resource')` to check the 
 | `instreamTracking.urlPattern` | Optional | RegExp | Regex for cache url patterns, to avoid false positives. |
 
 #### Basic Example
-{% highlight js %}
+```javascript
 pbjs.setConfig({
         'instreamTracking': {
             enabled: true,
         }
 });
-{% endhighlight %}
+```
 
 #### Example with urlPattern
 
 While checking for URLs having `videoCacheKey`, there are chances of false positives. To avoid those cases, we can set `instreamTracking.urlPattern: /REGEX_PATTERN/`.
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
         'instreamTracking': {
             enabled: true,
             urlPattern: /(prebid\.adnxs\.com\/pbc\/v1\/cache\.*)|(search\.spotxchange\.com\/ad\/vast\.html\?key=\.*)/
         }
 });
-{% endhighlight %}
+```
 
 ## Intergation
 
@@ -69,13 +69,13 @@ To install the module, follow these instructions:
 
 Enable `instreamTracking` using `pbjs.setConfig`
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
         'instreamTracking': {
             enabled: true,
         }
 });
-{% endhighlight %}
+```
 
 ## Further Reading
 ​

--- a/dev-docs/modules/pubCommonId.md
+++ b/dev-docs/modules/pubCommonId.md
@@ -33,14 +33,14 @@ Add a pubcid object in the setConfig() call.
 
 Example: Changing ID expiration to 1 year
 
-{% highlight js %}
+```javascript
      var pbjs = pbjs || {};
      pbjs.que = pbjs.que || [];
      pbjs.que.push(function() {
         pbjs.setConfig({pubcid: {expInterval: 525600}});
         pbjs.addAdUnits(adUnits);
      });
-{% endhighlight %}
+```
 
 ### User Opt-Out
 
@@ -56,9 +56,9 @@ Users must be allowed to opt out of targeted advertising. When implementing this
 
 Follow the basic build instructions on the GitHub repo's main README. To include the module, an additional option must be added to the the gulp build command:
  
-{% highlight bash %}
+```bash
 gulp build --modules=pubCommonId,bidAdapter1,bidAdapter2
-{% endhighlight %}
+```
  
 #### Step 2: Publish the package(s) to the CDN
 
@@ -70,7 +70,7 @@ Note that there are more dynamic ways of combining these components for publishe
 
 Adapters should look for `bid.crumbs.pubcid` in buildRequests() method. 
 
-{% highlight js %}
+```javascript
 [
    {
       "bidder":"appnexus",
@@ -88,7 +88,7 @@ Adapters should look for `bid.crumbs.pubcid` in buildRequests() method.
       "auctionId":"a1a98ab2-97c9-4f42-970e-6e03040559f2"
    }
 ]
-{% endhighlight %}
+```
 
 
 ## Technical Details

--- a/dev-docs/modules/schain.md
+++ b/dev-docs/modules/schain.md
@@ -38,7 +38,7 @@ The module performs validations on the schain data provided and makes it availab
 
 Call `setConfig` with the `schain` object to be used:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
   "schain": {
     "validation": "strict",
@@ -55,13 +55,13 @@ pbjs.setConfig({
     }
   }
 });
-{% endhighlight %}
+```
 
 ### Bidder-Specific Supply Chains
 
 This method uses the `pbjs.setBidderConfig` function, with a syntax similar to the global scenario above.
 
-{% highlight js %}
+```javascript
 pbjs.setBidderConfig({
   "bidders": ['bidderA'],   // can list more bidders here if they share the same config
   "config": {

--- a/dev-docs/modules/sizeMappingV2.md
+++ b/dev-docs/modules/sizeMappingV2.md
@@ -55,7 +55,7 @@ If you've used [`sizeConfig`](/dev-docs/publisher-api-reference/setConfig.html#s
 
 - A **sizeConfig** parameter may be specified on the AdUnit mediaType or a bidder. In these scenarios, the syntax is a little different than with the global configuration. Here's an example for a sizeConfig object for banner media type:
 
-{% highlight js %}
+```javascript
   mediaTypes: {
     banner: {
       sizeConfig: [
@@ -64,7 +64,7 @@ If you've used [`sizeConfig`](/dev-docs/publisher-api-reference/setConfig.html#s
       ];
     }
   }
-{% endhighlight %}
+```
 
 - **Labels** aren't defined in AdUnit sizeConfig objects. Instead of funneling viewport sizes into a small number of labeled scenarios, the Advanced Size Mapping approach allows each AdUnit and Bidder to define separate size buckets. Labels are still an effective way to do other tasks such as filtering AdUnits and Bidders based on their geo location. For more details on Labels, visit [Conditional Ad Units](/dev-docs/conditional-ad-units.html).
 
@@ -74,7 +74,7 @@ It may be useful to compare the globally-configured sizeConfig with the AdUnit-l
 
 Here's that same example using Advanced Size Mapping:
 
-{% highlight js %}
+```javascript
   const adUnit = {
     code: "ad-slot-1",
     mediaTypes: {
@@ -88,7 +88,7 @@ Here's that same example using Advanced Size Mapping:
       }
     }
   }
-{% endhighlight %}
+```
 
 Note the tradeoff here: If you're specifying duplicate sizeConfigs on every AdUnit, you might be better off using the global sizeConfig approach. But if the global approach isn't flexible enough for your site design, the AdUnit-level approach is the right way to go.
 
@@ -157,7 +157,7 @@ Note that the labels are assumed to be passed in via [`pbjs.requestBids()`](/dev
       ]
   }]
 }
-{% endhighlight %}
+```
 
 Here are two requests and how they would be handled in this scenario:
 
@@ -229,7 +229,7 @@ II. A request originating in the UK, viewport size: `[1700px, 900px]`
         ]
     }]
 }
-{% endhighlight %}
+```
 
 Here are two requests and how they would be handled in this scenario:
 
@@ -254,9 +254,9 @@ II. A tablet with viewport size: `[1100px, 980px]`
 
 Follow the basic build instructions in the GitHub Prebid.js repo's main [README](https://github.com/prebid/Prebid.js/blob/master/README.md). To include the Advanced Size Mapping module, the `sizeMappingV2` module must be added to the **gulp build** command:
 
-{% highlight bash %}
+```bash
 gulp build --modules=sizeMappingV2,bidAdapter1,bidAdapter2
-{% endhighlight %}
+```
 
 ## Further Reading
 

--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -219,7 +219,7 @@ For example, the adapter code might do something like:
    if (bidRequest.userId && bidRequest.userId.sharedid) {
     url+="&pubcid="+bidRequest.userId.sharedid;
    }
-{% endhighlight %}
+```
 
 ### Prebid Server Adapters
 

--- a/dev-docs/modules/userid-submodules/admixer.md
+++ b/dev-docs/modules/userid-submodules/admixer.md
@@ -49,4 +49,4 @@ gulp build --modules=admixerIdSystem
            auctionDelay: 50             // 50ms maximum auction delay, applies to all userId modules
        }
    });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/adriver.md
+++ b/dev-docs/modules/userid-submodules/adriver.md
@@ -22,4 +22,4 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/adtelligent.md
+++ b/dev-docs/modules/userid-submodules/adtelligent.md
@@ -27,7 +27,7 @@ adtelligentIdSystem adapter doesn't require any configuration or storage params.
          }]
      }
  });
-{% endhighlight %}
+```
 
 Example with a short storage for ~10 minutes and refresh in 5 minutes:
 
@@ -45,4 +45,4 @@ Example with a short storage for ~10 minutes and refresh in 5 minutes:
             }]
         }
     });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/audienceone.md
+++ b/dev-docs/modules/userid-submodules/audienceone.md
@@ -36,4 +36,4 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/britepool.md
+++ b/dev-docs/modules/userid-submodules/britepool.md
@@ -55,4 +55,4 @@ The BritePool privacy policy is at [https://britepool.com/services-privacy-notic
            syncDelay: 3000 // 3 seconds after the first auction
        }
    });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/cpexid.md
+++ b/dev-docs/modules/userid-submodules/cpexid.md
@@ -28,4 +28,4 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/criteo.md
+++ b/dev-docs/modules/userid-submodules/criteo.md
@@ -34,4 +34,4 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/deepintent.md
+++ b/dev-docs/modules/userid-submodules/deepintent.md
@@ -42,7 +42,7 @@ pbjs.setConfig({
     auctionDelay: 50             // 50ms maximum auction delay, applies to all userId modules
   }
 });
-{% endhighlight %}
+```
 
 2) Publisher stores the hashed identity from healthcare identity in localstorage
 {% highlight javascript %}
@@ -58,4 +58,4 @@ pbjs.setConfig({
     auctionDelay: 50             // 50ms maximum auction delay, applies to all userId modules
   }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/dmd.md
+++ b/dev-docs/modules/userid-submodules/dmd.md
@@ -43,4 +43,4 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/fabrick.md
+++ b/dev-docs/modules/userid-submodules/fabrick.md
@@ -64,7 +64,7 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```
 
 2) Publisher passes an apiKey and hashed email address and elects to store the fabrickId envelope in HTML5 localStorage.
 
@@ -85,4 +85,4 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/gravito.md
+++ b/dev-docs/modules/userid-submodules/gravito.md
@@ -31,4 +31,4 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/id5.md
+++ b/dev-docs/modules/userid-submodules/id5.md
@@ -75,4 +75,4 @@ pbjs.setConfig({
     auctionDelay: 50             // 50ms maximum auction delay, applies to all userId modules
   }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/idplus.md
+++ b/dev-docs/modules/userid-submodules/idplus.md
@@ -33,4 +33,4 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/idx.md
+++ b/dev-docs/modules/userid-submodules/idx.md
@@ -38,4 +38,4 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/imuid.md
+++ b/dev-docs/modules/userid-submodules/imuid.md
@@ -41,4 +41,4 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/intentiq.md
+++ b/dev-docs/modules/userid-submodules/intentiq.md
@@ -67,7 +67,7 @@ pbjs.setConfig({
     syncDelay: 3000,
   },
 });
-{% endhighlight %}
+```
 
 {% highlight javascript %}
 pbjs.setConfig({
@@ -90,4 +90,4 @@ pbjs.setConfig({
         syncDelay: 3000
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/just.md
+++ b/dev-docs/modules/userid-submodules/just.md
@@ -44,7 +44,7 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```
 
 ex. 2. Mode `BASIC`
 
@@ -56,7 +56,7 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```
 
 ## Just ID  Disclosure
 

--- a/dev-docs/modules/userid-submodules/liveintent.md
+++ b/dev-docs/modules/userid-submodules/liveintent.md
@@ -65,7 +65,7 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```
 
 ### Multiple user ids
 
@@ -88,7 +88,7 @@ For example, in case 'uid2' is configured to be requested - additionally to the 
     ...
 }
 ```
-{% endhighlight %}
+```
 
 Note that 'uid2' is exposed as part of 'lipb' as well as separately as 'uid2'. 'medianet' and 'bidswitch' behave the same way.
 
@@ -110,7 +110,7 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```
 
 ## LiveIntent ID configuration
 

--- a/dev-docs/modules/userid-submodules/lotame.md
+++ b/dev-docs/modules/userid-submodules/lotame.md
@@ -45,7 +45,7 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```
 
 {: .alert.alert-info :}
 NOTE: For optimal performance, the Lotame Panorama Id module should be called at every opportunity. It is best not to use params.storage with this module as the module has its own optimal caching mechanism.

--- a/dev-docs/modules/userid-submodules/merkle.md
+++ b/dev-docs/modules/userid-submodules/merkle.md
@@ -29,4 +29,4 @@ pbjs.setConfig({
       }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/navegg.md
+++ b/dev-docs/modules/userid-submodules/navegg.md
@@ -19,4 +19,4 @@ pbjs.setConfig({
       }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/netid.md
+++ b/dev-docs/modules/userid-submodules/netid.md
@@ -25,4 +25,4 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/novatiq.md
+++ b/dev-docs/modules/userid-submodules/novatiq.md
@@ -36,7 +36,7 @@ pbjs.setConfig({
     auctionDelay: 1000
   }
 });
-{% endhighlight %}
+```
 
 ## Parameters for the Novatiq Module
 
@@ -95,7 +95,7 @@ pbjs.setConfig({
     auctionDelay: 1000
   }
 });
-{% endhighlight %}
+```
 
 
 If you have any questions, please reach out to us at [prebid@novatiq.com](mailto:prebid@novatiq.com)

--- a/dev-docs/modules/userid-submodules/onekey.md
+++ b/dev-docs/modules/userid-submodules/onekey.md
@@ -47,4 +47,4 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/pair.md
+++ b/dev-docs/modules/userid-submodules/pair.md
@@ -39,7 +39,7 @@ pbjs.setConfig({
       }]
     }
 });
-{% endhighlight %}
+```
 
 Or if to use cleanrooms provided implementation, it can be specified by adding the provider and their configs to the config, take liveramp as an example.
 
@@ -59,7 +59,7 @@ pbjs.setConfig({
       }]
     }
 });
-{% endhighlight %}
+```
 
 
 

--- a/dev-docs/modules/userid-submodules/parrable.md
+++ b/dev-docs/modules/userid-submodules/parrable.md
@@ -74,4 +74,4 @@ pbjs.setConfig({
         syncDelay: 1000
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/quantcast.md
+++ b/dev-docs/modules/userid-submodules/quantcast.md
@@ -42,4 +42,4 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/ramp.md
+++ b/dev-docs/modules/userid-submodules/ramp.md
@@ -60,7 +60,7 @@ pbjs.setConfig({
         syncDelay: 3000                 // 3 seconds after the first auction
     }
 });
-{% endhighlight %}
+```
 
 2) Publisher passes a Placement ID and elects to store the RampID envelope in HTML5 localStorage.
 
@@ -83,4 +83,4 @@ pbjs.setConfig({
         syncDelay: 3000                 // 3 seconds after the first auction
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/sharedid.md
+++ b/dev-docs/modules/userid-submodules/sharedid.md
@@ -50,7 +50,7 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```
 
 2) Publisher supports both UnifiedID and SharedID and first party domain cookie storage
 
@@ -81,7 +81,7 @@ pbjs.setConfig({
         syncDelay: 5000       // 5 seconds after the first bidRequest()
     }
 });
-{% endhighlight %}
+```
 
 3) Publisher supports SharedID and first party domain cookie storage initiated by a first party server
 
@@ -101,4 +101,4 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/tapad.md
+++ b/dev-docs/modules/userid-submodules/tapad.md
@@ -47,4 +47,4 @@ pbjs.setConfig({
       ]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/unified.md
+++ b/dev-docs/modules/userid-submodules/unified.md
@@ -58,7 +58,7 @@ pbjs.setConfig({
         syncDelay: 3000              // 3 seconds after the first auction
     }
 });
-{% endhighlight %}
+```
 
 2) Publisher supports UnifiedID with a vendor other than Trade Desk and HTML5 local storage.
 
@@ -79,7 +79,7 @@ pbjs.setConfig({
         syncDelay: 3000
     }
 });
-{% endhighlight %}
+```
 
 3) Publisher has integrated with UnifiedID on their own and wants to pass the UnifiedID directly through to Prebid.js.
 
@@ -92,4 +92,4 @@ pbjs.setConfig({
         }]
     }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/userid-submodules/unified2.md
+++ b/dev-docs/modules/userid-submodules/unified2.md
@@ -82,7 +82,7 @@ pbjs.setConfig({
     }]
   }
 });
-{% endhighlight %}
+```
 
 In the following example, the publisher has retrieved a server-generated UID2 response, and it is currently stored in the JavaScript variable `uid2Identity`:
 
@@ -97,4 +97,4 @@ pbjs.setConfig({
     }]
   }
 });
-{% endhighlight %}
+```

--- a/dev-docs/modules/viewability.md
+++ b/dev-docs/modules/viewability.md
@@ -94,7 +94,7 @@ When a tracker needs to be stopped without direct access to Prebid.js, postMessa
 ## Examples
 
 ### Starting a viewability measurement when you have direct access to Prebid.js
-{% highlight js %}
+```javascript
 
     pbjs.viewability.startMeasurement(
         'test-div-1', 
@@ -103,10 +103,10 @@ When a tracker needs to be stopped without direct access to Prebid.js, postMessa
         { inViewThreshold: 0.5, timeInView: 1000 }
     );
 
-{% endhighlight %}
+```
 
 ### Starting a viewability measurement from within a rendered creative
-{% highlight js %}
+```javascript
 
     let viewabilityRecord = {
       vid: 'ae0f9',
@@ -118,17 +118,17 @@ When a tracker needs to be stopped without direct access to Prebid.js, postMessa
 
     window.parent.postMessage(JSON.stringify(viewabilityRecord), '*');
 
-{% endhighlight %}
+```
 
 ### Stopping the viewability measurement when you have direct access to Prebid.js
-{% highlight js %}
+```javascript
 
     pbjs.viewability.stopMeasurement('test-div-1');
 
-{% endhighlight %}
+```
 
 ### Stopping the viewability measurement from within a rendered creative
-{% highlight js %}
+```javascript
 
     let viewabilityRecord = {
       vid: 'ae0f9',
@@ -138,7 +138,7 @@ When a tracker needs to be stopped without direct access to Prebid.js, postMessa
 
     window.parent.postMessage(JSON.stringify(viewabilityRecord), '*');
 
-{% endhighlight %}
+```
 
 ## Related Reading
 - Alternate module: [Bid Viewability - Ad Server Independent](/dev-docs/modules/bidViewableIO.html)

--- a/dev-docs/publisher-api-reference.md
+++ b/dev-docs/publisher-api-reference.md
@@ -17,6 +17,7 @@ This page has documentation for the public API methods of Prebid.js.
 {% assign api_pages = site.pages | where: "layout", "api_prebidjs" %}
 
 ### Find a method
+
 <input type="text" id="autocomplete-filter" class="autocomplete-filter">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/awesomplete/1.1.5/awesomplete.min.js" integrity="sha512-HcBl0GSJvt4Qecm4srHapirUx0HJDi2zYXm6KUKNNUGdTIN9cBwakVZHWmRVj4MKgy1AChqhWGYcMDbRKgO0zg==" crossorigin="anonymous"></script>
 <script>
@@ -25,9 +26,9 @@ var AutocompleteList = [{% for page in api_pages %}{ label: '{{ page.title }}', 
 <script src="{{site.baseurl}}/assets/js/autocomplete.js"></script>
 
 <a name="module_pbjs"></a>
+
 ## pbjs
+
 {% for page in api_pages %}
 <li><a href="/{{ page.path | replace: '.md', '.html'}}">{{page.title}}</a></li>
 {% endfor %}
-
-

--- a/dev-docs/publisher-api-reference/aliasBidder.md
+++ b/dev-docs/publisher-api-reference/aliasBidder.md
@@ -8,11 +8,11 @@ sidebarType: 1
 
 To define an alias for a bidder adapter, call this method at runtime:
 
-{% highlight js %}
+```javascript
 
 pbjs.aliasBidder('appnexus', 'newAlias', optionsObject );
 
-{% endhighlight %}
+```
 
 Defining an alias can help avoid user confusion since it's possible to send parameters to the same adapter but in different contexts (e.g, The publisher uses `"appnexus"` for demand and also uses `"newAlias"` which is an SSP partner that uses the `"appnexus"` adapter to serve their own unique demand).
 

--- a/dev-docs/publisher-api-reference/aliasRegistry.md
+++ b/dev-docs/publisher-api-reference/aliasRegistry.md
@@ -8,11 +8,11 @@ sidebarType: 1
 
 Exposes the aliasRegistry. It can be used to fetch the entire aliasRegistry object or an individual adapter code by alias name.
 
-{% highlight js %}
+```javascript
 
 pbjs.aliasRegistry; or pbjs.aliasRegistry[aliasName];
 
-{% endhighlight %}
+```
 
 {: .alert.alert-warning :}
 Note that by default, the alias registry will be made public.  If you would like the registry to be private, you can utilize the `setConfig` option below:

--- a/dev-docs/publisher-api-reference/bidderSettings.md
+++ b/dev-docs/publisher-api-reference/bidderSettings.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.bidderSettings
-description:
+description: bidderSettings API
 sidebarType: 1
 ---
 
@@ -11,8 +11,7 @@ sidebarType: 1
 The bidderSettings object provides a way to define some behaviors for the
 platform and specific adapters. The basic structure is a 'standard' section with defaults for all adapters, and then one or more adapter-specific sections that override behavior for that bidder:
 
-{% highlight js %}
-
+```javascript
 pbjs.bidderSettings = {
     standard: {
          [...]
@@ -24,8 +23,7 @@ pbjs.bidderSettings = {
         [...]
     },
 }
-
-{% endhighlight %}
+```
 
 Defining bidderSettings is optional; the platform has default values for all of the options.
 Adapters may specify their own default settings, though this isn't common.
@@ -72,12 +70,11 @@ The key value pair targeting is applied to the bid's corresponding ad unit. Your
 If you'd like to customize the key value pairs, you can overwrite the settings as the below example shows. *Note* that once you updated the settings, let your ad ops team know about the change, so they can update the line item targeting accordingly. See the [Ad Ops](/adops/before-you-start.html) documentation for more information.
 
 <a name="bidderSettingsDefault"></a>
-<a name="default-keywords">
+<a name="default-keywords"></a>
 
 There's no need to include the following code if you choose to use the *below default setting*.
 
-{% highlight js %}
-
+```javascript
 pbjs.bidderSettings = {
     standard: {
         adserverTargeting: [{
@@ -113,8 +110,7 @@ pbjs.bidderSettings = {
         }]
     }
 }
-
-{% endhighlight %}
+```
 
 {: .alert.alert-warning :}
 Note that the existence of `bidderSettings.adserverTargeting.standard` will prevent the system from adding the standard display targeting values: hb_bidder, hb_adid, hb_pb, hb_size, and hb_format. However, if the mediaType is video and `bidderSettings.adserverTargeting.standard` does not specify hb_uuid, hb_cache_id, or hb_cache_host, they will be added unless `bidderSettings.sendStandardTargeting` is set to false.
@@ -127,7 +123,7 @@ settings as the below example for AppNexus shows.
 
 *Note that the line item setup has to match the targeting change*
 
-{% highlight js %}
+```javascript
 pbjs.bidderSettings = {
     appnexus: {
       sendStandardTargeting: false,
@@ -146,8 +142,7 @@ pbjs.bidderSettings = {
       ]
     }
 }
-{% endhighlight %}
-
+```
 
 In other words, the above config sends 2 pairs of key/value strings targeting for every AppNexus bid and for every ad unit. The 1st pair would be `apn_pbMg` => the value of `bidResponse.pbMg`. The 2nd pair would be `apn_adId` => the value of `bidResponse.adId`. You can find the bidResponse object documentation [here](/troubleshooting/troubleshooting-guide.html#common-bid-response-parameters).
 
@@ -159,8 +154,7 @@ Now let's say you would like to define a bidder-specific price bucket function r
 
 *Note: this will only impact the price bucket sent to the ad server for targeting. It won't actually impact the cpm value used for ordering the bids.*
 
-{% highlight js %}
-
+```javascript
 pbjs.bidderSettings = {
     standard: {
         [...]
@@ -181,10 +175,10 @@ pbjs.bidderSettings = {
                 return "pb6"; // all bids $6 and above are assigned to price bucket 'pb6'
             }
         }]
-	[...]
+    // [...]
     }
 }
-{% endhighlight %}
+```
 
 ##### 2.2. bidCpmAdjustment
 
@@ -194,13 +188,12 @@ In this case, the publisher may want to adjust the bidder's returned price to ru
 header bidding auction. Otherwise, this bidder's gross price will unfairly win over your
 other demand sources who report the real price.
 
-Custom adjustment can be provided as a function taking 3 arguments: `bidCpmAdjustment(cpm, bidResponse, bidRequest)`. 
-Note that either `bidResponse` or `bidRequest` may be missing, although at least one of them is guaranteed to be present. This is because Prebid will sometimes need to run adjustment when no bid has been made yet; see [inverseCpmAdjustment](#inverseCpmAdjustment) below. 
+Custom adjustment can be provided as a function taking 3 arguments: `bidCpmAdjustment(cpm, bidResponse, bidRequest)`.
+Note that either `bidResponse` or `bidRequest` may be missing, although at least one of them is guaranteed to be present. This is because Prebid will sometimes need to run adjustment when no bid has been made yet; see [inverseCpmAdjustment](#inverseCpmAdjustment) below.
 
 For example:
 
-{% highlight js %}
-
+```javascript
 pbjs.bidderSettings = {
   standard: { ... }
   aol: {
@@ -211,20 +204,18 @@ pbjs.bidderSettings = {
     }
   }
 };
-
-{% endhighlight %}
+```
 
 In the above example, the AOL bidder will inherit from "standard" adserverTargeting keys, so that you don't have to define the targeting keywords again.
 
 ##### 2.3. inverseCpmAdjustment
 
-When using [price floors](/dev-docs/modules/floors.html), Prebid attempts to calculate the inverse of `bidCpmAdjustment`, so that the floor values it requests from SSPs take into account how the bid will be adjusted. 
+When using [price floors](/dev-docs/modules/floors.html), Prebid attempts to calculate the inverse of `bidCpmAdjustment`, so that the floor values it requests from SSPs take into account how the bid will be adjusted.
 For example, if the adjustment is `bidCpm * .85` as above, floors are adjusted by `bidFloor * 1 / .85`.
 
 The automatically derived inverse function is correct only when `bidCpmAdjustment` is a simple multiplication. If it isn't, the inverse should also be provided through `inverseCpmAdjustment`. For example:
 
-{% highlight js %}
-
+```javascript
 pbjs.bidderSettings = {
     aol: {
         bidCpmAdjustment : function(cpm) {
@@ -234,12 +225,8 @@ pbjs.bidderSettings = {
           return Math.max(0.2, (cpm / .85) + 0.2)
         }
     }
-}
 };
-
-{% endhighlight %}
-
-
+```
 
 ##### 2.4. sendStandardTargeting
 
@@ -258,23 +245,24 @@ If a custom adServerTargeting function can return an empty value, this boolean f
 ##### 2.6. allowZeroCpmBids
 
 By default, 0 CPM bids are ignored by Prebid.js entirely.  However if there's a valid business reason to allow these bids, this setting can be enabled to allow
-either specific bid adapter(s) or all bid adapters the permission for these bids to be processed by Prebid.js and potentially sent to the respective ad server 
+either specific bid adapter(s) or all bid adapters the permission for these bids to be processed by Prebid.js and potentially sent to the respective ad server
 (depending on the Prebid.js auction results).
 
 ##### 2.7. storageAllowed
 
 This setting defines if the bid adapter can access browser cookies or local storage. Allowed values are:
 
- - an array containing either `'html5'`, `'cookie'` or both to allow specific storage methods (e.g. `['cookie']` enables cookies but not local storage)
- - `true` to allow any storage method;
- - `false` to disable all storage.
- 
+* an array containing either `'html5'`, `'cookie'` or both to allow specific storage methods (e.g. `['cookie']` enables cookies but not local storage)
+* `true` to allow any storage method;
+* `false` to disable all storage.
+
 <br />Default value is `true` in version 6.x
 <br />Default value is `false` in version 7.x
 
 Note that:
- - [Disabling device access](/dev-docs/publisher-api-reference/setConfig.html#setConfig-deviceAccess) will prevent access to storage regardless of this setting;  
- - `storageAllowed` will only affect bid adapters and not any other type of module (such as analytics or RTD).
+
+* [Disabling device access](/dev-docs/publisher-api-reference/setConfig.html#setConfig-deviceAccess) will prevent access to storage regardless of this setting;  
+* `storageAllowed` will only affect bid adapters and not any other type of module (such as analytics or RTD).
 
 <a id="allowAlternateBidderCodes" />
 
@@ -284,12 +272,11 @@ If this flag is set to `true`, bidders that have not been explicitly requested i
 <br />Default value is `true` in version 6.x
 <br />Default value will be `false` from version 7.0
 
-
 ##### 2.9. allowedAlternateBidderCodes
 
 This array will work in conjunction with `allowAlternateBidderCodes`. In this array, you can specify the names of the bidder for which an adapter can accept the bid. If the value is not specified for the array or `[‘*’]` is specified, Prebid will accept bids of all the bidders for the given adapter.
 
-{% highlight js %}
+```javascript
 
 pbjs.bidderSettings = {
     standard: {
@@ -313,7 +300,7 @@ pbjs.bidderSettings = {
         [...]
     }
 }
-{% endhighlight %}
+```
 
 In the above example, `groupm` bid will have a bid adjustment of 80% since the `bidCpmAdjustment` function says so.<br />
 If `appnexus` bids with another bidder code, say `appnexus2`. This bidder code will adjust the bid cpm to 95% because it will apply the `bidCpmAdjustment` function from `standard` setting, since the `bidCpmAdjustment` is missing for given bidder code I.e `appnexus2`
@@ -326,7 +313,7 @@ Optionally allow alternate bidder codes originating from a specific bid adapter 
 2. Adapter bidCpmAdjustment function
 3. The standard bidCpmAdjustment function
 
-{% highlight js %}
+```javascript
 
 pbjs.bidderSettings = {
     standard: {
@@ -348,7 +335,7 @@ pbjs.bidderSettings = {
         [...]
     }
 }
-{% endhighlight %}
+```
 
 In the above example, if PubMatic were to return the "groupm" bidder code then the bidCpmAdjustment function under `pubmatic` would be used instead of what is available under `standard`.
 

--- a/dev-docs/publisher-api-reference/enableAnalytics.md
+++ b/dev-docs/publisher-api-reference/enableAnalytics.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.enableAnalytics(config)
-description: 
+description: enableAnalytics API
 sidebarType: 1
 ---
 
@@ -10,7 +10,7 @@ Enables sending event data to the analytics provider of your choice. For a list 
 
 ### Example
 
-```
+```javascript
 pbjs.enableAnalytics([{
     provider: "analyticsA",    
     options: {
@@ -31,16 +31,13 @@ pbjs.enableAnalytics([{
 | `includeEvents` | Optional | Array of strings | Event whitelist; if provided, only these events will be forwarded to the adapter |
 | `excludeEvents` | Optional | Array of strings | Event blacklist; if provided, these events will not be forwarded to the adapter |
 
-
 Note each analytics adapter has its own invocation parameters. Analytics adapters that are built in the standard way should
 support a `option.sampling` parameter. You'll need to check with your analytics provider to confirm
 whether their system recommends the use of this parameter. They may have alternate methods of sampling.
 
-
 ### See also
 
-- [Prebid.js events](/dev-docs/publisher-api-reference/getEvents.html)
-- [How to Add an Analytics Adapter](/dev-docs/integrate-with-the-prebid-analytics-api.html).
-
+* [Prebid.js events](/dev-docs/publisher-api-reference/getEvents.html)
+* [How to Add an Analytics Adapter](/dev-docs/integrate-with-the-prebid-analytics-api.html).
 
 <hr class="full-rule" />

--- a/dev-docs/publisher-api-reference/getAdserverTargeting.md
+++ b/dev-docs/publisher-api-reference/getAdserverTargeting.md
@@ -1,12 +1,11 @@
 ---
 layout: api_prebidjs
 title: pbjs.getAdserverTargeting()
-description:
+description: getAdserverTargeting API
 sidebarType: 1
 ---
 
 <a name="module_pbjs.getAdserverTargeting"></a>
-
 
 Returns all ad server targeting for all ad units. Note that some bidder's response may not have been received if you call this function too quickly after the requests are sent.
 
@@ -20,7 +19,7 @@ When [deals are enabled]({{site.baseurl}}/adops/deals.html), the object returned
 
 **Returned Object Example:**
 
-{% highlight js %}
+```javascript
 {
   "/9968336/header-bid-tag-0": {
     "hb_bidder": "rubicon",
@@ -39,4 +38,4 @@ When [deals are enabled]({{site.baseurl}}/adops/deals.html), the object returned
     "hb_deal_appnexus": "ABC_123"
   }
 }
-{% endhighlight %}
+```

--- a/dev-docs/publisher-api-reference/getAdserverTargetingForAdUnitCode.md
+++ b/dev-docs/publisher-api-reference/getAdserverTargetingForAdUnitCode.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.getAdserverTargetingForAdUnitCode([adunitCode])
-description:
+description: getAdserverTargetingForAdUnitCode API
 sidebarType: 1
 ---
 
@@ -21,10 +21,10 @@ This function returns the query string targeting parameters available at this mo
 
 **Returned Object Example:**
 
-{% highlight js %}
+```javascript
 {
   "hb_bidder": "rubicon",
   "hb_adid": "13f44b0d3c",
   "hb_pb": "0.50"
 }
-{% endhighlight %}
+```

--- a/dev-docs/publisher-api-reference/getAllPrebidWinningBids.md
+++ b/dev-docs/publisher-api-reference/getAllPrebidWinningBids.md
@@ -1,11 +1,11 @@
 ---
 layout: api_prebidjs
 title: pbjs.getAllPrebidWinningBids()
-description: 
+description: getAllPrebidWinningBids API
 sidebarType: 1
 ---
 
 
 Use this method to get all of the bids that have won their respective auctions but not rendered on the page.  Useful for [troubleshooting your integration]({{site.baseurl}}/dev-docs/prebid-troubleshooting-guide.html).
 
-+ `pbjs.getAllPrebidWinningBids()`: returns an array of bid objects that have won their respective auctions but not rendered on the page.
+* `pbjs.getAllPrebidWinningBids()`: returns an array of bid objects that have won their respective auctions but not rendered on the page.

--- a/dev-docs/publisher-api-reference/getAllWinningBids.md
+++ b/dev-docs/publisher-api-reference/getAllWinningBids.md
@@ -1,11 +1,11 @@
 ---
 layout: api_prebidjs
 title: pbjs.getAllWinningBids()
-description: 
+description: getAllWinningBids API
 sidebarType: 1
 ---
 
 
 Use this method to get all of the bids that have won their respective auctions and also rendered on the page.  Useful for [troubleshooting your integration]({{site.baseurl}}/dev-docs/prebid-troubleshooting-guide.html).
 
-+ `pbjs.getAllWinningBids()`: returns an array of bid objects that have won their respective auctions and also rendered on the page.
+* `pbjs.getAllWinningBids()`: returns an array of bid objects that have won their respective auctions and also rendered on the page.

--- a/dev-docs/publisher-api-reference/getBidResponses.md
+++ b/dev-docs/publisher-api-reference/getBidResponses.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.getBidResponses()
-description:
+description: getBidResponses API
 sidebarType: 1
 ---
 
@@ -47,14 +47,12 @@ This function returns the bid responses at the given moment.
         <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
           > Response Object Example
         </a>
-
       </h4>
     </div>
     <div id="collapseThree" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingThree">
       <div class="panel-body" markdown="1">
 
-
-{% highlight bash %}
+```json
 {
   "/9968336/header-bid-tag-0": {
     "bids": [
@@ -168,7 +166,8 @@ This function returns the bid responses at the given moment.
     ]
   }
 }
-{% endhighlight %}
+```
+
 </div>
 </div>
 </div>
@@ -182,84 +181,83 @@ This function returns the bid responses at the given moment.
         <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion2" href="#response-example-2" aria-expanded="false" aria-controls="response-example-2">
           > Response Object Example - Native
         </a>
-
       </h4>
     </div>
     <div id="response-example-2" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-response-example-2">
       <div class="panel-body" markdown="1">
 
-{% highlight bash %}
+```json
 {
-           "div-banner-outstream-native" : {
-              "bids" : [
-                 {
-                    "pbMg" : "10.00",
-                    "pbLg" : "5.00",
-                    "width" : 0,
-                    "requestTimestamp" : 1516315716062,
-                    "creativeId" : 81589325,
-                    "pbCg" : "",
-                    "adUnitCode" : "div-banner-outstream-native",
-                    "size" : "0x0",
-                    "bidder" : "appnexus",
-                    "pbAg" : "10.00",
-                    "adId" : "473965c9df19d2",
-                    "adserverTargeting" : {
-                       "hb_native_icon" : "https://vcdn.adnxs.com/p/creative-image/d4/06/e2/33/d406e233-a5f9-44a6-a3e0-8a714bf0e980.png",
-                       "hb_native_title" : "This is a Prebid Native Multi-Format Creative",
-                       "hb_native_brand" : "Prebid.org",
-                       "hb_adid" : "473965c9df19d2",
-                       "hb_pb" : "10.00",
-                       "hb_source" : "client",
-                       "hb_bidder" : "appnexus",
-                       "hb_native_image" : "https://vcdn.adnxs.com/p/creative-image/9e/26/5f/b2/9e265fb2-50c8-43f0-88ef-a5a48a9d0dcf.jpg",
-                       "hb_size" : "0x0",
-                       "hb_mediatype" : "native",
-                       "hb_native_body" : "This is a Prebid Native Creative. There are many like it, but this one is mine.",
-                       "hb_native_linkurl" : "https://prebid.org/dev-docs/show-native-ads.html"
-                    },
-                    "native" : {
-                       "icon" : {
-                          "url" : "https://vcdn.adnxs.com/p/creative-image/d4/06/e2/33/d406e233-a5f9-44a6-a3e0-8a714bf0e980.png",
-                          "height" : 75,
-                          "width" : 75
-                       },
-                       "body" : "This is a Prebid Native Creative. There are many like it, but this one is mine.",
-                       "image" : {
-                          "url" : "https://vcdn.adnxs.com/p/creative-image/9e/26/5f/b2/9e265fb2-50c8-43f0-88ef-a5a48a9d0dcf.jpg",
-                          "height" : 2250,
-                          "width" : 3000
-                       },
-                       "clickUrl" : "https://prebid.org/dev-docs/show-native-ads.html",
-                       "clickTrackers" : [
-                          "..."
-                       ],
-                       "title" : "This is a Prebid Native Multi-Format Creative",
-                       "impressionTrackers" : [
-                          "..."
-                       ],
-                       "sponsoredBy" : "Prebid.org"
-                    },
-                    "timeToRespond" : 143,
-                    "mediaType" : "native",
-                    "bidderCode" : "appnexus",
-                    "source" : "client",
-                    "auctionId" : "1338a6fb-e514-48fc-8db6-872ddf3babdb",
-                    "responseTimestamp" : 1516315716205,
-                    "netRevenue" : true,
-                    "pbDg" : "10.00",
-                    "pbHg" : "10.00",
-                    "ttl" : 300,
-                    "status" : "targetingSet",
-                    "height" : 0,
-                    "statusMessage" : "Bid available",
-                    "cpm" : 10,
-                    "currency" : "USD"
-                 }
-              ]
-           }
-        }
-{% endhighlight %}
+    "div-banner-outstream-native" : {
+      "bids" : [
+          {
+            "pbMg" : "10.00",
+            "pbLg" : "5.00",
+            "width" : 0,
+            "requestTimestamp" : 1516315716062,
+            "creativeId" : 81589325,
+            "pbCg" : "",
+            "adUnitCode" : "div-banner-outstream-native",
+            "size" : "0x0",
+            "bidder" : "appnexus",
+            "pbAg" : "10.00",
+            "adId" : "473965c9df19d2",
+            "adserverTargeting" : {
+                "hb_native_icon" : "https://vcdn.adnxs.com/p/creative-image/d4/06/e2/33/d406e233-a5f9-44a6-a3e0-8a714bf0e980.png",
+                "hb_native_title" : "This is a Prebid Native Multi-Format Creative",
+                "hb_native_brand" : "Prebid.org",
+                "hb_adid" : "473965c9df19d2",
+                "hb_pb" : "10.00",
+                "hb_source" : "client",
+                "hb_bidder" : "appnexus",
+                "hb_native_image" : "https://vcdn.adnxs.com/p/creative-image/9e/26/5f/b2/9e265fb2-50c8-43f0-88ef-a5a48a9d0dcf.jpg",
+                "hb_size" : "0x0",
+                "hb_mediatype" : "native",
+                "hb_native_body" : "This is a Prebid Native Creative. There are many like it, but this one is mine.",
+                "hb_native_linkurl" : "https://prebid.org/dev-docs/show-native-ads.html"
+            },
+            "native" : {
+                "icon" : {
+                  "url" : "https://vcdn.adnxs.com/p/creative-image/d4/06/e2/33/d406e233-a5f9-44a6-a3e0-8a714bf0e980.png",
+                  "height" : 75,
+                  "width" : 75
+                },
+                "body" : "This is a Prebid Native Creative. There are many like it, but this one is mine.",
+                "image" : {
+                  "url" : "https://vcdn.adnxs.com/p/creative-image/9e/26/5f/b2/9e265fb2-50c8-43f0-88ef-a5a48a9d0dcf.jpg",
+                  "height" : 2250,
+                  "width" : 3000
+                },
+                "clickUrl" : "https://prebid.org/dev-docs/show-native-ads.html",
+                "clickTrackers" : [
+                  "..."
+                ],
+                "title" : "This is a Prebid Native Multi-Format Creative",
+                "impressionTrackers" : [
+                  "..."
+                ],
+                "sponsoredBy" : "Prebid.org"
+            },
+            "timeToRespond" : 143,
+            "mediaType" : "native",
+            "bidderCode" : "appnexus",
+            "source" : "client",
+            "auctionId" : "1338a6fb-e514-48fc-8db6-872ddf3babdb",
+            "responseTimestamp" : 1516315716205,
+            "netRevenue" : true,
+            "pbDg" : "10.00",
+            "pbHg" : "10.00",
+            "ttl" : 300,
+            "status" : "targetingSet",
+            "height" : 0,
+            "statusMessage" : "Bid available",
+            "cpm" : 10,
+            "currency" : "USD"
+          }
+      ]
+    }
+}
+```
 
 </div>
 </div>

--- a/dev-docs/publisher-api-reference/getBidResponsesForAdUnitCode.md
+++ b/dev-docs/publisher-api-reference/getBidResponsesForAdUnitCode.md
@@ -1,12 +1,11 @@
 ---
 layout: api_prebidjs
 title: pbjs.getBidResponsesForAdUnitCode(adUnitCode)
-description:
+description: getBidResponsesForAdUnitCode API
 sidebarType: 1
 ---
 
-
-Returns bidResponses for the specified adUnitCode. See full documentation at [pbjs.getBidResponses()](#module_pbjs.getBidResponses).
+Returns bidResponses for the specified adUnitCode. See full documentation at [pbjs.getBidResponses()](module_pbjs.getBidResponses).
 
 **Kind**: static method of `pbjs`
 

--- a/dev-docs/publisher-api-reference/getConfig.md
+++ b/dev-docs/publisher-api-reference/getConfig.md
@@ -1,29 +1,27 @@
 ---
 layout: api_prebidjs
 title: pbjs.getConfig([string])
-description: 
+description: getConfig API
 sidebarType: 1
 ---
 
 ## Overview
 
-The `getConfig` function is used for retrieving the current configuration object or subscribing to configuration updates. When called with no parameters, the entire config object is returned. When called with a string parameter, a single configuration property matching that parameter is returned. Be careful with use of this function, as it returns a reference to the configuration instead of a clone. The readConfig function has been introduced for safer use. 
+The `getConfig` function is used for retrieving the current configuration object or subscribing to configuration updates. When called with no parameters, the entire config object is returned. When called with a string parameter, a single configuration property matching that parameter is returned. Be careful with use of this function, as it returns a reference to the configuration instead of a clone. The readConfig function has been introduced for safer use.
 
-{% highlight js %}
+```javascript
 /* Get config object */
 config.getConfig()
 
 /* Get debug config */
 config.getConfig('debug')
-{% endhighlight %}
-
+```
 
 ### Subscribe
 
 The `getConfig` function contains a `subscribe` feature that adds a callback function to a set of listeners that are invoked whenever `setConfig` is called. The `subscribed` function will be passed the `options` object that was used in the `setConfig` call. Individual topics can be subscribed to by passing a string as the first parameter and a callback function as the second.  For example:
 
-{% highlight js %}
-
+```javascript
 /* Subscribe to all configuration changes */
 getConfig((config) => console.log('config set:', config));
 
@@ -33,7 +31,6 @@ getConfig('logging', (config) => console.log('logging set:', config));
 /* Unsubscribe */
 const unsubscribe = getConfig(...);
 unsubscribe(); // no longer listening
-
-{% endhighlight %}
+```
 
 <hr class="full-rule" />

--- a/dev-docs/publisher-api-reference/getConsentMetadata.md
+++ b/dev-docs/publisher-api-reference/getConsentMetadata.md
@@ -1,14 +1,13 @@
 ---
 layout: api_prebidjs
 title: pbjs.getConsentMetadata()
-description: 
+description: getConsentMetadata API
 sidebarType: 1
 ---
 
-
 The `getConsentMetadata()` function will return basic information about the status of supported (and configured!) consent content within Prebid.
 
-```
+```javascript
 pbjs.getConsentMetadata() // returns e.g.
 {
     "coppa": false,

--- a/dev-docs/publisher-api-reference/getEvents.md
+++ b/dev-docs/publisher-api-reference/getEvents.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.getEvents()
-description: 
+description: getEvents API
 sidebarType: 1
 ---
 
@@ -14,10 +14,11 @@ The `getEvents` method returns a copy of all emitted events since the page loade
 **Returns**: `array of objects`
 
 **Returned Object Params**:
-- eventType (see table below)
-- args (varies for each event type)
-- id (only for bidWon, set to adUnit.code)
-- elapsedTime
+
+* eventType (see table below)
+* args (varies for each event type)
+* id (only for bidWon, set to adUnit.code)
+* elapsedTime
 
 The available events are:
 
@@ -47,13 +48,13 @@ The available events are:
 
 The example below shows how these events can be used.
 
-{% highlight js %}
-      pbjs.getEvents().forEach(event => {
-        console.log("event: "+event.eventType)
-      });
-{% endhighlight %}
-
+```javascript
+pbjs.getEvents().forEach(event => {
+  console.log("event: "+event.eventType)
+});
+```
 
 ## See Also
-- [onEvent](/dev-docs/publisher-api-reference/onEvent.html)
-- [offEvent](/dev-docs/publisher-api-reference/offEvent.html)
+
+* [onEvent](/dev-docs/publisher-api-reference/onEvent.html)
+* [offEvent](/dev-docs/publisher-api-reference/offEvent.html)

--- a/dev-docs/publisher-api-reference/getHighestCpmBids.md
+++ b/dev-docs/publisher-api-reference/getHighestCpmBids.md
@@ -1,15 +1,15 @@
 ---
 layout: api_prebidjs
 title: pbjs.getHighestCpmBids([adUnitCode])
-description: 
+description: getHighestCpmBids API
 sidebarType: 1
 ---
 
 
 Use this method to retrieve an array of winning bids.
 
-+ `pbjs.getHighestCpmBids()`: with no argument, returns an array of winning bid objects for each ad unit on page
-+ `pbjs.getHighestCpmBids(adUnitCode)`: when passed an ad unit code, returns an array with the winning bid object for that ad unit
+* `pbjs.getHighestCpmBids()`: with no argument, returns an array of winning bid objects for each ad unit on page
+* `pbjs.getHighestCpmBids(adUnitCode)`: when passed an ad unit code, returns an array with the winning bid object for that ad unit
 
 {: .alert.alert-warning :}
 Note that from **Prebid 3.0** onwards, `pbjs.getHighestCpmBids` will not return rendered bids.

--- a/dev-docs/publisher-api-reference/getHighestUnusedBidResponseForAdUnitCode.md
+++ b/dev-docs/publisher-api-reference/getHighestUnusedBidResponseForAdUnitCode.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.getHighestUnusedBidResponseForAdUnitCode(adUnitCode)
-description:
+description: getHighestUnusedBidResponseForAdUnitCode API
 sidebarType: 1
 ---
 

--- a/dev-docs/publisher-api-reference/getNoBids.md
+++ b/dev-docs/publisher-api-reference/getNoBids.md
@@ -1,11 +1,11 @@
 ---
 layout: api_prebidjs
 title: pbjs.getNoBids()
-description: 
+description: getNoBids API
 sidebarType: 1
 ---
 
 
 Use this method to get all of the bid requests that resulted in a NO_BID.  These are bid requests that were sent to a bidder but, for whatever reason, the bidder decided not to bid on.  Used by debugging snippet in the [Troubleshooting Guide](/troubleshooting/troubleshooting-guide.html).
 
-+ `pbjs.getNoBids()`: returns an array of bid request objects that were deliberately not bid on by a bidder.
+* `pbjs.getNoBids()`: returns an array of bid request objects that were deliberately not bid on by a bidder.

--- a/dev-docs/publisher-api-reference/getNoBidsForAdUnitCode.md
+++ b/dev-docs/publisher-api-reference/getNoBidsForAdUnitCode.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.getNoBidsForAdUnitCode(adUnitCode)
-description:
+description: getNoBidsForAdUnitCode API
 sidebarType: 1
 ---
 

--- a/dev-docs/publisher-api-reference/getUserIds.md
+++ b/dev-docs/publisher-api-reference/getUserIds.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.getUserIds()
-description: 
+description: getUserIds API
 sidebarType: 1
 ---
 
@@ -11,6 +11,6 @@ To use this function, include the [UserId module](/dev-docs/modules/userId.html)
 
 If you need to export the user IDs stored by Prebid User ID module, the `getUserIds()` function will return an object formatted the same as bidRequest.userId.
 
-```
+```javascript
 pbjs.getUserIds() // returns object like bidRequest.userId. e.g. {"pubcid":"1111", "tdid":"2222"}
 ```

--- a/dev-docs/publisher-api-reference/getUserIdsAsEids.md
+++ b/dev-docs/publisher-api-reference/getUserIdsAsEids.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.getUserIdsAsEids()
-description: 
+description: getUserIdsAsEids API
 sidebarType: 1
 ---
 
@@ -11,7 +11,7 @@ To use this function, include the [UserId module](/dev-docs/modules/userId.html)
 
 If you need to export the user IDs stored by Prebid User ID module in ORTB Eids frormat, then the `getUserIdsAsEids()` function will return an array formatted as per [ORTB Eids](https://github.com/prebid/Prebid.js/blob/master/modules/userId/eids.md).
 
-```
+```javascript
 pbjs.getUserIdsAsEids() // returns userIds in ORTB Eids format. e.g.
 [
   {

--- a/dev-docs/publisher-api-reference/getUserIdsAsync.md
+++ b/dev-docs/publisher-api-reference/getUserIdsAsync.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.getUserIdsAsync()
-description: 
+description: getUserIdsAsync API
 sidebarType: 1
 ---
 
@@ -10,7 +10,7 @@ To use this function, include the [UserId module](/dev-docs/modules/userId.html)
 
 `getUserIdsAsync()` returns a promise to the same value returned by [getUserIds()](/dev-docs/publisher-api-reference/getUserIds.html), but it's guaranteed to resolve only once the complete set of IDs is available:
 
-```
+```javascript
 pbjs.getUserIdsAsync().then(function (userIds) {
    // all IDs are available here:
    pbjs.getUserIds()       // same as the `userIds` argument

--- a/dev-docs/publisher-api-reference/installedModules.md
+++ b/dev-docs/publisher-api-reference/installedModules.md
@@ -1,14 +1,15 @@
 ---
 layout: api_prebidjs
 title: pbjs.installedModules
-description: 
+description: installedModules API
 sidebarType: 1
 ---
 
 When a Prebid.js package is built, the list of modules compiled into it are placed in the pbjs.installedModules array.
 
 e.g. if this builds the package:
-```
+
+```bash
 gulp build --modules=a,b,c
 ```
 

--- a/dev-docs/publisher-api-reference/markWinningBidAsUsed.md
+++ b/dev-docs/publisher-api-reference/markWinningBidAsUsed.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.markWinningBidAsUsed(markBidRequest)
-description: 
+description: markWinningBidAsUsed API
 sidebarType: 1
 ---
 

--- a/dev-docs/publisher-api-reference/mergeBidderConfig.md
+++ b/dev-docs/publisher-api-reference/mergeBidderConfig.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.mergeBidderConfig(options)
-description:
+description: mergeBidderConfig API
 sidebarType: 1
 ---
 
@@ -9,13 +9,13 @@ This is the same as [`setBidderConfig(options, true)`](/dev-docs/publisher-api-r
 
 The page usage is:
 
-{% highlight js %}
+```javascript
 pbjs.mergeBidderConfig({
    bidders: ['bidderA'],
    config: {
       customArg: "customVal"
    }
 });
-{% endhighlight %}
+```
 
 Intrepration: When 'bidderA' calls `getConfig('customArg')`, it will receive the object that contains 'customArg'. If any other bidder calls `getConfig('customArg')`, it will receive nothing.

--- a/dev-docs/publisher-api-reference/mergeConfig.md
+++ b/dev-docs/publisher-api-reference/mergeConfig.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.mergeConfig(options)
-description:
+description: mergeConfig API
 sidebarType: 1
 ---
 

--- a/dev-docs/publisher-api-reference/offEvent.md
+++ b/dev-docs/publisher-api-reference/offEvent.md
@@ -24,7 +24,7 @@ events for a specific item in the event context.
 
 Example
 
-{% highlight js %}
+```javascript
         /* This handler will be called only for rightAdUnit */
         /* Uses the `pbjs.offEvent` method to remove the handler once it has been called */
         var bidWonHandler = function bidWonHandler() {
@@ -50,7 +50,7 @@ Example
             pbjs.onEvent('bidWon', bidWonHandler, rightAdUnit);
 
             ...
-{% endhighlight %}
+```
 
 ## See Also
 - [getEvents](/dev-docs/publisher-api-reference/getEvents.html)

--- a/dev-docs/publisher-api-reference/onEvent.md
+++ b/dev-docs/publisher-api-reference/onEvent.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.onEvent(eventType, handler, id)
-description: 
+description: onEvent API
 sidebarType: 1
 ---
 
@@ -31,39 +31,42 @@ this method registers the callback for every `bidWon` event.
 Currently, `bidWon` is the only event that accepts the `id` parameter.
 
 Example 1: Basic event logging
-```
-        /* Log when ad units are added to Prebid */
-        pbjs.onEvent('addAdUnits', function() {
-          console.log('Ad units were added to Prebid.')
-          console.log(pbjs.adUnits);
-        });
 
-        /* Log when Prebid wins the ad server auction */
-        pbjs.onEvent('bidWon', function(data) {
-          console.log(data.bidderCode+ ' won the ad server auction for ad unit ' +data.adUnitCode+ ' at ' +data.cpm+ ' CPM');
-        });
+```javascript
+/* Log when ad units are added to Prebid */
+pbjs.onEvent('addAdUnits', function() {
+  console.log('Ad units were added to Prebid.')
+  console.log(pbjs.adUnits);
+});
 
+/* Log when Prebid wins the ad server auction */
+pbjs.onEvent('bidWon', function(data) {
+  console.log(data.bidderCode+ ' won the ad server auction for ad unit ' +data.adUnitCode+ ' at ' +data.cpm+ ' CPM');
+});
 ```
 
 Example 2: Dynamically modify the auction
-```
-        var bidderFilter = function bidderFilter(adunits) {
-            // pub-specific logic to optimize bidders
-            // e.g. "remove any that haven't bid in the last 4 refreshes"
-        };
-        pbjs.onEvent('beforeRequestBids', bidderFilter);
+
+```javascript
+var bidderFilter = function bidderFilter(adunits) {
+    // pub-specific logic to optimize bidders
+    // e.g. "remove any that haven't bid in the last 4 refreshes"
+};
+pbjs.onEvent('beforeRequestBids', bidderFilter);
 ```
 
 Example 3: Log errors and render fails to your own endpoint
-```
-        pbjs.onEvent('adRenderFailed', function () {
-              // pub-specific logic to call their own endpoint
-            });
-        pbjs.onEvent('auctionDebug', function () {
-              // pub-specific logic to call their own endpoint
-            });
+
+```javascript
+pbjs.onEvent('adRenderFailed', function () {
+      // pub-specific logic to call their own endpoint
+    });
+pbjs.onEvent('auctionDebug', function () {
+      // pub-specific logic to call their own endpoint
+    });
 ```
 
 ## See Also
-- [getEvents](/dev-docs/publisher-api-reference/getEvents.html)
-- [offEvent](/dev-docs/publisher-api-reference/offEvent.html)
+
+* [getEvents](/dev-docs/publisher-api-reference/getEvents.html)
+* [offEvent](/dev-docs/publisher-api-reference/offEvent.html)

--- a/dev-docs/publisher-api-reference/readConfig.md
+++ b/dev-docs/publisher-api-reference/readConfig.md
@@ -8,12 +8,12 @@ sidebarType: 1
 
 The `readConfig` function is used for retrieving the current configuration object or subscribing to configuration updates. When called with no parameters, the entire config object is returned. When called with a string parameter, a single configuration property matching that parameter is returned.  The readConfig function has been introduced for safer use of the getConfig functionality, as it returns a clone. 
 
-{% highlight js %}
+```javascript
 /* Get config object */
 config.readConfig()
 
 /* Get debug config */
 config.readConfig('debug')
-{% endhighlight %}
+```
 
 <hr class="full-rule" />

--- a/dev-docs/publisher-api-reference/refreshUserIds.md
+++ b/dev-docs/publisher-api-reference/refreshUserIds.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.refreshUserIds(options, callback)
-description: 
+description: refreshUserIds API
 sidebarType: 1
 ---
 
@@ -18,8 +18,7 @@ The `refreshUserIds` function allows you to force either all or a subset of user
 | options.submoduleNames | optional | Array of strings | The userId submodule names that should be refreshed. If this option is omitted, all userId submodules are refreshed. |
 | callback | optional | Function | Callback that is called after refreshing user ids has completed |
 
-
-```
+```javascript
 pbjs.refreshUserIds();
 pbjs.refreshUserIds({ submoduleNames: ['britepoolId'] }, () => console.log("Done!"));
 ```

--- a/dev-docs/publisher-api-reference/removeAdUnit.md
+++ b/dev-docs/publisher-api-reference/removeAdUnit.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.removeAdUnit(adUnitCode)
-description:
+description: removeAdUnit API
 sidebarType: 1
 ---
 
@@ -9,7 +9,6 @@ sidebarType: 1
 Remove adUnit(s) from the pbjs configuration, If adUnit is not given then it will remove all adUnits
 
 **Kind**: static method of pbjs API.
-
 
 {: .table .table-bordered .table-striped }
 | Param | Scope | Type | Description |

--- a/dev-docs/publisher-api-reference/renderAd.md
+++ b/dev-docs/publisher-api-reference/renderAd.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.renderAd(doc, id, options)
-description:
+description: renderAd API
 sidebarType: 1
 ---
 
@@ -16,11 +16,11 @@ If this property is set the value of clickThrough will replace any occurrence of
 
 {: .alert.alert-info :}
 Note: In regards to `options.clickThrough`:
+
 - To make use of this feature, bid adapters would be required to respond with ad tags including the ${CLICKTHROUGH} macro.
 - The renderAd function must be invoked with the options argument. Ex: `renderAd(doc, bidId, {clickThrough: 'https://someadserverclickurl.com'});`
 - Not compatible with safeframes (since the logic around rendering safeframe's does not invoke the renderAd function).
 - Not supported with Prebid Universal Creative at this time, only the standard pbjs.renderAd method.
-
 
 {: .table .table-bordered .table-striped }
 | Param | Scope | Type | Description |

--- a/dev-docs/publisher-api-reference/requestBids.md
+++ b/dev-docs/publisher-api-reference/requestBids.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.requestBids(requestObj)
-description:
+description: requestBids API
 sidebarType: 1
 ---
 
@@ -22,13 +22,12 @@ Request bids. When `adUnits` or `adUnitCodes` are not specified, request bids fo
 | requestObj.adUnits | Optional | `Array of objects` | AdUnitObjects to request. Use this or `requestObj.adUnitCodes`. Default to all `adUnits` if empty. |
 | requestObj.timeout | Optional | `Integer` | Timeout for requesting the bids specified in milliseconds |
 | requestObj.bidsBackHandler | Optional | `function` | Callback to execute when all the bid responses are back or the timeout hits. Callback will be passed 3 arguments - `bids`, `timedOut`, and `auctionId` - [see below](#result) |
-| requestObj.labels | Optional | `Array of strings` | Defines [labels](#labels) that may be matched on ad unit targeting conditions. |
+| requestObj.labels | Optional | `Array of strings` | Defines `labels` that may be matched on ad unit targeting conditions. |
 | requestObj.auctionId | Optional | `String` | Defines an auction ID to be used rather than having the system generate one. This can be useful if there are multiple wrappers on a page and a single auction ID is desired to tie them together in analytics. |
 | requestObj.ortb2 | Optional | `Object` | Additional [first-party data](/features/firstPartyData.html) to use for this auction only |
 | requestObj.ttlBuffer | Optional | `Number` |  TTL buffer override for this auction. See [setConfig({ttlBuffer})](/dev-docs/publisher-api-reference/setConfig.html#setConfig-ttlBuffer) |
 
-
-<a id="result" />
+<a id="result"></a>
 
 **Result**:
 
@@ -41,7 +40,7 @@ Request bids. When `adUnits` or `adUnitCodes` are not specified, request bids fo
 
 Example call:
 
-```
+```javascript
 pbjs.requestBids({
     bidsBackHandler: sendAdserverRequest,
     timeout: 1000,
@@ -50,7 +49,8 @@ pbjs.requestBids({
 ```
 
 Example parameters sent to the bidsBackHandler:
-```
+
+```javascript
 function sendAdserverRequest(bids, timedOut, auctionId) {
     // bids
     // {"test-div":{"bids":[{"bidderCode":"bidderA", ...}]}}

--- a/dev-docs/publisher-api-reference/setBidderConfig.md
+++ b/dev-docs/publisher-api-reference/setBidderConfig.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.setBidderConfig(options, mergeFlag)
-description:
+description: setBidderConfig API
 sidebarType: 1
 ---
 
@@ -17,16 +17,18 @@ Note if you would like to add to existing config you can pass `true` for the opt
 
 The page usage is:
 
-{% highlight js %}
+```javascript
 pbjs.setBidderConfig({
    bidders: ['bidderA'],
    config: {
       customArg: "customVal"
    }
 });
-{% endhighlight %}
+```
+
 or
-{% highlight js %}
+
+```javascript
 pbjs.setBidderConfig({
    bidders: ['bidderB'],
    config: {
@@ -50,11 +52,12 @@ pbjs.setBidderConfig({
       }
    }
 });
-{% endhighlight %}
+```
 
 How to interpret these examples:
-- When 'bidderA' calls `getConfig('customArg')`, it will receive the object that contains 'customArg'. If any other bidder calls `getConfig('customArg')`, it will receive nothing.
-- When 'bidderB' calls `getConfig('ortb2')`, it will receive this override definition rather than whatever else might have been defined globally. If any other bidder calls `getConfig('ortb2')`, it will receive the globally defined objects.
+
+* When 'bidderA' calls `getConfig('customArg')`, it will receive the object that contains 'customArg'. If any other bidder calls `getConfig('customArg')`, it will receive nothing.
+* When 'bidderB' calls `getConfig('ortb2')`, it will receive this override definition rather than whatever else might have been defined globally. If any other bidder calls `getConfig('ortb2')`, it will receive the globally defined objects.
 
 {: .alert.alert-info :}
 This function is also used by the `schain` feature. Refer to the [schain](/dev-docs/modules/schain.html) documentation for examples.

--- a/dev-docs/publisher-api-reference/setConfig.md
+++ b/dev-docs/publisher-api-reference/setConfig.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.setConfig(options)
-description:
+description: setConfig API
 sidebarType: 1
 ---
 
@@ -14,42 +14,42 @@ See below for usage examples.
 
 Core config:
 
-+ [Debugging](#setConfig-Debugging)
-+ [Device Access](#setConfig-deviceAccess)
-+ [Bidder Timeouts](#setConfig-Bidder-Timeouts)
-+ [Max Requests Per Origin](#setConfig-Max-Requests-Per-Origin)
-+ [Disable Ajax Timeout](#setConfig-Disable-Ajax-Timeout)
-+ [Set Timeout Buffer](#setConfig-timeoutBuffer)
-+ [Set TTL Buffer](#setConfig-ttlBuffer)
-+ [Turn on send all bids mode](#setConfig-Send-All-Bids)
-+ [Configure send bids control](#setConfig-Send-Bids-Control)
-+ [Bid cache](#setConfig-Use-Bid-Cache)
-+ [Set the order in which bidders are called](#setConfig-Bidder-Order)
-+ [Set the page URL](#setConfig-Page-URL)
-+ [Set price granularity](#setConfig-Price-Granularity)
-+ [Set media type price granularity](#setConfig-MediaType-Price-Granularity)
-+ [Set custom cpm rounding](#setConfig-Cpm-Rounding)
-+ [Configure server-to-server header bidding](#setConfig-Server-to-Server)
-+ [Configure user syncing](#setConfig-Configure-User-Syncing)
-+ [Configure targeting controls](#setConfig-targetingControls)
-+ [Configure responsive ad units with `sizeConfig` and `labels`](#setConfig-Configure-Responsive-Ads)
-+ [COPPA](#setConfig-coppa)
-+ [First Party Data](#setConfig-fpd)
-+ [Video Module to integrate with Video Players](#video-module)
-+ [Caching VAST XML](#setConfig-vast-cache)
-+ [Site Metadata](#setConfig-site)
-+ [Disable performance metrics](#setConfig-performanceMetrics)
-+ [Setting alias registry to private](#setConfig-aliasRegistry)
-+ [Generic Configuration](#setConfig-Generic-Configuration)
-+ [Troubleshooting configuration](#setConfig-Troubleshooting-your-configuration)
+* [Debugging](#setConfig-Debugging)
+* [Device Access](#setConfig-deviceAccess)
+* [Bidder Timeouts](#setConfig-Bidder-Timeouts)
+* [Max Requests Per Origin](#setConfig-Max-Requests-Per-Origin)
+* [Disable Ajax Timeout](#setConfig-Disable-Ajax-Timeout)
+* [Set Timeout Buffer](#setConfig-timeoutBuffer)
+* [Set TTL Buffer](#setConfig-ttlBuffer)
+* [Turn on send all bids mode](#setConfig-Send-All-Bids)
+* [Configure send bids control](#setConfig-Send-Bids-Control)
+* [Bid cache](#setConfig-Use-Bid-Cache)
+* [Set the order in which bidders are called](#setConfig-Bidder-Order)
+* [Set the page URL](#setConfig-Page-URL)
+* [Set price granularity](#setConfig-Price-Granularity)
+* [Set media type price granularity](#setConfig-MediaType-Price-Granularity)
+* [Set custom cpm rounding](#setConfig-Cpm-Rounding)
+* [Configure server-to-server header bidding](#setConfig-Server-to-Server)
+* [Configure user syncing](#setConfig-Configure-User-Syncing)
+* [Configure targeting controls](#setConfig-targetingControls)
+* [Configure responsive ad units with `sizeConfig` and `labels`](#setConfig-Configure-Responsive-Ads)
+* [COPPA](#setConfig-coppa)
+* [First Party Data](#setConfig-fpd)
+* [Video Module to integrate with Video Players](#video-module)
+* [Caching VAST XML](#setConfig-vast-cache)
+* [Site Metadata](#setConfig-site)
+* [Disable performance metrics](#setConfig-performanceMetrics)
+* [Setting alias registry to private](#setConfig-aliasRegistry)
+* [Generic Configuration](#setConfig-Generic-Configuration)
+* [Troubleshooting configuration](#setConfig-Troubleshooting-your-configuration)
 
 Module config: other options to `setConfig()` are available if the relevant module is included in the Prebid.js build.
 
-+ [Currency module](/dev-docs/modules/currency.html)
-+ [Consent Management](/dev-docs/modules/consentManagement.html#page-integration)
-+ [User ID module](/dev-docs/modules/userId.html#configuration)
-+ [Adpod](/dev-docs/modules/adpod.html)
-+ [IAB Category Translation](/dev-docs/modules/categoryTranslation.html)
+* [Currency module](/dev-docs/modules/currency.html)
+* [Consent Management](/dev-docs/modules/consentManagement.html#page-integration)
+* [User ID module](/dev-docs/modules/userId.html#configuration)
+* [Adpod](/dev-docs/modules/adpod.html)
+* [IAB Category Translation](/dev-docs/modules/categoryTranslation.html)
 
 <a name="setConfig-Debugging" />
 
@@ -62,9 +62,10 @@ Note that debugging can be specified for a specific page view by adding
 `pbjs_debug=true` to the URL's query string. e.g. <code>/pbjs_demo.html?pbjs_debug=true</code> See [Prebid.js troubleshooting guide](/troubleshooting/troubleshooting-guide.html) for more information.
 
 Turn on debugging permanently in the page:
-{% highlight js %}
+
+```javascript
 pbjs.setConfig({ debug: true });
-{% endhighlight %}
+```
 
 {: .alert.alert-warning :}
 Note that turning on debugging for Prebid Server causes most server-side adapters to consider it a test request, meaning that they won't count on reports.
@@ -75,9 +76,9 @@ Note that turning on debugging for Prebid Server causes most server-side adapter
 
 You can prevent Prebid.js from reading or writing cookies or HTML localstorage by setting this flag:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({ deviceAccess: false });
-{% endhighlight %}
+```
 
 This can be useful in GDPR, CCPA, COPPA or other privacy scenarios where a publisher has determined that header bidding should not read from or write the user's device.
 
@@ -87,9 +88,9 @@ This can be useful in GDPR, CCPA, COPPA or other privacy scenarios where a publi
 
 Set a global bidder timeout:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({ bidderTimeout: 3000 });
-{% endhighlight %}
+```
 
 {: .alert.alert-warning :}
 **Bid Timeouts and JavaScript Timers**
@@ -106,14 +107,14 @@ will queue auctions that would cause requests to a specific origin to exceed tha
 for each browser. Prebid.js defaults to a max of `4` requests per origin.  That value can be configured with
 `maxRequestsPerOrigin`.
 
-{% highlight js %}
+```javascript
 // most browsers allow at least 6 requests, but your results may vary for your user base.  Sometimes using all
 // `6` requests can impact performance negatively for users with poor internet connections.
 pbjs.setConfig({ maxRequestsPerOrigin: 6 });
 
 // to emulate pre 1-x behavior and have all auctions queue (no concurrent auctions), you can set it to `1`.
 pbjs.setConfig({ maxRequestsPerOrigin: 1 });
-{% endhighlight %}
+```
 
 #### Disable Ajax Timeout
 
@@ -121,9 +122,9 @@ pbjs.setConfig({ maxRequestsPerOrigin: 1 });
 
 Prebid core adds a timeout on XMLHttpRequest request to terminate the request once auction is timedout. Since Prebid is ignoring all the bids after timeout it does not make sense to continue the request after timeout. However, you have the option to disable this by using `disableAjaxTimeout`.
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({ disableAjaxTimeout: true });
-{% endhighlight %}
+```
 
 #### Set Timeout Buffer
 
@@ -131,9 +132,9 @@ pbjs.setConfig({ disableAjaxTimeout: true });
 
 Prebid core adds a timeout buffer to extend the time that bidders have to return a bid after the auction closes. This buffer is used to offset the "time slippage" of the setTimeout behavior in browsers. Prebid.js sets the default value to 400ms. You can change this value by setting `timeoutBuffer` to the amount of time you want to use. The following example sets the buffer to 300ms.
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({ timeoutBuffer: 300 });
-{% endhighlight %}
+```
 
 #### Set TTL Buffer
 
@@ -141,11 +142,11 @@ pbjs.setConfig({ timeoutBuffer: 300 });
 
 When an adapter bids, it provides a TTL (time-to-live); the bid is considered expired and unusuable after that time has elapsed. Core subtracts from it a buffer of 1 second; that is, a bid with TTL of 30 seconds is considered expired after 29 seconds. You can adjust this buffer with:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({ 
   ttlBuffer: 10  // TTL buffer in seconds 
 });
-{% endhighlight %}
+```
 
 #### Send All Bids
 
@@ -166,7 +167,7 @@ Note that targeting config must be set before either `pbjs.setTargetingForGPTAsy
 
 ##### Example results where enableSendAllBids is true
 
-{% highlight bash %}
+```bash
 {
   "hb_adid_audienceNetw": "1663076dadb443d",
   "hb_pb_audienceNetwor": "9.00",
@@ -191,7 +192,7 @@ Note that targeting config must be set before either `pbjs.setTargetingForGPTAsy
   "hb_size": "300x250",
   "hb_format": "banner"
 }
-{% endhighlight %}
+```
 
 You can see how the number of ad server targeting variable could get large
 when many bidders are present.
@@ -243,6 +244,7 @@ pbjs.setConfig({
   }
 });
 ```
+
 When this property is set, the value assigned to `bidLimit` is the maximum number of bids that will be sent to the ad server. If `bidLimit` is set to 0, sendAllBids will have no maximum bid limit and *all* bids will be sent. This setting can be helpful if you know that your ad server has a finite limit to the amount of query characters it will accept and process.
 
 {: .alert.alert-info :}
@@ -260,10 +262,9 @@ a given auction.
 This option is available in version 1.39 as true-by-default and became false-by-default as of Prebid.js 2.0. If you want to use this
 feature in 2.0 and later, you'll need to set the value to true.
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({ useBidCache: true })
-{% endhighlight %}
-
+```
 
 #### Bid Cache Filter Function
 
@@ -271,21 +272,20 @@ pbjs.setConfig({ useBidCache: true })
 
 When [Bid Caching](#setConfig-Use-Bid-Cache) is turned on, a custom Filter Function can be defined to gain more granular control over which "cached" bids can be used.  This function will only be called for "cached" bids from previous auctions, not "current" bids from the most recent auction.  The function should take a single bid object argument, and return `true` to use the cached bid, or `false` to not use the cached bid.  For Example, to turn on Bid Caching, but exclude cached video bids, you could do this:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     useBidCache: true,
     bidCacheFilterFunction: bid => bid.mediaType !== 'video'
 });
-{% endhighlight %}
-
+```
 
 #### Bidder Order
 
 Set the order in which bidders are called:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({ bidderSequence: "fixed" })   /* default is "random" */
-{% endhighlight %}
+```
 
 <a name="setConfig-Page-URL" />
 
@@ -293,10 +293,9 @@ pbjs.setConfig({ bidderSequence: "fixed" })   /* default is "random" */
 
 Override the Prebid.js page referrer for some bidders.
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({ pageUrl: "https://example.com/index.html" })
-{% endhighlight %}
-
+```
 
 <a name="setConfig-Price-Granularity" />
 
@@ -304,42 +303,42 @@ pbjs.setConfig({ pageUrl: "https://example.com/index.html" })
 
 This configuration defines the price bucket granularity setting that will be used for the `hb_pb` keyword.
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({ priceGranularity: "medium" })
-{% endhighlight %}
+```
 
 Standard values:
 
-+ `"low"`: $0.50 increments, capped at $5 CPM
-+ `"medium"`: $0.10 increments, capped at $20 CPM (the default)
-+ `"high"`: $0.01 increments, capped at $20 CPM
-+ `"auto"`: Applies a sliding scale to determine granularity as shown in the [Auto Granularity](#autoGranularityBucket) table below.
-+ `"dense"`: Like `"auto"`, but the bid price granularity uses smaller increments, especially at lower CPMs.  For details, see the [Dense Granularity](#denseGranularityBucket) table below.
-+ `customConfigObject`: If you pass in a custom config object (as shown in the [Custom CPM Bucket Sizing](#customCPMObject) example below), you can have much finer control over CPM bucket sizes, precision, and caps.
+* `"low"`: $0.50 increments, capped at $5 CPM
+* `"medium"`: $0.10 increments, capped at $20 CPM (the default)
+* `"high"`: $0.01 increments, capped at $20 CPM
+* `"auto"`: Applies a sliding scale to determine granularity as shown in the [Auto Granularity](#autoGranularityBucket) table below.
+* `"dense"`: Like `"auto"`, but the bid price granularity uses smaller increments, especially at lower CPMs.  For details, see the [Dense Granularity](#denseGranularityBucket) table below.
+* `customConfigObject`: If you pass in a custom config object (as shown in the [Custom CPM Bucket Sizing](#customCPMObject) example below), you can have much finer control over CPM bucket sizes, precision, and caps.
 
 <a name="autoGranularityBucket"></a>
 
 ##### Auto Granularity
 
 {: .table .table-bordered .table-striped }
-| CPM                 | 	Granularity                  |  Example |
+| CPM                 |     Granularity                  |  Example |
 |---------------------+----------------------------------+--------|
-| CPM <= $5            | 	$0.05 increments             | $1.87 floored to $1.85 |
-| CPM <= $10 and > $5  | 	$0.10 increments             | $5.09 floored to $5.00 |
-| CPM <= $20 and > $10 | 	$0.50 increments             | $14.26 floored to $14.00 |
-| CPM > $20           | 	Caps the price bucket at $20 | $24.82 floored to $20.00 |
+| CPM <= $5            |    $0.05 increments             | $1.87 floored to $1.85 |
+| CPM <= $10 and > $5  |    $0.10 increments             | $5.09 floored to $5.00 |
+| CPM <= $20 and > $10 |    $0.50 increments             | $14.26 floored to $14.00 |
+| CPM > $20            |    Caps the price bucket at $20 | $24.82 floored to $20.00 |
 
 <a name="denseGranularityBucket"></a>
 
 ##### Dense Granularity
 
 {: .table .table-bordered .table-striped }
-| CPM        | 	Granularity                  | Example |
+| CPM        |  Granularity                  | Example |
 |------------+-------------------------------+---------|
-| CPM <= $3  | 	$0.01 increments             | $1.87 floored to $1.87 |
-| CPM <= $8 and >$3  | 	$0.05 increments             | $5.09 floored to $5.05 |
-| CPM <= $20 and >$8 | 	$0.50 increments             | $14.26 floored to $14.00 |
-| CPM >  $20 | 	Caps the price bucket at $20 | $24.82 floored to $20.00 |
+| CPM <= $3  |  $0.01 increments             | $1.87 floored to $1.87 |
+| CPM <= $8 and >$3  |  $0.05 increments             | $5.09 floored to $5.05 |
+| CPM <= $20 and >$8 |  $0.50 increments             | $14.26 floored to $14.00 |
+| CPM >  $20 |  Caps the price bucket at $20 | $24.82 floored to $20.00 |
 
 <a name="customCPMObject"></a>
 
@@ -372,9 +371,9 @@ pbjs.setConfig({
 
 Here are the rules for CPM intervals:
 
-- `max` and `increment` must be specified
-- A range's minimum value is assumed to be the max value of the previous range. The first interval starts at a min value of 0.
-- `precision` is optional and defaults to 2
+* `max` and `increment` must be specified
+* A range's minimum value is assumed to be the max value of the previous range. The first interval starts at a min value of 0.
+* `precision` is optional and defaults to 2
 
 {% capture warning-granularity %}
 As of Prebid.js 3.0, the 'min' parameter is no longer supported in custom granularities.
@@ -390,8 +389,7 @@ This implies that ranges should have max values that are really the min value of
 
 {% include alerts/alert_warning.html content=warning-granularity %}
 
-
-<a name="setConfig-MediaType-Price-Granularity" />
+<a name="setConfig-MediaType-Price-Granularity"></a>
 
 #### Media Type Price Granularity
 
@@ -399,10 +397,11 @@ The standard [Prebid price granularities](#setConfig-Price-Granularity) cap out 
 granularity as described above. Another approach is to use
 `mediaTypePriceGranularity` config that may be set to define different price bucket
 structures for different types of media:
-- for each of five media types: banner, video, video-instream, video-outstream, and native.
-- it is recommended that defined granularities be custom. It's possible to define "standard" granularities (e.g. "medium"), but it's not possible to mix both custom and standard granularities.
 
-{% highlight js %}
+* for each of five media types: banner, video, video-instream, video-outstream, and native.
+* it is recommended that defined granularities be custom. It's possible to define "standard" granularities (e.g. "medium"), but it's not possible to mix both custom and standard granularities.
+
+```javascript
 const customPriceGranularityVideo = {
             'buckets': [
               { 'precision': 2, 'max': 5, 'increment': 0.25 },
@@ -419,11 +418,11 @@ const customPriceGranularityBanner = {
 
 pbjs.setConfig({'mediaTypePriceGranularity': {
           'video': customPriceGranularity,   // used as default for instream video
-	  'video-outstream': customPriceGranularityBanner,
+          'video-outstream': customPriceGranularityBanner,
           'banner': 'customPriceGranularityBanner'
         }
 });
-{% endhighlight %}
+```
 
 Any `mediaTypePriceGranularity` setting takes precedence over `priceGranularity`.
 
@@ -437,16 +436,17 @@ are recognized. This was driven by the recognition that outstream often shares l
 If the mediatype is video, the price bucketing code further looks at the context (e.g. outstream) to see if there's
 a price granularity override. If it doesn't find 'video-outstream' defined, it will then look for just 'video'.
 
-<a name="setConfig-Cpm-Rounding" />
+<a name="setConfig-Cpm-Rounding"></a>
 
 #### Custom CPM Rounding
 
-Prebid defaults to rounding down all bids to the nearest increment, which may cause lower CPM ads to be selected. 
-While this can be addressed through higher [price granularity](#setConfig-Price-Granularity), Prebid also allows setting a custom rounding function. 
-This function will be used by Prebid to determine what increment a bid will round to. 
+Prebid defaults to rounding down all bids to the nearest increment, which may cause lower CPM ads to be selected.
+While this can be addressed through higher [price granularity](#setConfig-Price-Granularity), Prebid also allows setting a custom rounding function.
+This function will be used by Prebid to determine what increment a bid will round to.
 <br/>
 <br/>
 You can set a simple rounding function:
+
 ```javascript
 // Standard rounding
 pbjs.setConfig({'cpmRoundingFunction': Math.round});
@@ -468,13 +468,13 @@ const roundToNearestEvenIncrement = function (number) {
 pbjs.setConfig({'cpmRoundingFunction': roundToNearestEvenIncrement});
 ```
 
-<a name="setConfig-Server-to-Server" />
+<a name="setConfig-Server-to-Server"></a>
 
 #### Server to Server
 
 See the [Prebid Server module](/dev-docs/modules/prebidServer.html).
 
-<a name="setConfig-app" />
+<a name="setConfig-app"></a>
 
 #### Mobile App Post-Bid
 
@@ -482,7 +482,7 @@ To support [post-bid](/overview/what-is-post-bid.html) scenarios on mobile apps,
 prebidServerBidAdapter module will accept `ortb2.app` config to
 forward details through the server:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
   ortb2: {
     app: {
@@ -491,12 +491,12 @@ pbjs.setConfig({
     }
   }
 });
-{% endhighlight %}
+```
 
 {: .alert.alert-warning :}
 In PBJS 4.29 and earlier, don't add the `ortb2` level here -- just `app` directly. Oh, and please upgrade. 4.29 was a long time ago.
 
-<a name="setConfig-Configure-User-Syncing" />
+<a name="setConfig-Configure-User-Syncing"></a>
 
 #### Configure User Syncing
 
@@ -505,9 +505,9 @@ This practice is called "user syncing" because the aim is to let the bidders mat
 There's a good reason for bidders to be doing this -- DSPs are more likely to bid on impressions where they know something about the history of the user.
 However, there are also good reasons why publishers may want to control the use of these practices:
 
-- *Page performance*: Publishers may wish to move ad-related cookie work to much later in the page load after ads and content have loaded.
-- *User privacy*: Some publishers may want to opt out of these practices even though it limits their users' values on the open market.
-- *Security*: Publishers may want to control which bidders are trusted to inject images and JavaScript into their pages.
+* *Page performance*: Publishers may wish to move ad-related cookie work to much later in the page load after ads and content have loaded.
+* *User privacy*: Some publishers may want to opt out of these practices even though it limits their users' values on the open market.
+* *Security*: Publishers may want to control which bidders are trusted to inject images and JavaScript into their pages.
 
 {: .alert.alert-info :}
 **User syncing default behavior**
@@ -515,9 +515,9 @@ If you don't tweak any of the settings described in this section, the default be
 
 For more information, see the sections below.
 
-- [User Sync Properties](#setConfig-ConfigureUserSyncing-UserSyncProperties)
-- [User Sync Examples](#setConfig-ConfigureUserSyncing-UserSyncExamples)
-- [How User Syncing Works](#setConfig-ConfigureUserSyncing-HowUserSyncingWorks)
+* [User Sync Properties](#setConfig-ConfigureUserSyncing-UserSyncProperties)
+* [User Sync Examples](#setConfig-ConfigureUserSyncing-UserSyncExamples)
+* [How User Syncing Works](#setConfig-ConfigureUserSyncing-HowUserSyncingWorks)
 
 <a name="setConfig-ConfigureUserSyncing-UserSyncProperties" />
 
@@ -544,37 +544,37 @@ For examples of configurations that will change the default behavior, see below.
 
 Push the user syncs to later in the page load:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     userSync: {
         syncDelay: 5000 // write image pixels 5 seconds after the auction
     }
 });
-{% endhighlight %}
+```
 
 Turn off user syncing entirely:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     userSync: {
         syncEnabled: false
     }
 });
-{% endhighlight %}
+```
 
 Delay auction to retrieve userId module IDs first:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     userSync: {
         auctionDelay: 1000 // delay auction up to 1 second
     }
 });
-{% endhighlight %}
+```
 
 Allow iframe-based syncs (the presence of a valid `filterSettings.iframe` object automatically enables iframe type user-syncing):
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     userSync: {
         filterSettings: {
@@ -585,12 +585,13 @@ pbjs.setConfig({
         }
     }
 });
-{% endhighlight %}
-_Note - iframe-based syncing is disabled by default.  Image-based syncing is enabled by default; it can be disabled by excluding all/certain bidders via the `filterSettings` object._
+```
+
+Note - iframe-based syncing is disabled by default.  Image-based syncing is enabled by default; it can be disabled by excluding all/certain bidders via the `filterSettings` object._
 
 Only certain bidders are allowed to sync and only certain types of sync pixels:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     userSync: {
         filterSettings: {
@@ -607,11 +608,11 @@ pbjs.setConfig({
         syncDelay: 6000, // 6 seconds after the auction
     }
 });
-{% endhighlight %}
+```
 
 If you want to apply the same bidder inclusion/exlusion rules for both types of sync pixels, you can use the `all` object instead specifying both `image` and `iframe` objects like so:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     userSync: {
         /* only these bidders are allowed to sync.  Both iframe and image pixels are permitted. */
@@ -625,13 +626,13 @@ pbjs.setConfig({
         syncDelay: 6000, // 6 seconds after the auction
     }
 });
-{% endhighlight %}
+```
 
-_Note - the `all` field is mutually exclusive and cannot be combined with the `iframe`/`image` fields in the `userSync` config.  This restriction is to promote clear logic as to how bidders will operate in regards to their `userSync` pixels.  If the fields are used together, this will be considered an invalid config and Prebid will instead use the default `userSync` logic (all image pixels permitted and all iframe pixels are blocked)._
+Note - the `all` field is mutually exclusive and cannot be combined with the `iframe`/`image` fields in the `userSync` config.  This restriction is to promote clear logic as to how bidders will operate in regards to their userSync` pixels.  If the fields are used together, this will be considered an invalid config and Prebid will instead use the default `userSync` logic (all image pixels permitted and all iframe pixels are blocked)._
 
 The same bidders can drop sync pixels, but the timing will be controlled by the page:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     userSync: {
         /* only these bidders are allowed to sync, and only image pixels */
@@ -644,13 +645,13 @@ pbjs.setConfig({
         enableOverride: true // publisher will call `pbjs.triggerUserSyncs()`
     }
 });
-{% endhighlight %}
+```
 
 As noted, there's a function available to give the page control of when registered user syncs are added.
 
-{% highlight js %}
+```javascript
 pbjs.triggerUserSyncs();
-{% endhighlight %}
+```
 
 <a name="setConfig-ConfigureUserSyncing-HowUserSyncingWorks" />
 
@@ -731,6 +732,7 @@ The `allowTargetingKeys` config creates a targeting key mask based on the defaul
 Prebid.js introduced the concept of optional targeting keys with 4.23. CONSTANTS.DEFAULT_TARGETING_KEYS is defined as a subset of CONSTANTS.TARGETING_KEYS. When a publisher defines targetingControls.allowTargetingKeys, this replaces the constant CONSTANTS.DEFAULT_TARGETING_KEYS and can include optional keys defined in CONSTANTS.TARGETING_KEYS. One example of this would be to make `hb_adomain` part of the default set.
 
 To accomplish this, Prebid does the following:
+
 * Collect original targeting generated by the auction.
 * Generate new targeting filtered against allowed keys.
   * Custom targeting keys are always added to targeting.
@@ -783,6 +785,7 @@ config.setConfig({
   }
 });
 ```
+
 Another example config showing the addition of `hb_adomain` and excluding all default targeting keys except `hb_bidder`, `hb_adid`, `hb_size` and `hb_pb`:
 
 ```javascript
@@ -797,7 +800,7 @@ config.setConfig({
 
 ##### Details on the addTargetingKeys setting
 
-The `addTargetingKeys` config is similar to `allowTargetingKeys`, except it adds to the keys in CONSTANTS.DEFAULT_TARGETING_KEYS instead of replacing them. This is useful if you need Prebid.js to generate targeting for some keys that are not allowed by default without removing any of the default ones (see [allowTargetingKeys](#targetingControls-allowTargetingKeys) for details on how targeting is generated). 
+The `addTargetingKeys` config is similar to `allowTargetingKeys`, except it adds to the keys in CONSTANTS.DEFAULT_TARGETING_KEYS instead of replacing them. This is useful if you need Prebid.js to generate targeting for some keys that are not allowed by default without removing any of the default ones (see [allowTargetingKeys](#targetingControls-allowTargetingKeys) for details on how targeting is generated).
 
 Note that you may specify only one of `allowTargetingKeys` or `addTargetingKeys`.
 
@@ -851,7 +854,6 @@ config.setConfig({
 });
 ```
 
-
 ##### Details on the allowSendAllBidsTargetingKeys setting
 
 The `allowSendAllBidsTargetingKeys` is similar to `allowTargetingKeys` except it limits any default bidder specific keys sent to the adserver when sendAllBids is enabled. Any default bidder specific keys that do not match the mask will not be sent to the adserver. This setting can be helpful if you find that your default Prebid.js implementation is sending key values that your adserver isn't configured to process; extraneous key values may lead to the ad server request being truncated, which can cause potential issues with the delivery or rendering ads. An example of an extraneous key value many publishers may find redundant and want to remove is `hb_bidder_biddercode = biddercode`.
@@ -866,8 +868,7 @@ config.setConfig({
 });
 ```
 
-
-<a name="setConfig-Configure-Responsive-Ads" />
+<a name="setConfig-Configure-Responsive-Ads"></a>
 
 #### Configure Responsive Ads
 
@@ -889,19 +890,19 @@ If, on the other hand, you're only working with the banner mediaType and the AdU
 {% endcapture %}
 {% include alerts/alert_tip.html content=tip-choosing %}
 
-+ [How it works](#sizeConfig-How-it-Works)
-+ [Example](#sizeConfig-Example)
-+ [Labels](#labels)
+* [How it works](#sizeConfig-How-it-Works)
+* [Example](#sizeConfig-Example)
+* [Labels](#labels)
 
-<a name="sizeConfig-How-it-Works" />
+<a name="sizeConfig-How-it-Works"></a>
 
 ##### How Size Config Works for Banners
 
-- Before `requestBids` sends bid requests to adapters, it will evaluate and pick the appropriate label(s) based on the `sizeConfig.mediaQuery` and device properties.  Once it determines the active label(s), it will then filter the `adUnit.bids` array based on the `labels` defined and whether the `banner` mediaType was included. Ad units that include a `banner` mediaType that don't match the label definition are dropped.
-- The required `sizeConfig.mediaQuery` property allows [CSS media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries).  The queries are tested using the [`window.matchMedia`](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) API.
-- If a label conditional (e.g. `labelAny`) doesn't exist on an ad unit, it is automatically included in all requests for bids.
-- If multiple rules match, the sizes will be filtered to the intersection of all matching rules' `sizeConfig.sizesSupported` arrays.
-- The `adUnit.mediaTypes.banner.sizes` selected will be filtered based on the `sizesSupported` of the matched `sizeConfig`. So the `adUnit.mediaTypes.banner.sizes` is a subset of the sizes defined from the resulting intersection of `sizesSupported` sizes and `adUnit.mediaTypes.banner.sizes`. (Note: size config will also operate on `adUnit.sizes`, however `adUnit.sizes` is deprecated in favor of `adUnit.mediaTypes`)
+* Before `requestBids` sends bid requests to adapters, it will evaluate and pick the appropriate label(s) based on the `sizeConfig.mediaQuery` and device properties.  Once it determines the active label(s), it will then filter the `adUnit.bids` array based on the `labels` defined and whether the `banner` mediaType was included. Ad units that include a `banner` mediaType that don't match the label definition are dropped.
+* The required `sizeConfig.mediaQuery` property allows [CSS media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries).  The queries are tested using the [`window.matchMedia`](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) API.
+* If a label conditional (e.g. `labelAny`) doesn't exist on an ad unit, it is automatically included in all requests for bids.
+* If multiple rules match, the sizes will be filtered to the intersection of all matching rules' `sizeConfig.sizesSupported` arrays.
+* The `adUnit.mediaTypes.banner.sizes` selected will be filtered based on the `sizesSupported` of the matched `sizeConfig`. So the `adUnit.mediaTypes.banner.sizes` is a subset of the sizes defined from the resulting intersection of `sizesSupported` sizes and `adUnit.mediaTypes.banner.sizes`. (Note: size config will also operate on `adUnit.sizes`, however `adUnit.sizes` is deprecated in favor of `adUnit.mediaTypes`)
 
 ###### Note on sizeConfig and different mediaTypes
 
@@ -913,11 +914,11 @@ If the ad unit does not include `banner` `mediaType` at all, then the sizeConfig
 
 <a name="sizeConfig-Example" />
 
-##### Example
+##### Size Config Example
 
 To set size configuration rules, pass in `sizeConfig` as follows:
 
-{% highlight js %}
+```javascript
 
 pbjs.setConfig({
     sizeConfig: [{
@@ -954,7 +955,7 @@ pbjs.setConfig({
     }]
 });
 
-{% endhighlight %}
+```
 
 ##### Labels
 
@@ -968,22 +969,24 @@ Labels may be defined in two ways:
 1. Through [`sizeConfig`](#setConfig-Configure-Responsive-Ads)
 2. As an argument to [`pbjs.requestBids`](/dev-docs/publisher-api-reference/requestBids.html)
 
-{% highlight js %}
+```javascript
 pbjs.requestBids({labels: []});
-{% endhighlight %}
+```
 
 Labels may be targeted in the AdUnit structure by two conditional operators: `labelAny` and `labelAll`.
 
 With the `labelAny` operator, just one label has to match for the condition to be true. In the example below, either A or B can be defined in the label array to activate the bid or ad unit:
-{% highlight bash %}
+
+```javascript
 labelAny: ["A", "B"]
-{% endhighlight %}
+```
 
 With the `labelAll` conditional, every element of the target array must match an element of the label array in
 order for the condition to be true. In the example below, both A and B must be defined in the label array to activate the bid or ad unit:
-{% highlight bash %}
+
+```javascript
 labelAll: ["A", "B"]
-{% endhighlight %}
+```
 
 {: .alert.alert-warning :}
 Only one conditional may be specified on a given AdUnit or bid -- if both `labelAny` and `labelAll` are specified, only the first one will be utilized and an error will be logged to the console. It is allowable for an AdUnit to have one condition and a bid to have another.
@@ -996,8 +999,7 @@ It is important to note that labels do not act as filters for sizeConfig. In the
 
 Label targeting on the ad unit looks like the following:
 
-{% highlight js %}
-
+```javascript
 pbjs.addAdUnits([{
     code: "ad-slot-1",
     mediaTypes: {
@@ -1048,12 +1050,11 @@ pbjs.addAdUnits([{
     ]
 }]);
 
-{% endhighlight %}
+```
 
 See [Conditional Ad Units]({{site.baseurl}}/dev-docs/conditional-ad-units.html) for additional use cases around labels.
 
-
-<a name="setConfig-coppa" />
+<a name="setConfig-coppa"></a>
 
 #### COPPA
 
@@ -1061,11 +1062,11 @@ Bidder adapters that support the Child Online Privacy Protection Act (COPPA) rea
 Publishers with content falling under the scope of this regulation should consult with their legal teams.
 The flag may be passed to supporting adapters with this config:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({coppa: true});
-{% endhighlight %}
+```
 
-<a name="setConfig-fpd" />
+<a name="setConfig-fpd"></a>
 
 #### First Party Data
 
@@ -1077,24 +1078,25 @@ Not all bid adapters currently support reading first party data in this way, but
 
 **Scenario 1** - Global (cross-adunit) First Party Data open to all bidders
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
    ortb2: {
        site: {
-	 ...
+         // ...
        },
        user: {
-         ...
+         // ...
        }
     }
 });
-{% endhighlight %}
+```
 
 The `ortb2` JSON structure reflects the OpenRTB standard:
-- Fields that like keywords, search, content, gender, yob, and geo are values defined in OpenRTB, so should go directly under the site or user objects.
-- Arbitrary values should go in site.ext.data or user.ext.data.
-- Segments should go in site.content.data[] or user.data[].
-- Any other OpenRTB 2.5 field could be added here as well, e.g. site.content.language.
+
+* Fields that like keywords, search, content, gender, yob, and geo are values defined in OpenRTB, so should go directly under the site or user objects.
+* Arbitrary values should go in site.ext.data or user.ext.data.
+* Segments should go in site.content.data[] or user.data[].
+* Any other OpenRTB 2.5 field could be added here as well, e.g. site.content.language.
 
 **Scenario 2** - Auction (cross-adunit) First Party Data open to all bidders
 
@@ -1110,7 +1112,7 @@ See the [AdUnit Reference](/dev-docs/adunit-reference.html) for AdUnit-specific 
 
 See [Prebid Server First Party Data](/prebid-server/features/pbs-fpd.html) for details about passing data server-side.
 
-<a name="video-module" />
+<a name="video-module"></a>
 
 #### Video Module to integrate with Video Players
 
@@ -1142,10 +1144,11 @@ To register a video player with Prebid, you must use `setConfig` to set a `video
 
 **Note:** You can integrate with different Player vendors. For this to work, you must ensure that the right Video Submodules are included in your build, and that the providers have the right `vendorCode`s and `divId`s.
 
-##### Example
+##### Player Integration Example
 
 Assuming your page has 2 JW Player video players, 1 video.js video player, and your ad server is GAM.
-{% highlight js %}
+
+```javascript
 pbjs.setConfig({
     video: {
         providers: [{
@@ -1181,9 +1184,9 @@ pbjs.setConfig({
         }
     }
 });
-{% endhighlight %}
+```
 
-<a name="setConfig-vast-cache" />
+<a name="setConfig-vast-cache"></a>
 
 #### Client-side Caching of VAST XML
 
@@ -1192,16 +1195,16 @@ video player can retrieve them when it's ready. Players don't obtain the VAST XM
 the JavaScript DOM in Prebid.js, but rather expect to be given a URL where it can
 be retrieved. There are two different flows possible with Prebid.js around VAST XML caching:
 
-- Server-side caching:  
+* Server-side caching:  
   Some video bidders (e.g. Rubicon Project) always cache the VAST XML on their servers as part of the bid. They provide a 'videoCacheKey', which is used in conjunction with the VAST URL in the ad server to retrieve the correct VAST XML when needed. In this case, Prebid.js has nothing else to do. As of Prebid.js 4.28, a publisher may specify the `ignoreBidderCacheKey` flag to re-cache these bids somewhere else using a VAST wrapper.
-- Client-side caching:  
+* Client-side caching:  
   Video bidders that don't cache on their servers return the entire VAST XML body. In this scenario, Prebid.js needs to copy the VAST XML to a publisher-defined cache location on the network. Prebid.js POSTs the VAST XML to the named Prebid Cache URL. It then sets the 'videoCacheKey' to the key that's returned in the response.
 
 {: .table .table-bordered .table-striped }
 | Cache Attribute | Required? | Type | Description |
 |----+--------+-----+-------|
 | cache.url | yes | string | The URL of the Prebid Cache server endpoint where VAST creatives will be sent. |
-| cache.timeout | no | number | Timeout (in milliseconds) for network requests to the cache | 
+| cache.timeout | no | number | Timeout (in milliseconds) for network requests to the cache |
 | cache.vasttrack | no | boolean | Passes additional data to the url, used for additional event tracking data. Defaults to `false`. |
 | cache.ignoreBidderCacheKey | no | boolean | If the bidder supplied their own cache key, setting this value to true adds a VAST wrapper around that URL, stores it in the cache defined by the `url` parameter, and replaces the original video cache key with the new one. This can dramatically simplify ad server setup because it means all VAST creatives reside behind a single URL. The tradeoff: this approach requires the video player to unwrap one extra level of VAST. Defaults to `false`. |
 | cache.batchSize | no | number | Enables video cache requests to be batched by a specified amount (defaults to 1) instead of making a single request per each video. |
@@ -1209,44 +1212,44 @@ be retrieved. There are two different flows possible with Prebid.js around VAST 
 
 Here's an example of basic client-side caching. Substitute your Prebid Cache URL as needed:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
         cache: {
             url: 'https://prebid.adnxs.com/pbc/v1/cache'
         }
 });
-{% endhighlight %}
+```
 
 {: .alert.alert-warning :}
 The endpoint URL provided must be a Prebid Cache or be otherwise compatible with the [Prebid Cache interface](https://github.com/prebid/prebid-cache).
 
 As of Prebid.js 4.28, you can specify the `ignoreBidderCacheKey` option:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
         cache: {
             url: 'https://my-pbs.example.com/cache',
-	    ignoreBidderCacheKey: true
+            ignoreBidderCacheKey: true
         }
 });
-{% endhighlight %}
+```
 
 As of Prebid.js 2.36, you can track client-side cached VAST XML. This functionality is useful for publishers who want to allow their analytics provider to measure video impressions. The prerequisite to using this feature is the availability of a Prebid Server that supports:
 
-- the /vtrack endpoint
-- an analytics module with connection to an analytics system that supports joining the impression event to the original auction request on the bidid
-- the ability of a publisher to utilize the feature (if account-level permission is enabled)
+* the /vtrack endpoint
+* an analytics module with connection to an analytics system that supports joining the impression event to the original auction request on the bidid
+* the ability of a publisher to utilize the feature (if account-level permission is enabled)
 
 Given those conditions, the `vasttrack` flag can be specified:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
         cache: {
             url: 'https://my-pbs.example.com/vtrack',
             vasttrack: true
         }
 });
-{% endhighlight %}
+```
 
 Setting the `vasttrack` parameter to `true` supplies the POST made to the `/vtrack`
 Prebid Server endpoint with a couple of additional parameters needed
@@ -1254,7 +1257,7 @@ by the analytics system to join the event to the original auction request.
 
 Optionally, `batchSize` and `batchTimeout` can be utlilized as illustrated with the example below:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
         cache: {
             url: 'https://prebid.adnxs.com/pbc/v1/cache',
@@ -1262,16 +1265,17 @@ pbjs.setConfig({
             batchTimeout: 50
         }
 });
-{% endhighlight %}
+```
 
 The example above states that a timer will be initialized and wait up to 50ms for 4 responses to have been collected and then will fire off one batch video cache request for all 4 responses. Note that the batch request will be made when the specified `batchSize` number is reached or with the number of responses that could be collected within the timeframe specified by the value for `batchTimeout`.
 
 If a batchSize is set to 2 and 5 video responses arrive (within the timeframe specified by `batchTimeout`), then three batch requests in total will be made:
+
 1. Batch 1 will contain cache requests for 2 videos
 2. Batch 2 will contain cache requests for 2 videos
 3. Batch 3 will contain cache requests for 1 video
 
-<a name="setConfig-instream-tracking" />
+<a name="setConfig-instream-tracking"></a>
 
 #### Instream tracking
 
@@ -1289,26 +1293,26 @@ This configuration will allow Analytics Adapters and Bid Adapters to track `BID_
 | `instreamTracking.pollingFreq` | Optional | Integer |The frequency of polling. Default: `500`ms |
 | `instreamTracking.urlPattern` | Optional | RegExp | Regex for cache url patterns, to avoid false positives. |
 
-#### Example
+#### Instream Tracking Example
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
         'instreamTracking': {
             enabled: true,
         }
 });
-{% endhighlight %}
+```
 
 More examples [here](/dev-docs/modules/instreamTracking.html#example-with-urlpattern).
 
-<a name="setConfig-site" />
+<a name="setConfig-site"></a>
 
 #### Site Configuration
 
 Adapters, including Prebid Server adapters, can support taking site parameters like language.
 Just set the `ortb2.site` object as First Party Data to make it available to client- and server-side adapters.
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
   ortb2: {
     site: {
@@ -1318,12 +1322,12 @@ pbjs.setConfig({
     }
   }
 });
-{% endhighlight %}
+```
 
 {: .alert.alert-warning :}
 In PBJS 4.29 and earlier, don't add the `ortb2` level here -- just `site` directly. Oh, and please upgrade. 4.29 was a long time ago.
 
-<a name="setConfig-auctionOptions" />
+<a name="setConfig-auctionOptions"></a>
 
 #### Auction Options
 
@@ -1336,47 +1340,51 @@ The `auctionOptions` object controls aspects related to auctions.
 | `suppressStaleRender` | Optional | Boolean | When true, prevents `banner` bids from being rendered more than once. It should only be enabled after auto-refreshing is implemented correctly.  Default is false.
 
 ##### Examples
-Exclude status of bidder _doNotWaitForMe_ when checking auction completion.
-{% highlight js %}
+
+Exclude status of bidder *doNotWaitForMe* when checking auction completion.
+
+```javascript
 pbjs.setConfig({
     'auctionOptions': {
         'secondaryBidders': ['doNotWaitForMe']
     }
 });
-{% endhighlight %}
+```
 
 Render winning bids only once.
-{% highlight js %}
+
+```javascript
 pbjs.setConfig({
     'auctionOptions': {
         'suppressStaleRender': true
     }
 });
-{% endhighlight %}
+```
 
 ##### More on Stale Rendering
+
 When auto-refreshing is done incorrectly, it could cause the same bids to be rendered repeatedly. For instance, when googletag.pubads.refresh() is called directly without removing the PBJS targeting, the same hb_ variables get re-sent to GAM, re-chosen, and re-rendered. Over and over without ever asking PBJS for updated targeting variables.
 
 PBJS performs following actions when stale rendering is detected.
+
 * Log a warning in the browser console if pbjs_debug=true.
 * Emit a `STALE_RENDER` event before `BID_WON` event.
 
 Stale winning bids will continue to be rendered unless `suppressStaleRender` is set to true.  Events including `STALE_RENDER` and `BID_WON` are unaffected by this option.
 
-
-<a name="setConfig-maxNestedIframes" />
+<a name="setConfig-maxNestedIframes"></a>
 
 #### maxNestedIframes
 
 Prebid.js will loop upward through nested iframes to find the top-most referrer. This setting limits how many iterations it will attempt before giving up and not setting referrer.
 
-```
+```javascript
 pbjs.setConfig({
     maxNestedIframes: 5   // default is 10
 });
 ```
 
-<a name="setConfig-realTimeData" />
+<a name="setConfig-realTimeData"></a>
 
 #### Real-Time Data Modules
 
@@ -1386,22 +1394,22 @@ RTD modules, define an overall amount of time they're willing to wait for
 results, and even flag some of the modules as being more "important"
 than others.
 
-```
+```javascript
 pbjs.setConfig({
-    ...,
+    // ...,
     realTimeData: {
       auctionDelay: 100,     // REQUIRED: applies to all RTD modules
       dataProviders: [{
           name: "RTD-MODULE-1",
           waitForIt: true,   // OPTIONAL: flag this module as important
           params: {
-	    ... module-specific parameters ...
+            // ... module-specific parameters ...
           }
       },{
           name: "RTD-MODULE-2",
           waitForIt: false,   // OPTIONAL: flag this module as less important
           params: {
-	    ... module-specific parameters ...
+            //... module-specific parameters ...
           }
       }]
     }
@@ -1428,18 +1436,17 @@ Some publishers carefully manage these precious milliseconds, balancing impact
 of the real-time data with the revenue loss from auction delay.
 
 Notes:
-- The only time `waitForIt` means anything is if some modules are flagged as true and others as false. If all modules are the same (true or false), it has no effect.
-- Likewise, `waitForIt` doesn't mean anything without an auctionDelay specified.
 
+* The only time `waitForIt` means anything is if some modules are flagged as true and others as false. If all modules are the same (true or false), it has no effect.
+* Likewise, `waitForIt` doesn't mean anything without an auctionDelay specified.
 
-
-<a name="setConfig-topicsIframeConfig" />
+<a name="setConfig-topicsIframeConfig"></a>
 
 #### Topics Iframe Configuration
 
 Topics iframe implementation is the enhancements of existing module under topicsFpdModule.js where different bidders will call the topic API under their domain to fetch the topics for respective domain and the segment data will be part of ORTB request under user.data object. Default config is maintained in the module itself. Below are the configuration which can be used to configure and override the default config maintained in the module.
 
-```
+```javascript
 pbjs.setConfig({
     userSync: {
         ...,
@@ -1474,53 +1481,55 @@ pbjs.setConfig({
 | topics.bidders[].iframeURL | yes | string  | URL which is hosted on bidder/SSP/third-party domains which will call Topics API.  |
 | topics.bidders[].expiry | no | integer  | Max number of days where Topics data will be persist. If Data is stored for more than mentioned expiry day, it will be deleted from storage. Default is 21 days which is hardcoded in Module. |
 
+<a id="setConfig-performanceMetrics"></a>
 
-<a id="setConfig-performanceMetrics" />
 #### Disable performance metrics
 
-Since version 7.17, Prebid collects fine-grained performance metrics and attaches them to several events for the purpose of analytics. If you find that this generates too much data for your analytics provider you may disable this feature with: 
+Since version 7.17, Prebid collects fine-grained performance metrics and attaches them to several events for the purpose of analytics. If you find that this generates too much data for your analytics provider you may disable this feature with:
 
-```
+```javascript
 pbjs.setConfig({performanceMetrics: false})
 ```
 
-<a id="setConfig-aliasRegistry" />
+<a id="setConfig-aliasRegistry"></a>
+
 #### Setting alias registry to private
 
 The alias registry is made public by default during an auction.  It can be referenced in the following way:
 
-```
+```javascript
 pbjs.aliasRegistry or pbjs.aliasRegistry[aliasName];
 ```
 
-Inversely, if you wish for the alias registry to be private you can do so by using the option below (causing `pbjs.aliasRegistry` to return undefined): 
+Inversely, if you wish for the alias registry to be private you can do so by using the option below (causing `pbjs.aliasRegistry` to return undefined):
 
-```
+```javascript
 pbjs.setConfig({aliasRegistry: 'private'})
 ```
 
-<a name="setConfig-Generic-Configuration" />
+<a name="setConfig-Generic-Configuration"></a>
+
 #### Generic setConfig Configuration
 
 Some adapters may support other options, as defined in their documentation. To set arbitrary configuration values:
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({ <key>: <value> });
-{% endhighlight %}
+```
 
-<a name="setConfig-Troubleshooting-your-configuration" />
+<a name="setConfig-Troubleshooting-your-configuration"></a>
 
 #### Troubleshooting your configuration
 
 Towards catching syntax errors, one tip is to call `pbjs.setConfig` without an object, e.g.,
 
-{% highlight js %}
-pbjs.setConfig('debug', 'true'));
-{% endhighlight %}
+```javascript
+pbjs.setConfig('debug', 'true');
+```
 
 then Prebid.js will print an error to the console that says:
 
-```
+```noformat
 ERROR: setConfig options must be an object
 ```
 
@@ -1530,4 +1539,4 @@ If you don't see that message, you can assume the config object is valid.
 
 ## Related Reading
 
-- [Prebid.js and Ad Server Key Values](/features/adServerKvps.html)
+* [Prebid.js and Ad Server Key Values](/features/adServerKvps.html)

--- a/dev-docs/publisher-api-reference/setTargetingForAst.md
+++ b/dev-docs/publisher-api-reference/setTargetingForAst.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.setTargetingForAst(adUnitCode)
-description:
+description: setTargetingForAst API
 sidebarType: 1
 ---
 

--- a/dev-docs/publisher-api-reference/setTargetingForGPTAsync.md
+++ b/dev-docs/publisher-api-reference/setTargetingForGPTAsync.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.setTargetingForGPTAsync([codeArr], customSlotMatching)
-description:
+description: setTargetingForGPTAsync API
 sidebarType: 1
 ---
 
@@ -20,6 +20,7 @@ This function matches AdUnits that have returned from the auction to a GPT ad sl
 targeting attributes to the slot so they get sent to GAM.
 
 Here's how it works:
+
 1. For each AdUnit code that's returned from auction or is specified in the `codeArr` parameter:
 2. For each GPT ad slot on the page:
 3. If the `customSlotMatching` function is defined, call it. Else, try to match the AdUnit `code` with the GPT slot name. Else try to match the AdUnit `code` with the ID of the HTML div containing the slot.
@@ -34,7 +35,7 @@ the ad results should render into. This could be useful on long-scrolling pages.
 short to make sure they get good viewability, the logic can find an appropriate placement for the auction
 result depending on where the user is once the auction completes.
 
-```
+```javascript
 // returns a filter function that matches either with the slot or the adUnitCode
 // this filter function is being invoked after the auction has completed
 // this means that it can be used in order to place this within viewport instead of a static div naming

--- a/dev-docs/publisher-api-reference/triggerBilling.md
+++ b/dev-docs/publisher-api-reference/triggerBilling.md
@@ -1,7 +1,7 @@
 ---
 layout: api_prebidjs
 title: pbjs.triggerBilling
-description:
+description: triggerBilling API
 sidebarType: 1
 ---
 
@@ -20,7 +20,7 @@ See below for an example of how triggerBilling can be used:
 {: .alert.alert-warning :}
 Note: The logic to decide when to invoke `pbjs.triggerBilling` is open-ended. One common use case could be to listen for an "on view" event emitted from your ad server.<br><br>For instance, the example below listens for GPT's "impressionViewable" event to determine if a deferred ad unit has become visible and is therefore ready for billing.  The utilized approach to determine when to invoke `pbjs.triggerBilling` should be customized to your specific needs (For more on GPT's "impressionViewable" event, see: [https://developers.google.com/publisher-tag/reference#googletag.events.impressionviewableevent](https://developers.google.com/publisher-tag/reference#googletag.events.impressionviewableevent)).<br><br>Additionally, the example below takes into account the possibility of multiple deferred ad units being present on a page that could potentially invoke the triggerBilling function (see the "deferredAdUnitIds" variable in the snippet below).  The amount of deferred ad units needed on a page are dependent on your needs and could vary.
 
-{% highlight js %}
+```javascript
 ...
 
 var adUnits = [
@@ -74,6 +74,6 @@ function sendAdserverRequest(bids, timedOut, auctionId) {
 
 ...
 
-{% endhighlight %}
+```
 
 <hr class="full-rule" />

--- a/dev-docs/release-notes.md
+++ b/dev-docs/release-notes.md
@@ -7,6 +7,7 @@ description: Release Notes
 <div class="bs-docs-section" markdown="1">
 
 # Release Notes
+
 {:.no_toc}
 
 This page has links to release notes for each of the projects associated with Prebid.org.

--- a/dev-docs/show-multi-format-ads.md
+++ b/dev-docs/show-multi-format-ads.md
@@ -10,15 +10,16 @@ sidebarType: 1
 ---
 
 # Show Multi-Format Ads with Prebid.js
+
 {: .no_toc }
 
 This page has instructions for showing multi-format ads using Prebid.js.
 
 An ad unit is said to be multi-format if it supports at least two of the following media types:
 
-+ Banner
-+ Native
-+ Video
+* Banner
+* Native
+* Video
 
 Once declared, any bidder that supports at least one of the media types can participate in the auction for that ad unit.
 
@@ -26,6 +27,7 @@ Once declared, any bidder that supports at least one of the media types can part
 For ad ops setup instructions, see [Google Ad Manager with Prebid Step by Step](/adops/step-by-step.html).
 
 * TOC
+
 {:toc}
 
 ## How Multi-Format Ads Work
@@ -40,7 +42,7 @@ At a high level, Prebid.js supports multi-format ads as follows:
 
 The following key is added to your ad server targeting, and set to the value of the bid response's `mediaType` property.
 
-+ `hb_format`
+* `hb_format`
 
 The ad ops team will reference this key in the ad server to set targeting.  For ad ops setup instructions, see [Google Ad Manager with Prebid Step by Step](/adops/step-by-step.html).
 
@@ -48,7 +50,7 @@ The ad ops team will reference this key in the ad server to set targeting.  For 
 
 Keep the following prerequisites in mind during the implementation:
 
-+ Make sure to work with bidders that support demand for the media types you want, particularly native and video.  To see which bidders have native and/or video demand, see [Bidders with Video and Native Demand]({{site.baseurl}}/dev-docs/bidders.html#bidders-with-video-and-native-demand).
+* Make sure to work with bidders that support demand for the media types you want, particularly native and video.  To see which bidders have native and/or video demand, see [Bidders with Video and Native Demand]({{site.baseurl}}/dev-docs/bidders.html#bidders-with-video-and-native-demand).
 
 ## Implementation
 
@@ -59,55 +61,54 @@ This section describes the implementation using code samples, but ignores some o
 The ad unit below supports the banner, native, and video media types.
 
 ```javascript
-
-    pbjs.addAdUnits({
-        code: 'div-banner-outstream-native',
-        mediaTypes: {
-            banner: {
-                sizes: [
-                    [300, 250],
-                    [300, 50]
-                ]
-            },
-            native: {
-                image: {
-                    sizes: [300, 250]
-                }
-            },
-            video: {
-                context: 'outstream',
-                playerSize: [640, 480],
-                mimes: ['video/mp4'],
-                protocols: [1, 2, 3, 4, 5, 6, 7, 8],
-                playbackmethod: [2],
-                skip: 1
-            },
+pbjs.addAdUnits({
+    code: 'div-banner-outstream-native',
+    mediaTypes: {
+        banner: {
+            sizes: [
+                [300, 250],
+                [300, 50]
+            ]
         },
-        bids: [
+        native: {
+            image: {
+                sizes: [300, 250]
+            }
+        },
+        video: {
+            context: 'outstream',
+            playerSize: [640, 480],
+            mimes: ['video/mp4'],
+            protocols: [1, 2, 3, 4, 5, 6, 7, 8],
+            playbackmethod: [2],
+            skip: 1
+        },
+    },
+    bids: [
 
-            {
-                bidder: 'bannerBidder',
-                params: {
-                    placementId: '481'
-                }
-            },
+        {
+            bidder: 'bannerBidder',
+            params: {
+                placementId: '481'
+            }
+        },
 
-            {
-                bidder: 'nativeBidder',
-                params: {
-                    titleAsset: '516'
-                }
-            },
+        {
+            bidder: 'nativeBidder',
+            params: {
+                titleAsset: '516'
+            }
+        },
 
-            {
-                bidder: 'videoBidder',
-                params: {
-                    vidId: '234'
-                }
-            },
+        {
+            bidder: 'videoBidder',
+            params: {
+                vidId: '234'
+            }
+        },
 
-        ]
-    });
+    ]
+});
 ```
 
 ### 2. Add your tag to the page body
@@ -115,20 +116,20 @@ The ad unit below supports the banner, native, and video media types.
 Add a tag like the following to your page.  Depending on who wins the auction, a banner, outstream, or native ad should serve.
 
 ```html
-    <div id='div-banner-outstream-native'>
-        <p>No response</p>
-        <script type='text/javascript'>
-            googletag.cmd.push(function () {
-                googletag.display('div-banner-outstream-native');
-            });
-        </script>
-    </div>
+<div id='div-banner-outstream-native'>
+    <p>No response</p>
+    <script type='text/javascript'>
+        googletag.cmd.push(function () {
+            googletag.display('div-banner-outstream-native');
+        });
+    </script>
+</div>
 ```
 
 ## Working Examples
 
-+ [Multi-Format Example](/dev-docs/examples/multi-format-example.html)
+* [Multi-Format Example](/dev-docs/examples/multi-format-example.html)
 
 ## Further Reading
 
-- [Google Ad Manager with Prebid Step by Step](/adops/step-by-step.html)
+* [Google Ad Manager with Prebid Step by Step](/adops/step-by-step.html)

--- a/dev-docs/show-native-ads.md
+++ b/dev-docs/show-native-ads.md
@@ -8,6 +8,7 @@ sidebarType: 1
 ---
 
 # Show Native Ads with Prebid.js
+
 {: .no_toc }
 
 {% capture change-notice %}
@@ -40,17 +41,17 @@ At a high level, Prebid.js' support for native ads works like this:
 
 The native ad responses get placed on specific keys that are sent into your ad server. For example:
 
-+ `hb_native_title`
-+ `hb_native_body`
-+ `hb_native_body2`
-+ `hb_native_brand`
-+ `hb_native_image`
-+ `hb_native_icon`
-+ `hb_native_linkurl`
-+ `hb_native_privacy`
-+ `hb_native_privicon`
-+ `hb_native_rating`
-+ `hb_native_cta`
+* `hb_native_title`
+* `hb_native_body`
+* `hb_native_body2`
+* `hb_native_brand`
+* `hb_native_image`
+* `hb_native_icon`
+* `hb_native_linkurl`
+* `hb_native_privacy`
+* `hb_native_privicon`
+* `hb_native_rating`
+* `hb_native_cta`
 
 Note that these keys correspond directly to the `mediaTypes.native` object you define in your ad unit (which is [described in more detail below](#native-ad-keys)).
 
@@ -60,7 +61,7 @@ The ad ops team will then reference these keys in the ad server to set up the ti
 
 Keep the following prerequisites in mind during the implementation:
 
-+ Make sure to work with native-enabled bidders. To see which bidders have native demand, see [Bidders with Video and Native Demand]({{site.baseurl}}/dev-docs/bidders.html#bidders-with-video-and-native-demand).
+* Make sure to work with native-enabled bidders. To see which bidders have native demand, see [Bidders with Video and Native Demand]({{site.baseurl}}/dev-docs/bidders.html#bidders-with-video-and-native-demand).
 
 ## Implementation
 
@@ -70,15 +71,15 @@ This section describes the implementation using code samples, but ignores some o
 
 In this example we'll store the ad slot info in a variable for reference throughout the page.  We use a 1x1 static ad slot size since AppNexus (our demand partner in this example) uses that size for native creatives.
 
-{% highlight js %}
+```javascript
 const slot = {
     code: '/19968336/prebid_native_adunit',
     div: 'div-prebid-native-test-1',
     size: [1, 1],
 };
-{% endhighlight %}
+```
 
-<a name="native-ad-keys" />
+<a name="native-ad-keys"></a>
 
 ### 2. Add native ad units
 
@@ -109,9 +110,9 @@ Each key's value is an object with several fields.  Most important is the `requi
   </p>
 </div>
 
-<a name="native-object" />
+<a name="native-object"></a>
 
-{% highlight js %}
+```javascript
 
 pbjs.addAdUnits({
     code: slot.code,
@@ -151,7 +152,7 @@ pbjs.addAdUnits({
     }, ]
 })
 
-{% endhighlight %}
+```
 
 {: .alert.alert-danger :}
 For each native ad unit, all of the bidders within that ad unit must have declared native support in their adapter if you want ads to appear.  If there are any bidders without native support in a native ad unit, requests will not be made to those bidders.  For a list of bidders with native support, see [Bidders with Video and Native Demand]({{site.baseurl}}/dev-docs/bidders.html#bidders-with-video-and-native-demand).
@@ -164,16 +165,16 @@ For now there is only the `image` type, but more will be added.
 
 The image native ad type implies the following required fields:
 
-+ image
-+ title
-+ sponsoredBy
-+ clickUrl
+* image
+* title
+* sponsoredBy
+* clickUrl
 
 And the following optional fields:
 
-+ body
-+ icon
-+ cta
+* body
+* icon
+* cta
 
 A native "image-type" ad unit can be set up as shown in the following example.
 
@@ -196,9 +197,9 @@ const adUnits = [{
 
 {% include dev-docs/native-image-asset-sizes.md %}
 
-### 3. Add your native ad tag to the page body as usual:
+### 3. Add your native ad tag to the page body as usual
 
-{% highlight html %}
+```html
 <div id="div-prebid-native-test-1">
     <script>
         googletag.cmd.push(function() {
@@ -206,7 +207,7 @@ const adUnits = [{
         });
     </script>
 </div>
-{% endhighlight %}
+```
 
 ## Sending Asset Placeholders
 
@@ -280,8 +281,8 @@ The `native-trk.js` script from `prebid-universal-creative` can replace native p
 
 ## Working Examples
 
-+ [Prebid Native Examples](/dev-docs/examples/native-ad-example.html)
+* [Prebid Native Examples](/dev-docs/examples/native-ad-example.html)
 
 ## Further Reading
 
-+ [GAM Step by Step - Native Creatives](/adops/gam-native.html) (Ad Ops Setup Instructions)
+* [GAM Step by Step - Native Creatives](/adops/gam-native.html) (Ad Ops Setup Instructions)

--- a/dev-docs/show-outstream-video-ads.md
+++ b/dev-docs/show-outstream-video-ads.md
@@ -9,6 +9,7 @@ sidebarType: 4
 <div class="bs-docs-section" markdown="1">
 
 # Show Outstream Video Ads
+
 {: .no_toc}
 
 Unlike instream video ads, which require you to have your own video inventory, Outstream video ads can be shown on any web page, even pages that only have text content.
@@ -24,7 +25,7 @@ There should be no changes required on the ad ops side, since the outstream unit
 
 ## Prerequisites
 
-+ Inclusion of at least one demand adapter that supports the `"video"` media type
+* Inclusion of at least one demand adapter that supports the `"video"` media type
 
 ## Step 1: Set up ad units with the video media type and outstream context
 
@@ -32,8 +33,7 @@ Use the `adUnit.mediaTypes` object to set up your ad units with the `video` medi
 
 For full details on video ad unit parameters, see [Ad Unit Reference for Video]({{site.baseurl}}/dev-docs/adunit-reference.html#adunitmediatypesvideo)
 
-{% highlight js %}
-
+```javascript
 var videoAdUnits = [{
     code: 'video1',
     mediaTypes: {
@@ -54,8 +54,7 @@ var videoAdUnits = [{
         }
     }]
 }];
-
-{% endhighlight %}
+```
 
 ### Renderers
 
@@ -85,10 +84,9 @@ A renderer is an object containing these properties:
 2. `render` -- A function that tells Prebid.js how to invoke the renderer script.
 3. `backupOnly` -- Optional field, if set to true, buyer or adapter renderer will be preferred
 
-
 In a multiFormat adUnit, you might want the renderer to only apply to only one of the mediaTypes.  You can do this by defining the renderer on the media type itself.
-{% highlight js %}
 
+```javascript
 pbjs.addAdUnit({
     code: 'video1',
     // This renderer would apply to all prebid creatives...
@@ -120,12 +118,11 @@ pbjs.addAdUnit({
     },
     ...
 });
-{% endhighlight %}
+```
 
 Some demand partners that return a renderer with their video bid responses may support renderer configuration with the `adUnit.renderer.options` object. These configurations are bidder specific and may include options for skippability, player size, and ad text, for example. An example renderer configuration follows:
 
-{% highlight js %}
-
+```javascript
 pbjs.addAdUnit({
     code: 'video1',
     mediaTypes: {
@@ -145,8 +142,7 @@ pbjs.addAdUnit({
     },
     ...
 });
-
-{% endhighlight %}
+```
 
 For more technical information about renderers, see [the pull request originally adding the 'Renderer' type](https://github.com/prebid/Prebid.js/pull/1082) and [the pull request allowing the 'renderer' type in the mediaType](https://github.com/prebid/Prebid.js/pull/5760).
 
@@ -158,8 +154,7 @@ Invoke your ad server for the outstream adUnit from the body of the page in the 
 
 For a live example, see [Outstream with Google Ad Manager]({{site.github.url}}/examples/video/outstream/pb-ve-outstream-dfp.html).
 
-{% highlight html %}
-
+```html
 <div id='video1'>
     <p>Prebid Outstream Video Ad</p>
     <script type='text/javascript'>
@@ -169,8 +164,7 @@ For a live example, see [Outstream with Google Ad Manager]({{site.github.url}}/e
 
     </script>
 </div>
-
-{% endhighlight %}
+```
 
 ### Option 2: Serving without an ad server
 
@@ -185,8 +179,7 @@ In the Prebid.js event queue, you'll need to add a function that:
     1. Selects the bid that will serve for the appropriate adUnit
     2. Renders the ad
 
-{% highlight js %}
-
+```javascript
 pbjs.que.push(function () {
     pbjs.addAdUnits(videoAdUnits);
     pbjs.requestBids({
@@ -197,20 +190,19 @@ pbjs.que.push(function () {
         }
     });
 });
-
-{% endhighlight %}
+```
 
 For more information, see the API documentation for:
 
-+ [requestBids](/dev-docs/publisher-api-reference/requestBids.html)
-+ [getHighestCpmBids](/dev-docs/publisher-api-reference/getHighestCpmBids.html)
-+ [renderAd](/dev-docs/publisher-api-reference/renderAd.html)
+* [requestBids](/dev-docs/publisher-api-reference/requestBids.html)
+* [getHighestCpmBids](/dev-docs/publisher-api-reference/getHighestCpmBids.html)
+* [renderAd](/dev-docs/publisher-api-reference/renderAd.html)
 
 ## Working Examples
 
 Below, find links to end-to-end "working examples" demonstrating Prebid Outstream:
 
-+ [Outstream with Google Ad Manager]({{site.github.url}}/examples/video/outstream/pb-ve-outstream-dfp.html)
-+ [Outstream without an Ad Server]({{site.github.url}}/examples/video/outstream/pb-ve-outstream-no-server.html)
+* [Outstream with Google Ad Manager]({{site.github.url}}/examples/video/outstream/pb-ve-outstream-dfp.html)
+* [Outstream without an Ad Server]({{site.github.url}}/examples/video/outstream/pb-ve-outstream-no-server.html)
 
 </div>

--- a/dev-docs/show-prebid-ads-on-amp-pages.md
+++ b/dev-docs/show-prebid-ads-on-amp-pages.md
@@ -6,6 +6,7 @@ sidebarType: 2
 ---
 
 # Prebid AMP Implementation Guide
+
 {: .no_toc}
 
 This page has instructions for showing ads on Accelerated Mobile Pages (AMP) using Prebid.js.
@@ -14,11 +15,11 @@ Through this implementation, [Prebid Server][PBS] fetches demand and returns key
 
 For more information about AMP RTC, see:
 
-+ [Prebid Server and AMP](/prebid-server/use-cases/pbs-amp.html)
-+ [Prebid Server AMP Endpoint Technical Documentation](/prebid-server/endpoints/openrtb2/pbs-endpoint-amp.html)
-+ [Prebid Server Stored Bid Requests](https://github.com/prebid/prebid-server/blob/master/docs/developers/stored-requests.md#stored-bidrequests)
-+ [AMP RTC Overview](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/rtc-documentation.md)
-+ [AMP RTC Publisher Integration Guide](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/rtc-publisher-implementation-guide.md)
+* [Prebid Server and AMP](/prebid-server/use-cases/pbs-amp.html)
+* [Prebid Server AMP Endpoint Technical Documentation](/prebid-server/endpoints/openrtb2/pbs-endpoint-amp.html)
+* [Prebid Server Stored Bid Requests](https://github.com/prebid/prebid-server/blob/master/docs/developers/stored-requests.md#stored-bidrequests)
+* [AMP RTC Overview](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/rtc-documentation.md)
+* [AMP RTC Publisher Integration Guide](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/rtc-publisher-implementation-guide.md)
 
 {% capture tipNote %}
 For ad ops setup instructions, see [Google Ad Manager with Prebid Step by Step](/adops/step-by-step.html).
@@ -33,18 +34,18 @@ For ad ops setup instructions, see [Google Ad Manager with Prebid Step by Step](
 
 To set up Prebid to serve ads into your AMP pages, you'll need:
 
-+ An account with a [Prebid Server][PBS] instance
-+ One or more Prebid Server Stored Bid Requests. A Stored Bid Request is a partial OpenRTB JSON request which:
-    + Specifies properties like currency, schain, price granularity, etc.
-    + Contains a list of demand partners and their respective parameters
-+ An AMP page containing at least one amp-ad element for an AMP ad network that supports Fast Fetch and AMP RTC
+* An account with a [Prebid Server][PBS] instance
+* One or more Prebid Server Stored Bid Requests. A Stored Bid Request is a partial OpenRTB JSON request which:
+  * Specifies properties like currency, schain, price granularity, etc.
+  * Contains a list of demand partners and their respective parameters
+* An AMP page containing at least one amp-ad element for an AMP ad network that supports Fast Fetch and AMP RTC
 
 ## Implementation
 
-+ [Prebid Server Stored Request](#prebid-server-stored-request): This is the Prebid Server Stored Bid Request.
-+ [AMP content page](#amp-content-page): This is where your content lives.
-+ [HTML Creative](#html-creative): This is the creative your Ad Ops team puts in your ad server.
-+ [User Sync in AMP](#user-sync): This is the `amp-iframe` pixel that must be added to your AMP page to sync users with Prebid Server.
+* [Prebid Server Stored Request](#prebid-server-stored-request): This is the Prebid Server Stored Bid Request.
+* [AMP content page](#amp-content-page): This is where your content lives.
+* [HTML Creative](#html-creative): This is the creative your Ad Ops team puts in your ad server.
+* [User Sync in AMP](#user-sync): This is the `amp-iframe` pixel that must be added to your AMP page to sync users with Prebid Server.
 
 ### Prebid Server Stored Request
 
@@ -53,15 +54,14 @@ You will have to create at least one Stored Request for Prebid Server.  Valid St
 An example Stored Request is given below. You'll see that the Stored Request contains some important info
 that doesn't come from /amp parameters:
 
-- cur
-- schain
-- ext.prebid.cache.bids - needed to let Prebid Server know that you want it to store the result in PBC
-- ext.prebid.targeting.pricegranularity - needed to let Prebid Server know how to calculate the price bucket
-- ext.prebid.aliases
-- bidders and their parameters
+* cur
+* schain
+* ext.prebid.cache.bids - needed to let Prebid Server know that you want it to store the result in PBC
+* ext.prebid.targeting.pricegranularity - needed to let Prebid Server know how to calculate the price bucket
+* ext.prebid.aliases
+* bidders and their parameters
 
-```html
-
+```json
 {
     "id": "some-request-id",
     "cur": ["USD"],
@@ -114,25 +114,28 @@ that doesn't come from /amp parameters:
     }]
 }
 ```
+
 This basic OpenRTB record will be enhanced by the parameters from the call to the [/amp endpoint](/prebid-server/endpoints/openrtb2/pbs-endpoint-amp.html).
 
 ### AMP content page
 
 First ensure that the amp-ad component is imported in the header.
 
-```
+```html
 <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
 ```
+
 This script provides code libraries that will convert `<amp-ad>` properties to the endpoint query parameters usint the [Real Time Config](https://github.com/ampproject/amphtml/blob/main/extensions/amp-a4a/rtc-documentation.md) (RTC) protocol.
 
 The `amp-ad` elements in the page body need to be set up as shown below, especially the following attributes:
 
-+ `data-slot`: Identifies the ad slot for the auction.
-+ `rtc-config`: Used to pass JSON configuration data to [Prebid Server][PBS], which handles the communication with AMP RTC.
-    + `vendors` is an object that defines any vendors that will be receiving RTC callouts (including Prebid Server) up to a maximum of five.  The list of supported RTC vendors is maintained in [callout-vendors.js](https://github.com/ampproject/amphtml/blob/master/src/service/real-time-config/callout-vendors.js). We recommend working with your Prebid Server hosting company to set up which bidders and parameters should be involved for each AMP ad unit.
-    + `timeoutMillis` is an optional integer that defines the timeout in milliseconds for each individual RTC callout.  The configured timeout must be greater than 0 and less than 1000ms.  If omitted, the timeout value defaults to 1000ms.
+* `data-slot`: Identifies the ad slot for the auction.
+* `rtc-config`: Used to pass JSON configuration data to [Prebid Server][PBS], which handles the communication with AMP RTC.
+  * `vendors` is an object that defines any vendors that will be receiving RTC callouts (including Prebid Server) up to a maximum of five.  The list of supported RTC vendors is maintained in [callout-vendors.js](https://github.com/ampproject/amphtml/blob/master/src/service/real-time-config/callout-vendors.js). We recommend working with your Prebid Server hosting company to set up which bidders and parameters should be involved for each AMP ad unit.
+  * `timeoutMillis` is an optional integer that defines the timeout in milliseconds for each individual RTC callout.  The configured timeout must be greater than 0 and less than 1000ms.  If omitted, the timeout value defaults to 1000ms.
 
 e.g. for the AppNexus cluster of Prebid Servers:
+
 ```html
 <amp-ad width="300" height="250"
     type="doubleclick"
@@ -142,6 +145,7 @@ e.g. for the AppNexus cluster of Prebid Servers:
 ```
 
 e.g. for Rubicon Project's cluster of Prebid Servers:
+
 ```html
 <amp-ad width="300" height="250"
     type="doubleclick"
@@ -151,6 +155,7 @@ e.g. for Rubicon Project's cluster of Prebid Servers:
 ```
 
 For other hosts, you can specify the URL directly rather than using one of the convenient vendor aliases. e.g.
+
 ```html
 <amp-ad width="300" height="250"
     type="doubleclick"
@@ -172,7 +177,6 @@ You can always get the latest version of the creative code below from [the AMP e
 For Google Ad Manager:
 
 ```html
-
 <script src="https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/%%PATTERN:hb_format%%.js"></script>
 <script>
   var ucTagData = {};
@@ -193,7 +197,6 @@ For Google Ad Manager:
 For all other ad servers:
 
 ```html
-
 <script src="https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/%%MACRO:hb_format%%.js"></script>
 <script>
   var ucTagData = {};
@@ -213,7 +216,6 @@ For all other ad servers:
     console.log(e);
   }
 </script>
-
 ```
 
 Replace `MACRO` in the preceding example with the appropriate macro for the ad server. (Refer to your ad server's documentation or consult with a representative for specific details regarding the proper macros and how to use them.)
@@ -225,11 +227,13 @@ To sync user IDs with Prebid Server, the `amp-iframe` below may be added to your
 Note that AMP constrains syncing as described in the [amp-iframe](https://amp.dev/documentation/components/amp-iframe) documentation. You may only have *one* amp-iframe on your page that is small, e.g. 1x1. Many publishers already have some kind of analytics or tracking frame on their page, so they may find it difficult to manage this. Several hacks are possible, including building a 'frankenstein' script that combines all of your required tracking into one or tying the sync to an image that's large enough to be visible.
 
 Notes:
-- The following examples include a transparent image as a placeholder which will allow you to place the example at the top within the HTML body. If this is not included the iFrame must be either 600px away from the top or not within the first 75% of the viewport when scrolled to the top – whichever is smaller. For more information on this, see [amp-iframe](https://amp.dev/documentation/components/amp-iframe/)
-- Note that the `sandbox` parameter to the amp-iframe must include both "allow-scripts" and "allow-same-origin".
-- The load-cookie-with-consent.html file has the same argument syntax as load-cookie.html. It's a different file because it's larger and depends on the existence of an AMP Consent Management Platform.
+
+* The following examples include a transparent image as a placeholder which will allow you to place the example at the top within the HTML body. If this is not included the iFrame must be either 600px away from the top or not within the first 75% of the viewport when scrolled to the top – whichever is smaller. For more information on this, see [amp-iframe](https://amp.dev/documentation/components/amp-iframe/)
+* Note that the `sandbox` parameter to the amp-iframe must include both "allow-scripts" and "allow-same-origin".
+* The load-cookie-with-consent.html file has the same argument syntax as load-cookie.html. It's a different file because it's larger and depends on the existence of an AMP Consent Management Platform.
 
 If you're using AppNexus' managed service, you would enter something like this:
+
 ```html
 <amp-iframe width="1" title="User Sync"
   height="1"
@@ -241,6 +245,7 @@ If you're using AppNexus' managed service, you would enter something like this:
 ```
 
 If you are utilizing Magnite's managed service, there's an extra `args` parameter:
+
 ```html
 <amp-iframe width="1" title="User Sync"
   height="1"
@@ -252,6 +257,7 @@ If you are utilizing Magnite's managed service, there's an extra `args` paramete
 ```
 
 Or you can specify a full URL to another Prebid Server location (including a QA site) by setting `endpoint` to a URL-encoded string. e.g.
+
 ```html
 <amp-iframe width="1" title="User Sync"
   height="1"
@@ -267,35 +273,39 @@ See [manually initiating a sync](/prebid-server/developers/pbs-cookie-sync.html#
 ### AMP RTC
 
 If you're using a custom RTC callout rather than one of the pre-defined [vendor callouts](https://github.com/ampproject/amphtml/blob/main/src/service/real-time-config/callout-vendors.js), here are the parameters that can be passed through the RTC string:
-- tag_id (this correspondes to the Prebid Server stored request ID)
-- w=ATTR(width)
-- h=ATTR(height)
-- ow=ATTR(data-override-width)
-- oh=ATTR(data-override-height)
-- ms=ATTR(data-multi-size)
-- slot=ATTR(data-slot)
-- targeting=TGT
-- curl=CANONICAL_URL
-- timeout=TIMEOUT
-- adc=ADCID
-- purl=HREF
-- gdpr_consent=CONSENT_STRING
-- consent_type=CONSENT_METADATA(consentStringType)
-- gdpr_applies=CONSENT_METADATA(gdprApplies)
-- attl_consent=CONSENT_METADATA(additionalConsent)
+
+* tag_id (this correspondes to the Prebid Server stored request ID)
+* w=ATTR(width)
+* h=ATTR(height)
+* ow=ATTR(data-override-width)
+* oh=ATTR(data-override-height)
+* ms=ATTR(data-multi-size)
+* slot=ATTR(data-slot)
+* targeting=TGT
+* curl=CANONICAL_URL
+* timeout=TIMEOUT
+* adc=ADCID
+* purl=HREF
+* gdpr_consent=CONSENT_STRING
+* consent_type=CONSENT_METADATA(consentStringType)
+* gdpr_applies=CONSENT_METADATA(gdprApplies)
+* attl_consent=CONSENT_METADATA(additionalConsent)
 
 ## Debugging Tips
+
 To review that Prebid on AMP is working properly the following aspects can be looked at:
-+ Include `#development=1` to the URL to review AMP specifc debug messages in the browser console.
-+ Look for the Prebid server call in the network panel. You can open this URL in a new tab to view additional debugging information relating to the Prebid Server Stored Bid Request. If working properly, Prebid server will display the targeting JSON for AMP to use.
-+ Look for the network call from the Ad Server to ensure that key values are being passed. (For Google Ad Manager these are in the `scp` query string parameter in the network request)
-+ Most of the debugging information is omitted from the Prebid Server response unless the `debug=1` parameter is present in the Prebid Server query string. AMP won't add this parameter, so you'll need to grab the Prebid Server URL and manually add it to see the additional information provided.
+
+* Include `#development=1` to the URL to review AMP specifc debug messages in the browser console.
+* Look for the Prebid server call in the network panel. You can open this URL in a new tab to view additional debugging information relating to the Prebid Server Stored Bid Request. If working properly, Prebid server will display the targeting JSON for AMP to use.
+* Look for the network call from the Ad Server to ensure that key values are being passed. (For Google Ad Manager these are in the `scp` query string parameter in the network request)
+* Most of the debugging information is omitted from the Prebid Server response unless the `debug=1` parameter is present in the Prebid Server query string. AMP won't add this parameter, so you'll need to grab the Prebid Server URL and manually add it to see the additional information provided.
 
 ## Further Reading
 
-+ [Prebid Server and AMP](/prebid-server/use-cases/pbs-amp.html)
-+ [Google Ad Manager with Prebid Step by Step](/adops/step-by-step.html) (Ad Ops Setup)
-+ [AMP RTC Overview](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/rtc-documentation.md)
+* [Prebid Server and AMP](/prebid-server/use-cases/pbs-amp.html)
+* [Google Ad Manager with Prebid Step by Step](/adops/step-by-step.html) (Ad Ops Setup)
+* [AMP RTC Overview](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/rtc-documentation.md)
+* [callout-vendors.js]
 
 <!-- Reference Links -->
 

--- a/dev-docs/show-video-with-a-dfp-video-tag.md
+++ b/dev-docs/show-video-with-a-dfp-video-tag.md
@@ -8,6 +8,7 @@ sidebarType: 4
 <div class="bs-docs-section" markdown="1">
 
 # Show Video Ads with Google Ad Manager
+
 {: .no_toc}
 
 In this tutorial, we'll show how to set up Prebid to show a video ad
@@ -22,13 +23,13 @@ different video players and video-enabled bidders.
 
 The code example below was built using the following libraries:
 
-+ [video.js](https://videojs.com/) version 5.9.2
-+ MailOnline's [videojs-vast-vpaid plugin](https://github.com/MailOnline/videojs-vast-vpaid) version 2.0.2
+* [video.js](https://videojs.com/) version 5.9.2
+* MailOnline's [videojs-vast-vpaid plugin](https://github.com/MailOnline/videojs-vast-vpaid) version 2.0.2
 
 Also, you need to make sure to build Prebid.js with:
 
-+ Support for at least one video-enabled bidder
-+ Support for the `dfpAdServerVideo` ad server adapter, which will provide the video ad support
+* Support for at least one video-enabled bidder
+* Support for the `dfpAdServerVideo` ad server adapter, which will provide the video ad support
 
 For example, to build with the AppNexus bidder adapter and the Google Ad Manager
 Video ad server adapter, use the following command:
@@ -121,12 +122,12 @@ pbjs.que.push(function() {
 
 The VAST XML has to be cached somewhere because most video players can only work with a URL that returns VAST XML, not VAST directly. Some bidders cache the VAST XML on the server side, while others depend on Prebid.js to perform the caching.
 
-+ In general, video-enabled bidders must supply `bid.videoCacheKey`, `bid.vastXml`, or `bid.vastUrl` on their responses, and can provide any combination of the three.
-+ If `pbjs.setConfig({cache: {URL}})` isn't set and the bidder supplies only `bid.vastXml` in its bid response, [`pbjs.adServers.dfp.buildVideoUrl`](/dev-docs/publisher-api-reference/adServers.dfp.buildVideoUrl.html) will not be able to generate a videoCacheKey, and it will be dropped from the auction.
-+ If `pbjs.setConfig({cache: {URL}})` is defined and the bidder responds with `bid.videoCacheKey`, Prebid.js will not re-cache the VAST XML.
-+ If `options.url` is passed as an argument to [`pbjs.adServers.dfp.buildVideoUrl`](/dev-docs/publisher-api-reference/adServers.dfp.buildVideoUrl.html):
-    + If Prebid Cache is disabled, Prebid sets `description_url` field to the bid response's `bid.vastUrl`.
-    + If Prebid Cache is enabled, Prebid sets `description_url` field to the cache URL.
+* In general, video-enabled bidders must supply `bid.videoCacheKey`, `bid.vastXml`, or `bid.vastUrl` on their responses, and can provide any combination of the three.
+* If `pbjs.setConfig({cache: {URL}})` isn't set and the bidder supplies only `bid.vastXml` in its bid response, [`pbjs.adServers.dfp.buildVideoUrl`](/dev-docs/publisher-api-reference/adServers.dfp.buildVideoUrl.html) will not be able to generate a videoCacheKey, and it will be dropped from the auction.
+* If `pbjs.setConfig({cache: {URL}})` is defined and the bidder responds with `bid.videoCacheKey`, Prebid.js will not re-cache the VAST XML.
+* If `options.url` is passed as an argument to [`pbjs.adServers.dfp.buildVideoUrl`](/dev-docs/publisher-api-reference/adServers.dfp.buildVideoUrl.html):
+  * If Prebid Cache is disabled, Prebid sets `description_url` field to the bid response's `bid.vastUrl`.
+  * If Prebid Cache is enabled, Prebid sets `description_url` field to the cache URL.
 
 #### Notes on multiple video advertisements on one page
 
@@ -195,19 +196,20 @@ If you have [set up your ad server line items and creatives correctly]({{site.ba
 Below, find links to end-to-end "working examples" integrating Prebid.js demand with various video players:
 
 ### Using client-side adapters
-+ [Akamai AMP]({{site.github.url}}/examples/video/instream/akamai/pb-ve-amp.html)
-+ [Brid]({{site.github.url}}/examples/video/instream/brid/pb-ve-brid.html)
-+ [Brightcove]({{site.github.url}}/examples/video/instream/brightcove/pb-ve-brightcove.html)
-+ [Flowplayer]({{site.github.url}}/examples/video/instream/flowplayer/pb-ve-flowplayer.html)
-+ [JWPlayer - Platform]({{site.github.url}}/examples/video/instream/jwplayer/pb-ve-jwplayer-platform.html)
-+ [JWPlayer - Hosted]({{site.github.url}}/examples/video/instream/jwplayer/pb-ve-jwplayer-hosted.html)
-+ [Kaltura]({{site.github.url}}/examples/video/instream/kaltura/pb-ve-kaltura.html)
-+ [Ooyala]({{site.github.url}}/examples/video/instream/ooyala/pb-ve-ooyala.html)
-+ [VideoJS]({{site.github.url}}/examples/video/instream/videojs/pb-ve-videojs.html)
-+ [Instream and Banner Mixed](/dev-docs/examples/instream-banner-mix.html)
+
+* [Akamai AMP]({{site.github.url}}/examples/video/instream/akamai/pb-ve-amp.html)
+* [Brid]({{site.github.url}}/examples/video/instream/brid/pb-ve-brid.html)
+* [Brightcove]({{site.github.url}}/examples/video/instream/brightcove/pb-ve-brightcove.html)
+* [Flowplayer]({{site.github.url}}/examples/video/instream/flowplayer/pb-ve-flowplayer.html)
+* [JWPlayer - Platform]({{site.github.url}}/examples/video/instream/jwplayer/pb-ve-jwplayer-platform.html)
+* [JWPlayer - Hosted]({{site.github.url}}/examples/video/instream/jwplayer/pb-ve-jwplayer-hosted.html)
+* [Kaltura]({{site.github.url}}/examples/video/instream/kaltura/pb-ve-kaltura.html)
+* [Ooyala]({{site.github.url}}/examples/video/instream/ooyala/pb-ve-ooyala.html)
+* [VideoJS]({{site.github.url}}/examples/video/instream/videojs/pb-ve-videojs.html)
+* [Instream and Banner Mixed](/dev-docs/examples/instream-banner-mix.html)
 
 ## Related Topics
 
-+ [Setting up Prebid Video in Google Ad Manager]({{site.baseurl}}/adops/setting-up-prebid-video-in-dfp.html)
+* [Setting up Prebid Video in Google Ad Manager]({{site.baseurl}}/adops/setting-up-prebid-video-in-dfp.html)
 
 </div>

--- a/dev-docs/testing-prebid.md
+++ b/dev-docs/testing-prebid.md
@@ -4,14 +4,13 @@ layout: page_v2
 title: Testing Prebid.js
 description: How to write tests for the Prebid.js library
 pid: 199
-
 top_nav_section: dev_docs
-
 ---
 
 <div class="bs-docs-section" markdown="1">
 
 # Testing  Prebid.js
+
 {: .no_toc}
 
 Starting on 21 June 2016, all pull requests to the Prebid.js library will need to include tests with greater than 80% code coverage for any changed/added code before they can be merged into master.
@@ -27,68 +26,67 @@ This page describes how to test code in the Prebid.js repository to help prepare
 
 When you are adding code to Prebid.js, or modifying code that isn't covered by an existing test, test the code according to these guidelines:
 
-- If the module you are working on is already partially tested by a file within the `test` directory, add tests to that file
-- If the module does not have any tests, create a new test file
-- Group tests in a `describe` block
-- Test individual units of code within an `it` block
-- Within an `it` block, it may be helpful to use the "Arrange-Act-Assert" pattern
-  - _Arrange_: set up necessary preconditions and inputs
-    - e.g., creating objects, spies, etc.
-  - _Act_: call or act on the unit under test
-    - e.g., call the function you are testing with the parameters you set up
-  - _Assert_: check that the expected results have occurred
-    - e.g., use Chai assertions to check that the expected output is equal to the actual output
-- Test the public interface, not the internal implementation
-- If using global `pbjs` data structures in your test, take care to not completely overwrite them with your own data as that may affect other tests relying on those structures, e.g.:
-    - **OK**: `pbjs._bidsRequested.push(bidderRequestObject);`
-    - **NOT OK**: `pbjs._bidsRequested = [bidderRequestObject];`
-- If you need to check `adloader.loadScript` in a test, use a `stub` rather than a `spy`. `spy`s trigger a network call which can result in a `script error` and cause unrelated unit tests to fail. `stub`s will let you gather information about the `adloader.loadScript` call without affecting external resources
-
-- When writing tests you may use ES2015 syntax if desired
+* If the module you are working on is already partially tested by a file within the `test` directory, add tests to that file
+* If the module does not have any tests, create a new test file
+* Group tests in a `describe` block
+* Test individual units of code within an `it` block
+** Within an `it` block, it may be helpful to use the "Arrange-Act-Assert" pattern
+  * _Arrange_: set up necessary preconditions and inputs
+    * e.g., creating objects, spies, etc.
+  * _Act_: call or act on the unit under test
+    * e.g., call the function you are testing with the parameters you set up
+  * _Assert_: check that the expected results have occurred
+    * e.g., use Chai assertions to check that the expected output is equal to the actual output
+* Test the public interface, not the internal implementation
+* If using global `pbjs` data structures in your test, take care to not completely overwrite them with your own data as that may affect other tests relying on those structures, e.g.:
+  * **OK**: `pbjs._bidsRequested.push(bidderRequestObject);`
+  * **NOT OK**: `pbjs._bidsRequested = [bidderRequestObject];`
+* If you need to check `adloader.loadScript` in a test, use a `stub` rather than a `spy`. `spy`s trigger a network call which can result in a `script error` and cause unrelated unit tests to fail. `stub`s will let you gather information about the `adloader.loadScript` call without affecting external resources
+* When writing tests you may use ES2015 syntax if desired
 
 ## Running tests
 
 After checking out the Prebid.js repository and installing dev dependencies with `npm install`, use the following commands to run tests as you are working on code:
 
-- `gulp test` will run the test suite once (`npm test` is aliased to call `gulp test`)
-- `gulp serve` will run tests once and stay open, re-running tests whenever a file in the `src` or `test` directory is modified
+* `gulp test` will run the test suite once (`npm test` is aliased to call `gulp test`)
+* `gulp serve` will run tests once and stay open, re-running tests whenever a file in the `src` or `test` directory is modified
 
 ## Checking results and code coverage
 
 Check the test results using these guidelines:
 
-- Look at the total number of tests run, passed, and failed (shown below the rainbow Nyan Cat in the shell window).
-- If all tests are passing, great.
-- Otherwise look for errors printed in the console for a description of the failing test.
-- You may need to iterate on your code or tests until all tests are passing.
-- Make sure existing tests still pass.
-- There is a table below the testing report that shows code coverage percentage, for each file under the `src` directory.
-- Each time you run tests, a code coverage report is generated in `build/coverage/lcov/lcov-report/index.html`.
-- This is a static HTML page that you can load in your browser.
-- On that page, navigate to the file you are testing to see which lines are being tested.
-- Red indicates that a line isn't covered by a test.
-- Gray indicates a line that doesn't need coverage, such as a comment or blank line.
-- Green indicates a line that is covered by tests.
-- The code you have added or modified must have greater than 80% coverage to be accepted.
+* Look at the total number of tests run, passed, and failed (shown below the rainbow Nyan Cat in the shell window).
+* If all tests are passing, great.
+* Otherwise look for errors printed in the console for a description of the failing test.
+* You may need to iterate on your code or tests until all tests are passing.
+* Make sure existing tests still pass.
+* There is a table below the testing report that shows code coverage percentage, for each file under the `src` directory.
+* Each time you run tests, a code coverage report is generated in `build/coverage/lcov/lcov-report/index.html`.
+* This is a static HTML page that you can load in your browser.
+* On that page, navigate to the file you are testing to see which lines are being tested.
+* Red indicates that a line isn't covered by a test.
+* Gray indicates a line that doesn't need coverage, such as a comment or blank line.
+* Green indicates a line that is covered by tests.
+* The code you have added or modified must have greater than 80% coverage to be accepted.
 
 ## Examples
 
 Prebid.js already has lots of tests. Read them to see how Prebid.js is tested, and for inspiration:
 
-- Look in `test/spec` and its subdirectories
-- Tests for bidder adaptors are located in `test/spec/adapters`
+* Look in `test/spec` and its subdirectories
+* Tests for bidder adaptors are located in `test/spec/adapters`
 
 A test module might have the following general structure:
 
-{% highlight js %}
+```javascript
 
 // Import or require modules necessary for the test, e.g.:
 import { expect } from 'chai';  // may prefer 'assert' in place of 'expect'
-import adapter from 'src/adapters/<adapter>';
+import adapter from 'src/adapters/[adapter]';
 
-describe('<Adapter>', () => {
+describe('[Adapter]', () => {
 
-  it('<description of unit or feature being tested>', () => {
+  it('[description of unit or feature being tested]', () => {
     // Arrange - set up preconditions and inputs
     // Act - call or act on the code under test
     // Assert - use chai to check that expected results have occurred
@@ -98,14 +96,14 @@ describe('<Adapter>', () => {
 
 });
 
-{% endhighlight %}
+```
 
 ## Resources
 
 The Prebid.js testing stack contains some of the following tools. It may be helpful to consult their documentation during the testing process.
 
-- [Mocha - test framework](https://mochajs.org/)
-- [Chai - BDD/TDD assertion library](https://chaijs.com/)
-- [Sinon - spy, stub, and mock library](https://sinonjs.org/)
+* [Mocha - test framework](https://mochajs.org/)
+* [Chai - BDD/TDD assertion library](https://chaijs.com/)
+* [Sinon - spy, stub, and mock library](https://sinonjs.org/)
 
 </div>

--- a/dev-docs/troubleshooting-tips.md
+++ b/dev-docs/troubleshooting-tips.md
@@ -11,6 +11,7 @@ sidebarType: 1
 
 
 # Tips for Troubleshooting
+
 {:.no_toc}
 
 Moved to [the PBJS Troubleshooting Guide](/troubleshooting/troubleshooting-guide.html).

--- a/dev-docs/vendor-billing.md
+++ b/dev-docs/vendor-billing.md
@@ -6,6 +6,7 @@ sidebarType: 1
 ---
 
 # Vendor Billing in Prebid.js
+
 {:.no_toc}
 
 Prebid.js now supports a new event type: **Billable Event**. Billable events allow **Real Time Data (RTD)** modules to signal that their system calculated that a billing event occurred. Billable  events are trackable by analytics adapters as well as publishers to track and aggregate billing data.
@@ -16,7 +17,7 @@ In order to emit events, **RTD** modules simply need to utilize the existing Eve
 
 At this time there are limited requirements about the contents of billable events. However, it should be expected that partners who choose to leverage billable events may have unique requirements or implementations that will be documented individually, including adding additional parameters to the events as they see fit.
 
-**Event Payload Parameters**
+### Event Payload Parameters
 
 There are two parameters that emitters of this event must supply. Other parameters may be supplied as desired by the application.
 
@@ -28,28 +29,31 @@ There are two parameters that emitters of this event must supply. Other paramete
 
 For example, a RTD module could emit an event like this:
 
+```javascript
+events.emit(CONSTANTS.EVENTS.BILLABLE_EVENT, {
+  vendor: 'vendorA',
+  billingId: generateUUID(),
+  type: 'ad_request',
+  transactionId: transactionId,
+  auctionId: auctionId
+})
 ```
-    events.emit(CONSTANTS.EVENTS.BILLABLE_EVENT, {
-      vendor: 'vendorA',
-      billingId: generateUUID(),
-      type: 'ad_request',
-      transactionId: transactionId,
-      auctionId: auctionId
-    })
 
 It is expected that vendors will not emit duplicate events.
 
 ## Analytics Adapter Interface
 
 [Analytics Adapters](/dev-docs/integrate-with-the-prebid-analytics-api.html) just listen for the **BILLABLE_EVENT**. It is assumed that analytics adapters and their downstream reporting handles their own tracking of events any validation of the contract between vendors and publishers.
-```
-    switch (eventType) {
-      ...
-      case BILLABLE_EVENT:
-      ...
+
+```javascript
+switch (eventType) {
+  // ...
+  case BILLABLE_EVENT:
+  // ...
 ```
 
 ## Related Reading
+
 - [pbjs.getEvents()](/dev-docs/publisher-api-reference/getEvents.html)
 - [Real Time Data modules](/dev-docs/add-rtd-submodule.html)
 - [Analytics Adapters](/dev-docs/integrate-with-the-prebid-analytics-api.html)

--- a/features/InterstitialAds.md
+++ b/features/InterstitialAds.md
@@ -46,7 +46,7 @@ The Prebid Interstitial flag reflects the OpenRTB standard, specifying it at the
 
 If an attribute is specific to an AdUnit, it can be passed this way:
 
-{% highlight js %}
+```javascript
 pbjs.addAdUnits({
     code: "test-div",
     mediaTypes: {
@@ -61,7 +61,7 @@ pbjs.addAdUnits({
       ... bidders that support interstitials ...
     ]
 });
-{% endhighlight %}
+```
 
 
 
@@ -69,9 +69,9 @@ pbjs.addAdUnits({
 
 To access global data, a Prebid.js bid adapter needs only to retrieve the interstitial flag from the adUnit like this:
 
-{% highlight js %}
+```javascript
 utils.deepAccess(bidRequest.ortb2Imp, 'instl')
-{% endhighlight %}
+```
 
 
 The assumption is that bid adapters will copy the values to the appropriate protocol location for their endpoint.

--- a/features/firstPartyData.md
+++ b/features/firstPartyData.md
@@ -47,7 +47,7 @@ The Prebid First Party Data JSON structure reflects the OpenRTB standard.
 
 Here's how a publisher can let all bid adapters have access
 to first party data that might be useful in ad targeting that's good in PBJS 4.30 and later:
-{% highlight js %}
+```javascript
 pbjs.setConfig({
    ortb2: {
        site: {
@@ -103,7 +103,7 @@ pbjs.setConfig({
         }
     }
 });
-{% endhighlight %}
+```
 
 {: .alert.alert-warning :}
 Note that supplying first party **user** data may require special
@@ -120,7 +120,7 @@ for example in infinite scroll or instream video scenarios where multiple pieces
 
 To support this use case, Prebid version 7 and above accepts auction-specific first-party data as a parameter to `requestBids`. For example: 
 
-{% highlight js %}
+```javascript
 pbjs.requestBids({
     ortb2: {
         site: {
@@ -140,14 +140,14 @@ pbjs.requestBids({
         }
     }
 });
-{% endhighlight %}
+```
 
 
 ### Supplying AdUnit-Specific Data
 
 If an attribute is specific to an AdUnit, it can be passed this way:
 
-{% highlight js %}
+```javascript
 pbjs.addAdUnits({
     code: "test-div",
     mediaTypes: {
@@ -165,12 +165,12 @@ pbjs.addAdUnits({
     },
     ...
 });
-{% endhighlight %}
+```
 
 Another case is [declaring rewarded](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/422eedb76e8730c89dcac75c7427c18cfa10e8c4/2.6.md?plain=1#L993). Here is how one might do that: 
 
 
-{% highlight js %}
+```javascript
 pbjs.addAdUnits({
     code: "test-div-rewarded",
     mediaTypes: {
@@ -189,11 +189,11 @@ pbjs.addAdUnits({
     },
     ...
 });
-{% endhighlight %}
+```
 
 You may also specify adUnit-specific transaction IDs using `ortb2Imp.ext.tid`, and Prebid will use them instead of generating random new ones. This is useful if you are auctioning the same slots through multiple header bidding libraries. Note: you must take care to not re-use the same transaction IDs across different ad units or auctions. Here's a simplified example passing a tid through the [requestBids](/dev-docs/publisher-api-reference/requestBids.html) function:
 
-{% highlight js %}
+```javascript
 const tid = crypto.randomUUID();
 pbjs.requestBids({
    adUnits: [{
@@ -207,7 +207,7 @@ pbjs.requestBids({
    }]
 });
 // reuse `tid` when auctioning `test-div` through some other header bidding wrapper   
-{% endhighlight %}
+```
 
 {: .alert.alert-info :}
 Prebid does not support AdUnit-specific **user** data, nor does it support
@@ -222,7 +222,7 @@ If you're using PBJS version 4.29 or before, replace the following in the exampl
 Use the [`setBidderConfig()`](/dev-docs/publisher-api-reference/setBidderConfig.html) function to supply bidder-specific data. In this example, only bidderA and bidderB will get access to the supplied
 global data.
 
-{% highlight js %}
+```javascript
 pbjs.setBidderConfig({
    bidders: ['bidderA', 'bidderB'],
    config: {
@@ -253,13 +253,13 @@ pbjs.setBidderConfig({ // different bidders can receive different data
      ortb2: { ... }
    }
 });
-{% endhighlight %}
+```
 
 ### Supplying App or DOOH ORTB Objects
 
 Occasionally, an app which embeds a webview might run Prebid.js. In this case, the app object is often specified for OpenRTB, and the site object would be invalid. When this happens, one should specify app.content.data in place of site.content.data. We can also imagine scenarios where billboards or similar displays are running Prebid.js. In the case of a DOOH object existing, both the site object and the app object are considered invalid. 
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
   ortb2: {
     app: {
@@ -301,13 +301,13 @@ pbjs.setConfig({
   }
 )
 
-{% endhighlight %}
+```
 
 ### Supplying OpenRTB Content Data
 OpenRTB `content` object describes specific (mostly audio/video) content information, and it is useful for targeting.
 For website ad, the content object should be defined in `ortb2.site.content`, for non-browser ad, it should be defined in `ortb2.app.content`
 
-{% highlight js %}
+```javascript
 pbjs.setConfig({
     ortb2: {
         site: {
@@ -329,7 +329,7 @@ pbjs.setConfig({
         }
     }
 });
-{% endhighlight %}
+```
 
 ## Segments and Taxonomy
 
@@ -369,11 +369,11 @@ segment taxonomies they support.
 
 Prebid.js bid adapters are supplied global data in the `ortb2` property of [bid requests](/dev-docs/bidder-adaptor.html#building-the-request):
 
-{% highlight js %}
+```javascript
 buildRequests: function(validBidRequests, bidderRequest) {
    const firstPartyData = bidderRequest.ortb2;
 }
-{% endhighlight %}
+```
 
 AdUnit-specific values must be parsed out of the AdUnit object.
 

--- a/overview/analytics.md
+++ b/overview/analytics.md
@@ -16,16 +16,16 @@ Each analytics provider has specific instructions for using their system, but th
 - Create an account with the analytics vendor and obtain the necessary IDs
 - Build Prebid.js package with the vendor's analytics adapter
 
-{% highlight js %}
+```javascript
 gulp bundle --modules=exAnalyticsAdapter,xyzBidAdapter
-{% endhighlight %}
+```
 
 - If required, load analytics JavaScript from vendor directly on the page
 - Call the [`pbjs.enableAnalytics()` function](/dev-docs/publisher-api-reference/enableAnalytics.html)
 
 e.g.
 
-{% highlight js %}
+```javascript
 pbjs.que.push(function() {
   pbjs.enableAnalytics({
     provider: 'NAME',
@@ -34,7 +34,7 @@ pbjs.que.push(function() {
     }
   });
 });
-{% endhighlight %}
+```
 
 ## Analytics Adapters
 

--- a/prebid-video/video-module.md
+++ b/prebid-video/video-module.md
@@ -29,9 +29,9 @@ The Video Module does not load the Video Player source files on the page. The pu
 
 The first step is to include the submodules for the Video Players that you will be integrating with in your build.
 
-{% highlight bash %}
+```bash
 gulp build --modules=jwplayerVideoProvider,bidAdapter1,bidAdapter2
-{% endhighlight %}
+```
 
 The following Video Players are currently supported:
 

--- a/troubleshooting/pbs-troubleshooting.md
+++ b/troubleshooting/pbs-troubleshooting.md
@@ -21,13 +21,13 @@ If you're invoking Prebid Server directly, add one of these parameters to the Op
 - `"test":1`: This will inform bidders that this request should be treated as a test (non-billable), and provides additional debug information in the OpenRTB response.
 - `"ext.prebid.debug":true`: Similar to `test`, but just adds debug info, without declaring the request non-billable.
 
-{% highlight bash %}
+```bash
 POST https://prebid-server.rubiconproject.com/openrtb2/auction
 {
     ...
     "test":1
 }
-{% endhighlight %}
+```
 
 ### Invoked from Prebid.js
 
@@ -37,27 +37,27 @@ If you're invoking Prebid Server from Prebid.js, turn on the OpenRTB `test` flag
 
 2) Add the following `setConfig` to the page to get the same result:
 
-{% highlight bash %}
+```bash
     pbjs.setConfig({"debug":true});
-{% endhighlight %}
+```
 
 3) If instead of ext.prebid.debug you would like to set the OpenRTB 2.5 'test' flag, you can set that using the 'ortb2' approach:
 
-{% highlight bash %}
+```bash
     pbjs.setConfig({
         "ortb2": {
             "test":1
         }
     });
-{% endhighlight %}
+```
 
 ### Invoked from AMP
 
 If you're invoking Prebid Server from AMP, you'll be unable to get debug info from the AMP page. However, you can capture the Prebid Server AMP call and append `&debug=1` to it:
 
-{% highlight bash %}
+```bash
 https://my-prebid-server.com/openrtb2/amp?tag_id=1111111111111&w=300&h=50&...&debug=1
-{% endhighlight %}
+```
 
 ## Stored Responses
 
@@ -85,7 +85,7 @@ A `storedauctionresponse` ID can be specified in `imp[].ext.prebid`. If specifie
 - The impid of the original request is copied through to the response.
 
 So for example, this OpenRTB request:
-{% highlight bash %}
+```bash
 {
   "test":1,
   "tmax":500,
@@ -108,11 +108,11 @@ So for example, this OpenRTB request:
     }
   ]
 }
-{% endhighlight %}
+```
 
 Could result in this response, assuming that the IDs exist in the database table read by Prebid Server:
 
-{% highlight bash %}
+```bash
 {
     "id": "test-auction-id",
     "seatbid": [
@@ -126,7 +126,7 @@ Could result in this response, assuming that the IDs exist in the database table
        }
   ]
 }
-{% endhighlight %}
+```
 
 ## Request Logging
 


### PR DESCRIPTION
## 🏷 Type of documentation

- [x] text edit only (wording, typos)
- [x] bugfix (code examples)

While trying to get docusaurus up and running I noticed that there are a lot of inconsistencies, broken html and wrong code formatting stuff.

I'm using [markdownlint](https://github.com/DavidAnson/markdownlint) to find and fix those issues.
Current command:

```
markdownlint 'dev-docs/**/*.md' --ignore node_modules --disable MD013 MD025 MD033 MD036
```

