### PR TITLE
Add Qortex.AI bidders dev-docs

### DIFF
--- a/dev-docs/bidders/qortex.md
+++ b/dev-docs/bidders/qortex.md
@@ -1,8 +1,8 @@
 ---
 layout: bidder
-title: CatapultX
-description: CatapultX Bidder Adaptor
-biddercode: catapultx
+title: Qortex
+description: Qortex Bidder Adaptor
+biddercode: qortex
 pbjs: true
 pbs: false
 media_types: banner, native, video
@@ -26,5 +26,5 @@ sidebarType: 1
 {: .table .table-bordered .table-striped }
 | Name     | Scope    | Description           | Example                   | Type     |
 |----------|----------|-----------------------|---------------------------|----------|
-| `host`   | required | RTB host              | `'cpm.catapultx.com'`     | `string` |
+| `host`   | required | RTB host              | `'cpm.qortex.com'`        | `string` |
 | `zoneId` | required | Zone Id               | 76156                     | `integer`|


### PR DESCRIPTION
Company name change from 'CatapultX' to 'Qortex' - Updating the bid adapter alias names and host parameters

## 🏷 Type of documentation
- [x] update bid adapter

## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked

https://github.com/prebid/Prebid.js/pull/10056
