### PR TITLE
marking mass as deprecated

### DIFF
--- a/dev-docs/modules/mass.md
+++ b/dev-docs/modules/mass.md
@@ -17,6 +17,9 @@ sidebarType : 1
 
 ## Overview
 
+{: .alert.alert-warning :}
+This module does not exist in PBJS 8.0 or later.
+
 This module enables the MASS protocol for Prebid. To use it, you'll need to
 work with a MASS enabled provider.
 


### PR DESCRIPTION
in response to issue #4535, adding a note that the mass module is not in PBJS 8.0 or later.