### PR TITLE
Fix another batch of linting errors

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -7,11 +7,6 @@ node_modules/
 # Directories which remain to be fixed
 dev-docs/analytics/
 dev-docs/bidders/
-dev-docs/examples/
-dev-docs/modules/
-dev-docs/plugins/
-dev-docs/publisher-api-reference/
-dev-docs/requirements/
 faq/
 examples/
 partners/

--- a/dev-docs/bidders/rubicon.md
+++ b/dev-docs/bidders/rubicon.md
@@ -270,11 +270,11 @@ pbjs.setConfig({
 
 ### Notes
 
-1) There can only be one siteId and zoneId in an AdUnit bid. To get bids on multiple sitesIds or zoneIds, just add more 'rubicon' entries in the bids array.
+1. There can only be one siteId and zoneId in an AdUnit bid. To get bids on multiple sitesIds or zoneIds, just add more 'rubicon' entries in the bids array.
 
 <a name="rubicon-revenue-type"></a>
 
-2) Bids through the Rubicon Project Exchange are by default 'net'.  For certain use cases it is possible for publishers to define a bid as either 'net' or 'gross'.  In either case the Rubicon platform does not signal externally to other systems either bid state.  
+2. Bids through the Rubicon Project Exchange are by default 'net'.  For certain use cases it is possible for publishers to define a bid as either 'net' or 'gross'.  In either case the Rubicon platform does not signal externally to other systems either bid state.  
 
 For Prebid, the Rubicon Project bid adapter reports the revenue type as ‘gross’ by default before 2.35 and ‘net’ by default in 2.35 and later (as the vast majority of accounts are net and all new accounts are net).
 

--- a/dev-docs/faq.md
+++ b/dev-docs/faq.md
@@ -220,10 +220,10 @@ What we know about yield group feature:
 Sometimes the owner of a bid adapter or other kind of module wants to rename their module. However, Prebid considers module renames a
 'breaking change' -- publishers' build processes and pages could break as a result of a renaming, so Prebid's policy on renaming is:
 
-1) Create the new Prebid.js module files (js and md)
-2) If they're basically the same code base, change the old file so that it includes the new file. This prevents duplicate maintenance of code. In general we don't approve modules including each other, but we'll approve it to avoid repetition.
-3) The docs repo should contain both names, with the old name referring to the new name. You can add the "enable_download: false" flag to prevent installations of the old name.
-4) At the next major release the old files may be removed.
+1. Create the new Prebid.js module files (js and md)
+2. If they're basically the same code base, change the old file so that it includes the new file. This prevents duplicate maintenance of code. In general we don't approve modules including each other, but we'll approve it to avoid repetition.
+3. The docs repo should contain both names, with the old name referring to the new name. You can add the "enable_download: false" flag to prevent installations of the old name.
+4. At the next major release the old files may be removed.
 
 ## Does Prebid.js support Amazon TAM?
 

--- a/dev-docs/modules/1plusXRtdProvider.md
+++ b/dev-docs/modules/1plusXRtdProvider.md
@@ -24,13 +24,13 @@ The 1plusX RTD module appends User and Contextual segments to the bidding object
 
 ## Integration
 
-1) Compile the 1plusX RTD Module along with your bid adapter and other modules into your Prebid build:  
+1. Compile the 1plusX RTD Module along with your bid adapter and other modules into your Prebid build:  
 
-```
-gulp build --modules="rtdModule,1plusXRtdProvider,appnexusBidAdapter,..."  
-```
+    ```bash
+    gulp build --modules="rtdModule,1plusXRtdProvider,appnexusBidAdapter,..."  
+    ```
 
-2) Use `setConfig` to instruct Prebid.js to initilize the 1plusX RTD module, as specified below.
+2. Use `setConfig` to instruct Prebid.js to initilize the 1plusX RTD module, as specified below.
 
 ## Configuration
 

--- a/dev-docs/modules/adnuntiusRtdProvider.md
+++ b/dev-docs/modules/adnuntiusRtdProvider.md
@@ -17,9 +17,9 @@ sidebarType: 1
 
 1. Compile the Adnuntius RTD Module and Adnuntius Bid Adapter into your Prebid build:
 
-```
-gulp build --modules="adnuntiusRtdProvider,adnuntiusBidAdapter,..."
-```
+    ```bash
+    gulp build --modules="adnuntiusRtdProvider,adnuntiusBidAdapter,..."
+    ```
 
 2. Use `setConfig` to instruct Prebid.js to initilize the adnuntius module, as specified below.
 

--- a/dev-docs/modules/adpod.md
+++ b/dev-docs/modules/adpod.md
@@ -22,7 +22,7 @@ The adpod module enables developers to add support for a new adserver that handl
 
 There is a flag available for publishers to influence how this module behaves.  This field can be set by adding the following to the Prebid.js configuration:
 
-```
+```javascript
 pbjs.setConfig({
   "adpod": {
     "brandCategoryExclusion": true
@@ -34,7 +34,7 @@ When this setting is enabled, it requires the bidder to include a brand category
 
 Below is an example of the targeting key's value with the setting enabled (where `123` is the category id):
 
-```
+```javascript
 '10.00_123_10s'
 ```
 
@@ -42,7 +42,7 @@ When the setting is disabled (which is the default state), bidder's don't have t
 
 Below is an example of the targeting keys with the setting not enabled:
 
-```
+```javascript
 hb_pb_cat_dur = '10.00_10s'
 ```
 
@@ -50,7 +50,7 @@ hb_pb_cat_dur = '10.00_10s'
 
 In the user's equivalent `<name>AdServerVideo` module, import the `initAdpodHooks` function and call it from within their module. Executing the init function will initialize several key functions from the module that are designed to handle `adpod` objects (ie. adUnits, bids, etc.) as the auction proceeds. These functions will only affect `adpod` objects, other `mediaTypes` will be handled by the base Prebid code.
 
-```
+```javascript
 initAdpodHooks();
 ```
 

--- a/dev-docs/modules/airgridRtdProvider.md
+++ b/dev-docs/modules/airgridRtdProvider.md
@@ -81,7 +81,7 @@ gulp serve-fast --modules=rtdModule,airgridRtdProvider,appnexusBidAdapter
 
 Then in your browser access:
 
-```
+```text
 http://localhost:9999/integrationExamples/gpt/airgridRtdProvider_example.html
 ```
 
@@ -94,6 +94,7 @@ gulp test --file "test/spec/modules/airgridRtdProvider_spec.js"
 ## Support
 
 If you require further assistance or are interested in discussing the module functionality please reach out to:
+
 * [hello@airgrid.io](mailto:hello@airgrid.io) for general questions.
 * [support@airgrid.io](mailto:support@airgrid.io) for technical questions.
 

--- a/dev-docs/modules/akamaiDapRtdProvider.md
+++ b/dev-docs/modules/akamaiDapRtdProvider.md
@@ -22,17 +22,17 @@ The Akamai Data Activation Platform (DAP) is a privacy-first system that protect
 
 ## Publisher Usage
 
-1) Build the akamaiDapRTD module into the Prebid.js package with:
+1. Build the akamaiDapRTD module into the Prebid.js package with:
 
-```
-gulp build --modules=akamaiDapRtdProvider,...
-```
+    ```bash
+    gulp build --modules=akamaiDapRtdProvider,...
+    ```
 
-2) Use `setConfig` to instruct Prebid.js to initilaize the akamaiDapRtdProvider module, as specified below.
+2. Use `setConfig` to instruct Prebid.js to initilaize the akamaiDapRtdProvider module, as specified below.
 
 ### Configuration
 
-```
+```javascript
 pbjs.setConfig({
   realTimeData: {
     auctionDelay: 2000,
@@ -76,8 +76,8 @@ Please reach out to your Akamai account representative(<Prebid@akamai.com>) to g
 
 To view an example of available segments returned by dap:
 
-```
-‘gulp serve --modules=rtdModule,akamaiDapRtdProvider,appnexusBidAdapter,sovrnBidAdapter’
+```bash
+gulp serve --modules=rtdModule,akamaiDapRtdProvider,appnexusBidAdapter,sovrnBidAdapter
 ```
 
 and then point your browser at:

--- a/dev-docs/modules/arcspanRtdProvider.md
+++ b/dev-docs/modules/arcspanRtdProvider.md
@@ -29,7 +29,7 @@ Disclosure: This module loads external code that is not open source and has not 
 
 Compile the ArcSpan RTD Module into your Prebid build:
 
-```
+```bash
 gulp build --modules=rtdModule,arcspanRtdProvider
 ```
 

--- a/dev-docs/modules/blueconicRtdProvider.md
+++ b/dev-docs/modules/blueconicRtdProvider.md
@@ -34,9 +34,9 @@ configuration parameters. Please work with your BlueConic Prebid support team
 (<info@blueconic.com>) on which version of Prebid.js supports different bidder
 and segment configurations.
 
-```
+```javascript
 pbjs.setConfig(
-    ...
+    // ...
     realTimeData: {
         auctionDelay: 1000,
         dataProviders: [
@@ -51,7 +51,7 @@ pbjs.setConfig(
             }
         ]
     }
-    ...
+    //...
 }
 ```
 

--- a/dev-docs/modules/brandmetricsRtdProvider.md
+++ b/dev-docs/modules/brandmetricsRtdProvider.md
@@ -23,13 +23,13 @@ The module hooks in to brandmetrics events and requires a brandmetrics script to
 
 ## Publisher Usage
 
-1) Build the brandmetricsRtd module into the Prebid.js package with:
+1. Build the brandmetricsRtd module into the Prebid.js package with:
 
-```
-gulp build --modules=brandmetricsRtdProvider,...
-```
+    ```bash
+    gulp build --modules=brandmetricsRtdProvider,...
+    ```
 
-2) Use `setConfig` to instruct Prebid.js to initilaize the brandmetricsRtdProvider module, as specified below.
+2. Use `setConfig` to instruct Prebid.js to initilaize the brandmetricsRtdProvider module, as specified below.
 
 ### Configuration
 

--- a/dev-docs/modules/browsiRtdProvider.md
+++ b/dev-docs/modules/browsiRtdProvider.md
@@ -26,32 +26,32 @@ an account and receive instructions on how to set up your pages and ad server.
 
 Implementation works like this:
 
- 1) Build the Browsi module into the Prebid.js package with:
+1. Build the Browsi module into the Prebid.js package with:
 
-```
-gulp build --modules=browsiRtdProvider&...
-```
+    ```bash
+    gulp build --modules=browsiRtdProvider&...
+    ```
 
-2) Use `setConfig` to instruct the browser to obtain the viewability data in parallel with the header bidding auction
+2. Use `setConfig` to instruct the browser to obtain the viewability data in parallel with the header bidding auction
 
 ## Configuration
 
 This module is configured as part of the `realTimeData.dataProviders` object:
 
-```
-    pbjs.setConfig({
-        "realTimeData": {
-            dataProviders:[{          
-                "name": "browsi",
-                "params": {
-                    "url": "testUrl.com",   // get params values
-                    "siteKey": "testKey",   // from Browsi
-                    "pubKey": "testPub",    //
-                    "keyName":"bv"          //
-                }
-            }]
-        }
-    });
+```javascript
+pbjs.setConfig({
+    "realTimeData": {
+        dataProviders:[{          
+            "name": "browsi",
+            "params": {
+                "url": "testUrl.com",   // get params values
+                "siteKey": "testKey",   // from Browsi
+                "pubKey": "testPub",    //
+                "keyName":"bv"          //
+            }
+        }]
+    }
+});
 ```
 
 Syntax details:
@@ -73,7 +73,7 @@ When the data is received, it calls `pbjs.setTargetingForGPT` to set the defined
 
 Example:
 
-```
+```json
 {
   "slotA":{
       "p":0.56,   // ad server targeting variable (e.g. bv) for slotA is 0.56

--- a/dev-docs/modules/captifyRtdProvider.md
+++ b/dev-docs/modules/captifyRtdProvider.md
@@ -32,13 +32,13 @@ Contact <prebid@captify.tech> for more information.
 
 ## Integration
 
-1) Compile the Captify RTD Module along with your bid adapter and other modules into your Prebid build:  
+1. Compile the Captify RTD Module along with your bid adapter and other modules into your Prebid build:  
 
-```
-gulp build --modules="rtdModule,captifyRtdProvider,appnexusBidAdapter,..."  
-```
+    ```bash
+    gulp build --modules="rtdModule,captifyRtdProvider,appnexusBidAdapter,..."  
+    ```
 
-2) Use `setConfig` to instruct Prebid.js to initialize the Captify RTD module, as specified below.
+2. Use `setConfig` to instruct Prebid.js to initialize the Captify RTD module, as specified below.
 
 ## Configuration
 

--- a/dev-docs/modules/categoryTranslation.md
+++ b/dev-docs/modules/categoryTranslation.md
@@ -31,7 +31,7 @@ The module provides the following:
 
 The IAB Category Translation module uses a default mapping file to convert adserver categories or labels to IAB sub categories. If a publisher prefers to use their own mapping file they will need to set the URL location of that file. They can do so by adding the following to their Prebid.js configuration:
 
-```
+```javascript
 pbjs.setConfig({
     "brandCategoryTranslation": {
        "translationFile": "<url_to_file>"

--- a/dev-docs/modules/cleanioRtdProvider.md
+++ b/dev-docs/modules/cleanioRtdProvider.md
@@ -24,7 +24,7 @@ Using this module requires prior agreement with [clean.io](https://clean.io) to 
 
 clean.io Realtime module can be built just like any other prebid module:
 
-```
+```bash
 gulp build --modules=cleanioRtdProvider,...
 ```
 

--- a/dev-docs/modules/confiantRtdProvider.md
+++ b/dev-docs/modules/confiantRtdProvider.md
@@ -25,13 +25,13 @@ Disclosure: When configured, this module will insert a script, that is loaded fr
 
 ## Integration
 
-1) Build Prebid bundle with Confiant module included:
+1. Build Prebid bundle with Confiant module included:
 
-```
-gulp build --modules=confiantRtdProvider,...
-```
+    ```bash
+    gulp build --modules=confiantRtdProvider,...
+    ```
 
-2) Include the resulting bundle on your page.
+2. Include the resulting bundle on your page.
 
 # Configuration
 

--- a/dev-docs/modules/consentManagement.md
+++ b/dev-docs/modules/consentManagement.md
@@ -40,8 +40,8 @@ This base EU GDPR consent management module performs these actions:
 
 The optional [GDPR enforcement module](/dev-docs/modules/gdprEnforcement.html) adds on these actions:
 
-3. Allows the page to define which activities should be enforced at the Prebid.js level.
-4. Actively enforces those activities based on user consent data (in the TCF string, not the AC string).
+1. Allows the page to define which activities should be enforced at the Prebid.js level.
+2. Actively enforces those activities based on user consent data (in the TCF string, not the AC string).
 
 In the case of a new user, CMPs will generally respond only after there is consent information available (i.e., the user has made their consent choices).
 Making these selections can take some time for the average user, so the module provides timeout settings.

--- a/dev-docs/modules/consentManagementUsp.md
+++ b/dev-docs/modules/consentManagementUsp.md
@@ -60,10 +60,12 @@ As of January 1st 2023, CCPA will require that requests to "delete my personal i
 Prebid Modules that receive user data (bid adapters, analytics adapters), or set user data (UserId, RTD) may define a new method called `onDataDeletionRequest`. The US Privacy Consent Management Module will attach a `registerDeletion` event handler with the CMP, when triggered it will:
 
 The USP module attaches a 'registerDeletion' event handler with the CMP; when triggered, it will:
+
 * invoke the methods above on all adapters
 * delete all IDs from cookies/localStorage
 
 3rd parties can define the method like this:
+
 * UserID submodules can define a method onDataDeletionRequest(config, idValue)
 * Bid adapters can define a method spec.onDataDeletionRequest(bidderRequests)
 * Analytics adapters can define a method onDataDeletionRequest()

--- a/dev-docs/modules/dataControllerModule.md
+++ b/dev-docs/modules/dataControllerModule.md
@@ -20,7 +20,7 @@ The module attempts to filter/supress the EIDs/SDA being transmitted to bid stre
 
 The module can be added to the Prebid.js build with this command:
 
-```
+```bash
 gulp build --modules=dataControllerModule
 ```
 

--- a/dev-docs/modules/dchain.md
+++ b/dev-docs/modules/dchain.md
@@ -22,7 +22,7 @@ Publishers that interact with bidders that support the [IAB Buyers.json and Dema
 
 First, build the dchain module into your Prebid.js package:
 
-```
+```bash
 gulp build --modules=dchain,...
 ```
 
@@ -37,7 +37,7 @@ The module will then automatically perform validations on the dchain data, provi
 
 For example:
 
-```
+```javascript
 pbjs.setConfig({
   "dchain": {
     "validation": "strict"
@@ -49,20 +49,21 @@ pbjs.setConfig({
 
 Adapters who choose to support DChain should assign their ad server's IAB compliant dchain config object to the `bid.meta.dchain` field when creating their Prebid.js bidresponse object.  When the module is enabled, this dchain object will be evaluated per the publisher's config settings.
 
-```
+```javascript
 bid.meta.dchain: {
   "complete": 0,
   "ver": "1.0",
   "ext": {...},
   "nodes": [
-  ...,
+  // ...,
   {
     "asi": "domain.com",
     "bsid": "123",
     "name": "companyname",
     ...
   },
-  ...]
+  //...
+  ]
 }
 ```
 

--- a/dev-docs/modules/dfp_express.md
+++ b/dev-docs/modules/dfp_express.md
@@ -45,6 +45,7 @@ Adding the module to a page is done by adding just one line of javascript:
 The prebid.js file needs to be loaded before the GPT library loads, unless you're willing to manage the timing with additional queue functions. The examples here assume the easiest integration, which is synchronous.
 
 The prebid.js file must also be constructed so that it contains:
+
 * the Prebid.js adunits with the code keyed to the GAM slot name or the div element ID
 * a call to pbjs.express()
 
@@ -144,33 +145,33 @@ The practice of intercepting GPT ad calls has precedence in the industry, but ma
 
 ## Minimal Example
 
-1) Build a version of your prebid.js file
+1. Build a version of your prebid.js file
 
-2) Append the following lines to the file:
+2. Append the following lines to the file:
 
-```
-var adUnits = [
-  {
-    code: '/111111/slot-name',
-    mediaTypes: {
-      banner: {
-        sizes: [[300,250]]
-      }
-    },
-    bids: [
-    {
-      bidder: 'rubicon',
-      params: { account: 1001, siteId: 113932, zoneId: 535510 }
-    }
-  }];
-pbjs.express(adUnits);
-```
+    ```javascript
+    var adUnits = [
+      {
+        code: '/111111/slot-name',
+        mediaTypes: {
+          banner: {
+            sizes: [[300,250]]
+          }
+        },
+        bids: [
+        {
+          bidder: 'rubicon',
+          params: { account: 1001, siteId: 113932, zoneId: 535510 }
+        }
+      }];
+    pbjs.express(adUnits);
+    ```
 
-3) Two things to note: first, the AdUnit.code field must match an actual GPT slot name. Second, the call to `pbjs.express(adUnits)` is what kicks off header bidding.
+3. Two things to note: first, the AdUnit.code field must match an actual GPT slot name. Second, the call to `pbjs.express(adUnits)` is what kicks off header bidding.
 
-4) Integrate your Prebid.js file into the page
+4. Integrate your Prebid.js file into the page
 
-```
+```html
 <meta charset="UTF8">
 <html>
 <head>

--- a/dev-docs/modules/dfp_video.md
+++ b/dev-docs/modules/dfp_video.md
@@ -18,17 +18,17 @@ sidebarType : 1
 
 This module is required to use the Prebid Instream video examples with Google Ad Manager. For instructions showing how to add this module to Prebid.js, see below.
 
-### Step 1:  Prepare the base Prebid file as usual
+## Step 1:  Prepare the base Prebid file as usual
 
 The standard options:
 
 - Build from a locally-cloned git repo
 - Receive the email package from the Prebid [Download](/download.html) page
 
-### Step 2: Integrate into your prebid.js configuration
+## Step 2: Integrate into your prebid.js configuration
 
 The method exposes the [`pbjs.adServers.dfp.buildVideoUrl`]({{site.baseurl}}/dev-docs/publisher-api-reference/adServers.dfp.buildVideoUrl.html) method to use. For an example, see the DFP video guide linked below.
 
-## Further Reading
+# Further Reading
 
 - [Show Video Ads with GAM](/dev-docs/show-video-with-a-dfp-video-tag.html)

--- a/dev-docs/modules/dgkeywordRtdProvider.md
+++ b/dev-docs/modules/dgkeywordRtdProvider.md
@@ -20,13 +20,13 @@ sidebarType : 1
 
 ## Integration
 
-1) Compile the Digital Garage Keyword Module and Appnexus Bid Adapter into your Prebid build:  
+1. Compile the Digital Garage Keyword Module and Appnexus Bid Adapter into your Prebid build:  
 
-```
-gulp build --modules="dgkeywordRtdProvider,appnexusBidAdapter,..."  
-```
+    ```bash
+    gulp build --modules="dgkeywordRtdProvider,appnexusBidAdapter,..."  
+    ```
 
-2) Use `setConfig` to instruct Prebid.js to initilize the dgkeyword module, as specified below.
+2. Use `setConfig` to instruct Prebid.js to initilize the dgkeyword module, as specified below.
 
 ## Configuration
 

--- a/dev-docs/modules/fledgeForGpt.md
+++ b/dev-docs/modules/fledgeForGpt.md
@@ -24,7 +24,7 @@ the changes Bid Adapters need to implement in order to support FLEDGE.
 Publishers wishing to enable FLEDGE support must do two things. First, they must compile Prebid.js with support for this module.
 This is accomplished by adding the `fledgeForGpt` module to the list of modules they are already using:
 
-```
+```bash
 gulp build --modules=fledgeForGpt,...
 ```
 

--- a/dev-docs/modules/floors.md
+++ b/dev-docs/modules/floors.md
@@ -57,14 +57,14 @@ There are several places where the Floor module changes the behavior of the Preb
 1. When building the Prebid.js package, the Price Floors Module (and any analytics adapters) needs to be included with 'gulp build --modules=priceFloors,...'
 2. As soon as the setConfig({floors}) call is initiated, the Price Floors Module will build an internal hash table for each auction derived from a Rule Location (one of Dynamic, setConfig or adUnit)
 
-* a. If an endpoint URL (a Dynamic Floor) is defined, the Price Floors Module will attempt to fetch floor data from the Floor Provider's endpoint. When requestBids is called, the Price Floors Module will delay the auction up to the supplied amount of time in floors.auctionDelay or as soon as the dynamic endpoint returns data, whichever is first.
-* If the `skipRate` flag is specified, there's an A/B test in progress, so the module will decide for this request whether floors processing should be 'skipped' or not.
+    * If an endpoint URL (a Dynamic Floor) is defined, the Price Floors Module will attempt to fetch floor data from the Floor Provider's endpoint. When requestBids is called, the Price Floors Module will delay the auction up to the supplied amount of time in floors.auctionDelay or as soon as the dynamic endpoint returns data, whichever is first.
+    * If the `skipRate` flag is specified, there's an A/B test in progress, so the module will decide for this request whether floors processing should be 'skipped' or not.
 
 3. Bid Adapters are responsible for utilizing the getFloor() from the bidRequest object for each ad slot media type, size combination. The Price Floors Module will perform currency conversion if the bid adapter requests floors in a different currency from the defined floor data currency.
 4. Bid Adapters will pass the floor values to their bidding endpoints, to request bids, responding with any bids that meet or exceed the provided floor
 5. Bid adapters will submit bids to back to Prebid core, where the Price Floors Module will perform enforcement on each bid
 6. The Price Floors Module will mark all bids below the floor as bids rejected. Prebid core will submit all eligible bids to the publisher ad server
-    * a. The Price Floors Module emits floor event / bid data to Analytics adapters to allow Floor Providers a feedback loop on floor performance for model training
+    * The Price Floors Module emits floor event / bid data to Analytics adapters to allow Floor Providers a feedback loop on floor performance for model training
 
 ## Defining Floors
 
@@ -327,6 +327,7 @@ When you see 'skipped' in the floors data, it indicates the status of the `skipR
 Schema 2 allows floors providers to A/B-test one or more floor groups, determined at auction time.
 
 The following principles apply to Schema 2:
+
 * These attributes are required:
   * data.floorsSchemaVersion to be set to 2
   * A valid modelGroups object must be set
@@ -1200,7 +1201,7 @@ Even if a publisher is using a floors provider, they may wish to provide additio
 
 Here's an example covering the first two scenarios:
 
-```
+```javascript
 pbjs.setConfig({
       floors: {
           enforcement: {
@@ -1229,7 +1230,7 @@ pbjs.setConfig({
 
 And here's an example of imp-level floorMin, which is like a form of imp-level [first party data](/features/firstPartyData.html#supplying-adunit-specific-data):
 
-```
+```javascript
 pbjs.addAdUnits({
     code: "test-div",
     mediaTypes: {
@@ -1261,6 +1262,7 @@ For publishers requiring currency conversions (for example if the floors data cu
 {% include /alerts/alert_warning.html content=warning_note %}
 
 Currency conversion can occur in two areas of the Floor Module code:
+
 * On the **getFloor()** call when Bid Adapters request a floor
 * On the **enforcement** side when each bidder submits a bidResponse
 
@@ -1301,6 +1303,7 @@ If currency conversion is unsuccessful:
 ```
 
 Currency conversion can fail for the following reasons:
+
 * Currency module is not included in the prebid bundle.
 * Currency module is included but not enabled
 * Currency module is included and enabled but:
@@ -1353,4 +1356,5 @@ If the currency function is unable to derive the correct cpm in any of the scena
 | pubx.ai | [hello@pubx.ai](mailto:hello@pubx.ai) | AI-powered dynamic floor optimization |
 
 ## Further Reading
+
 * [Prebid Server Price Floors](/prebid-server/features/pbs-floors.html)

--- a/dev-docs/modules/freewheel.md
+++ b/dev-docs/modules/freewheel.md
@@ -20,7 +20,7 @@ This module returns the targeting key value pairs for the FreeWheel ad server.
 
 If you are using FreeWheel as your ad server for long-form header bidding then include this module while creating Prebid.js build. Use the exposed getTargeting method to get targeting key value pairs.
 
-#### Example
+### Example
 
 ```javascript
 pbjs.adServers.freewheel.getTargeting({
@@ -63,7 +63,7 @@ pbjs.adServers.freewheel.getTargeting({
 
 The values returned by `getTargeting` are concatenation of CPM, industy code, and video duration. FreeWheel SDK will send those values to FreeWheel Ad Server within the following query:
 
-```
+```text
 http://[customerId].v.fwmrm.net/ad/g/1[globalParams];hb_pb_cat_dur=10.00_400_15s&hb_pb_cat_dur=15.00_402_30s&hb_cacheid=123;[ParamsForSlot1];[ParamsForSlot2];...;[ParamsForSlotN];
 ```
 

--- a/dev-docs/modules/gdprEnforcement.md
+++ b/dev-docs/modules/gdprEnforcement.md
@@ -36,8 +36,8 @@ The [base consent module](/dev-docs/modules/consentManagement.html) performs the
 
 The GDPR Enforcement Module adds the following:
 
-3. Allows the page to define which activities should be enforced at the Prebid.js level.
-4. Actively enforces those activities based on user consent data.
+1. Allows the page to define which activities should be enforced at the Prebid.js level.
+2. Actively enforces those activities based on user consent data.
 
 The following table details the Prebid.js activities that fall under the [Transparency and Consent Framework (TCF)](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/) scope:
 
@@ -60,8 +60,8 @@ A page needs to define configuration rules about how Prebid.js should enforce ea
 {: .alert.alert-info :}
 To turn on Prebid.js enforcement you must:
 
-1) Include the gdprEnforcement module in the Prebid.js build
-and 2) setConfig `consentManagement.gdpr.cmpApi` to either 'iab' or 'static'
+(1) Include the gdprEnforcement module in the Prebid.js build
+and (2) setConfig `consentManagement.gdpr.cmpApi` to either 'iab' or 'static'
 
 The following fields related to GDPR enforcement are supported in the [`consentManagement`](/dev-docs/modules/consentManagement.html) object:
 
@@ -89,41 +89,42 @@ pbjs.setConfig({
         bidderB: 67890
     }
 });
-````
+```
 
 ### Examples
 
 The following examples cover a range of use cases and show how Prebid.js supports
 configuration of different business rules.
 
-1) Restrict device access activity and basic ads. These are the default values (in Prebid.js 4.0) if the module is included in the build.
+1. Restrict device access activity and basic ads. These are the default values (in Prebid.js 4.0) if the module is included in the build.
 
-```javascript
-pbjs.setConfig({
-  consentManagement: {
-    gdpr: {
-      cmpApi: 'iab',   // activates the enforcement module
-      defaultGdprScope: true,
-      rules: [{        // these are the default values
-        purpose: "storage",
-        enforcePurpose: true,
-        enforceVendor: true
-      },{
-        purpose: "basicAds",
-        enforcePurpose: true,
-        enforceVendor: true
-      },{
-        purpose: "measurement",
-        enforcePurpose: true,
-        enforceVendor: true
-      }]
-    }
-  }
-});
-```
+    ```javascript
+    pbjs.setConfig({
+      consentManagement: {
+        gdpr: {
+          cmpApi: 'iab',   // activates the enforcement module
+          defaultGdprScope: true,
+          rules: [{        // these are the default values
+            purpose: "storage",
+            enforcePurpose: true,
+            enforceVendor: true
+          },{
+            purpose: "basicAds",
+            enforcePurpose: true,
+            enforceVendor: true
+          },{
+            purpose: "measurement",
+            enforcePurpose: true,
+            enforceVendor: true
+          }]
+        }
+      }
+    });
+    ```
 
-2) Restrict that the user consents to DeviceAccess as an activity and consider their per-vendor selection. However, idSystemA is a special case - the publisher has confirmed that this system obtains a user ID every auction and does not write to the local device.
+2. Restrict that the user consents to DeviceAccess as an activity and consider their per-vendor selection. However, idSystemA is a special case - the publisher has confirmed that this system obtains a user ID every auction and does not write to the local device.
 
+    ```javascript
       ...
       rules: [{
         purpose: "storage",
@@ -131,9 +132,11 @@ pbjs.setConfig({
         enforceVendor: true,
         vendorExceptions: ["idSystemA"]
       }]
+    ```
 
-3) Restrict for both storage and basicAds, with the exception of "firstPartyBidder", which is always allowed to run an auction. Assumes the publisher has special legal basis for this entity.
+3. Restrict for both storage and basicAds, with the exception of "firstPartyBidder", which is always allowed to run an auction. Assumes the publisher has special legal basis for this entity.
 
+    ```javascript
       ...
       rules: [{
         purpose: "storage",
@@ -145,18 +148,22 @@ pbjs.setConfig({
     enforceVendor: true,
         vendorExceptions: ["firstPartyBidder"]
       }]
+    ```
 
-4) Turn off restriction of Purpose 1: don't enforce either the user's DeviceAccess consent or their per-vendor selection.
+4. Turn off restriction of Purpose 1: don't enforce either the user's DeviceAccess consent or their per-vendor selection.
 
+    ```javascript
       ...
       rules: [{
         purpose: "storage",
         enforcePurpose: false,
         enforceVendor: false
       }]
+    ```
 
-5) Allow the user to suppress analtyics provider A, but make an exception for analytics provider B.
+5. Allow the user to suppress analtyics provider A, but make an exception for analytics provider B.
 
+    ```javascript
       ...
       rules: [{
         purpose: "measurement",
@@ -164,6 +171,7 @@ pbjs.setConfig({
         enforceVendor: true,
     vendorExceptions: ["analyticsB"]
       }]
+    ```
 
 ## Basic Enforcement
 

--- a/dev-docs/modules/geoedgeRtdProvider.md
+++ b/dev-docs/modules/geoedgeRtdProvider.md
@@ -28,13 +28,13 @@ Disclosure: This module loads external code that is not open source and has not 
 
 ## Integration
 
-1) Build the geoedge RTD module into the Prebid.js package with:
+1. Build the geoedge RTD module into the Prebid.js package with:
 
-```
-gulp build --modules=geoedgeRtdProvider,...
-```
+    ```bash
+    gulp build --modules=geoedgeRtdProvider,...
+    ```
 
-2) Use `setConfig` to instruct Prebid.js to initilize the geoedge module, as specified below.
+2. Use `setConfig` to instruct Prebid.js to initilize the geoedge module, as specified below.
 
 ## Configuration
 
@@ -73,14 +73,14 @@ Parameters details:
 
 To view an integration example:
 
-1) in your cli run:
+1. in your cli run:
 
-```
-gulp serve --modules=appnexusBidAdapter,geoedgeRtdProvider
-```
+    ```bash
+    gulp serve --modules=appnexusBidAdapter,geoedgeRtdProvider
+    ```
 
-2) in your browser, navigate to:
+2. in your browser, navigate to:
 
-```
+```text
 http://localhost:9999/integrationExamples/gpt/geoedgeRtdProvider_example.html
 ```

--- a/dev-docs/modules/gpt-pre-auction.md
+++ b/dev-docs/modules/gpt-pre-auction.md
@@ -115,13 +115,14 @@ Here's what the module does to define these values:
 In PBJS 6.5 and later, we recommend using the useDefaultPreAuction flag or the customPreAuction function.
 
 The following customPbAdSlot function will work for many publishers. Assumptions:
+
 * AdUnits have been registered with [pbjs.addAdUnits](/dev-docs/publisher-api-reference/addAdUnits.html).
 * AdUnit.code is either the GPT slot name or the div-id.
 * The site has unique (non-random) div-ids.
 
 If either of these isn't the case, you'll need to supply your own function.
 
-```
+```javascript
 // Use adunit.ortb2Imp.ext.data.pbadslot if it exists.
 // compare adunit.code to find a single matching slot in GPT
 // if there is a single slot match, just use that slot name
@@ -129,39 +130,40 @@ If either of these isn't the case, you'll need to supply your own function.
 
 pbjs.setConfig({
     gptPreAuction: {
-    enabled: true, // enabled by default
-    customPbAdSlot: function(adUnitCode, adServerAdSlot) {
-        // get adunit object
-        au=pbjs.adUnits.filter(au => au.code==adUnitCode);
-        if (au.length==0) {
-            return;
-        }
+        enabled: true, // enabled by default
+        customPbAdSlot: function(adUnitCode, adServerAdSlot) {
+            // get adunit object
+            au=pbjs.adUnits.filter(au => au.code==adUnitCode);
+            if (au.length==0) {
+                return;
+            }
 
-        // use pbadslot if supplied
-        if (au[0].ort2bImp && au[0].ort2bImp.ext && au[0].ort2bImp.ext.data && au[0].ort2bImp.ext.data.pbadslot) {
-            return au[0].ort2bImp.ext.data.pbadslot;
-        }
+            // use pbadslot if supplied
+            if (au[0].ort2bImp && au[0].ort2bImp.ext && au[0].ort2bImp.ext.data && au[0].ort2bImp.ext.data.pbadslot) {
+                return au[0].ort2bImp.ext.data.pbadslot;
+            }
 
-        // confirm that GPT is set up
-        if (!(googletag && googletag.apiReady)) {
-            return;
+            // confirm that GPT is set up
+            if (!(googletag && googletag.apiReady)) {
+                return;
+            }
+            // find all GPT slots with this name
+            var gptSlots = googletag.pubads().getSlots().filter(function(gpt) {
+                return gpt.getAdUnitPath() == adServerAdSlot;
+            });
+            if (gptSlots.length==0) {
+                return;  // should never happen
+            }
+            if (gptSlots.length==1) {
+                return adServerAdSlot;
+            }
+            // else the adunit code must be div id. append it.
+            return adServerAdSlot+"#"+adUnitCode;
         }
-        // find all GPT slots with this name
-        var gptSlots = googletag.pubads().getSlots().filter(function(gpt) {
-            return gpt.getAdUnitPath() == adServerAdSlot;
-        });
-        if (gptSlots.length==0) {
-            return;  // should never happen
-        }
-        if (gptSlots.length==1) {
-            return adServerAdSlot;
-        }
-        // else the adunit code must be div id. append it.
-        return adServerAdSlot+"#"+adUnitCode;
     }
-  });
-};
+});
 ```
 
 # Further Reading
+
 * [Prebid Ad Slot and GPID](/features/pbAdSlot.html)

--- a/dev-docs/modules/greenbidsRtdProvider.md
+++ b/dev-docs/modules/greenbidsRtdProvider.md
@@ -36,7 +36,7 @@ This module is configured as part of the `realTimeData.dataProviders` object.
 | `params.targetTPR`      | optional (default 0.95) | Target True positive rate for the throttling model | `0.99` | `[0-1]` |
 | `params.timeout`      | optional (default 200) | Maximum amount of milliseconds allowed for module to finish working (has to be <= to the realTimeData.auctionDelay property) | `200` | `number` |
 
-#### Example
+### Example
 
 ```javascript
 const greenbidsDataProvider = {
@@ -59,16 +59,16 @@ pbjs.setConfig({
 
 To install the module, follow these instructions:
 
-#### Step 1: Contact Greenbids to get a pbuid and account
+### Step 1: Contact Greenbids to get a pbuid and account
 
-#### Step 2: Integrate the Greenbids Analytics Adapter (see prebid Analytics modules)
+### Step 2: Integrate the Greenbids Analytics Adapter (see prebid Analytics modules)
 
-#### Step 3: Prepare the base Prebid file
+### Step 3: Prepare the base Prebid file
 
 * Option 1: Use Prebid [Download](/download.html) page to build the prebid package. Ensure that you do check *Greenbids Realtime Module* module
 
 * Option 2: From the command line, run `gulp build --modules=greenbidsRtdProvider,...`
 
-#### Step 4: Set configuration
+### Step 4: Set configuration
 
 Enable Greenbids Real Time Module using `pbjs.setConfig`. Example is provided in Configuration section.

--- a/dev-docs/modules/growthCodeRtdProvider.md
+++ b/dev-docs/modules/growthCodeRtdProvider.md
@@ -18,7 +18,7 @@ sidebarType : 1
 * TOC
 {:toc}
 
-The <a href="https://growthcode.io">GrowthCode</a> real-time data module in Prebid enables publishers to fully
+The [GrowthCode](https://growthcode.io) real-time data module in Prebid enables publishers to fully
 leverage the potential of their first-party audiences and contextual data.
 With an integrated cookieless GrowthCode identity, this module offers real-time
 contextual and audience segmentation capabilities that can seamlessly
@@ -31,11 +31,11 @@ Compile the GrowthCode RTD module into your Prebid build:
 
 `gulp build --modules=userId,rtdModule,growthCodeRtdProvider,appnexusBidAdapter`
 
-Please visit <a href="https://growthcode.io">https://growthcode.io/</a> for more information.
+Please visit [https://growthcode.io/](https://growthcode.io) for more information.
 
-```
-pbjs.setConfig(
-    ...
+```javascript
+pbjs.setConfig({
+    // ...
     realTimeData: {
          auctionDelay: 200,
           dataProviders: [
@@ -48,8 +48,8 @@ pbjs.setConfig(
           }
        ]
     }
-    ...
-}
+    // ...
+});
 ```
 
 ### Parameter Descriptions for the GrowthCode Configuration Section

--- a/dev-docs/modules/hadronRtdProvider.md
+++ b/dev-docs/modules/hadronRtdProvider.md
@@ -50,9 +50,9 @@ configuration parameters. Please work with your Audigent Prebid support team
 (<prebid@audigent.com>) on which version of Prebid.js supports different bidder
 and segment configurations.
 
-```
-pbjs.setConfig(
-    ...
+```javascript
+pbjs.setConfig({
+    // ...
     realTimeData: {
         auctionDelay: auctionDelay,
         dataProviders: [
@@ -66,8 +66,8 @@ pbjs.setConfig(
             }
         ]
     }
-    ...
-}
+    // ...
+});
 ```
 
 **Config Syntax details:**
@@ -94,9 +94,9 @@ optional handleRtd parameter and provide your custom RTD handling logic there.
 Please see the following example, which provides a function to modify bids for
 a bid adapter called adBuzz and perform custom logic on bidder parameters.
 
-```
-pbjs.setConfig(
-    ...
+```javascript
+pbjs.setConfig({
+    // ...
     realTimeData: {
         auctionDelay: auctionDelay,
         dataProviders: [
@@ -122,8 +122,8 @@ pbjs.setConfig(
             }
         ]
     }
-    ...
-}
+    // ...
+});
 ```
 
 The handleRtd function can also be used to configure custom ortb2 data

--- a/dev-docs/modules/iasRtdProvider.md
+++ b/dev-docs/modules/iasRtdProvider.md
@@ -19,13 +19,13 @@ Integral Ad Science(IAS) Real Time Data Module. Please contact [Integral Ad Scie
 
 ## Integration
 
-1) Compile Integral Ad Science(IAS) RTD Provider into your Prebid build:
+1. Compile Integral Ad Science(IAS) RTD Provider into your Prebid build:
 
-```
-`gulp build --modules=iasBidAdapter,iasRtdProvider`...
-```
+    ```bash
+    gulp build --modules=iasBidAdapter,iasRtdProvider
+    ```
 
-2) Use `setConfig` to instruct Prebid.js to initialize the IAS module, as specified below.
+2. Use `setConfig` to instruct Prebid.js to initialize the IAS module, as specified below.
 
 ## Configuration
 
@@ -34,25 +34,26 @@ This module is configured as part of the `realTimeData.dataProviders` object.
 Configuration example for using RTD module with the `ias` provider:
 
 ```javascript
-  pbjs.setConfig({
-    realTimeData: {
-      dataProviders: [
-        {
-          name: 'ias',
-          waitForIt: true,
-          params: {
-            pubId: '1234',
-            keyMappings: {
-              'id': 'ias_id'
-            },
-            pageUrl: 'https://integralads.com/test',
-            adUnitPath: {
-              'one-div-id': '/012345/ad/unit/path'
-            }
+pbjs.setConfig({
+  realTimeData: {
+    dataProviders: [
+      {
+        name: 'ias',
+        waitForIt: true,
+        params: {
+          pubId: '1234',
+          keyMappings: {
+            'id': 'ias_id'
+          },
+          pageUrl: 'https://integralads.com/test',
+          adUnitPath: {
+            'one-div-id': '/012345/ad/unit/path'
           }
         }
-      ]
-    }
+      }
+    ]
+  }
+});
 ```
 
 Parameters details:

--- a/dev-docs/modules/idWardRtdProvider.md
+++ b/dev-docs/modules/idWardRtdProvider.md
@@ -18,17 +18,17 @@ ID Ward’s Real-time Data Provider automatically obtains segment IDs from the I
 
 ## Publisher Usage
 
-1) Build the idWardRtd module into the Prebid.js package with:
+1. Build the idWardRtd module into the Prebid.js package with:
 
-```
-gulp build --modules=idWardRtdProvider,...
-```
+    ```bash
+    gulp build --modules=idWardRtdProvider,...
+    ```
 
-2) Use `setConfig` to instruct Prebid.js to initilaize the idWardRtdProvider module, as specified below.
+2. Use `setConfig` to instruct Prebid.js to initilaize the idWardRtdProvider module, as specified below.
 
 ### Configuration
 
-```
+```javascript
  pbjs.setConfig({
    realTimeData: {
      dataProviders: [

--- a/dev-docs/modules/imRtdProvider.md
+++ b/dev-docs/modules/imRtdProvider.md
@@ -31,9 +31,9 @@ Add it to your Prebid.js package with:
 
 The following configuration parameters are available:
 
-```
-pbjs.setConfig(
-    ...
+```javascript
+pbjs.setConfig({
+    // ...
     realTimeData: {
         auctionDelay: 5000,
         dataProviders: [
@@ -47,8 +47,8 @@ pbjs.setConfig(
             }
         ]
     }
-    ...
-}
+    // ...
+}):
 ```
 
 ## Parameters

--- a/dev-docs/modules/instreamTracking.md
+++ b/dev-docs/modules/instreamTracking.md
@@ -34,7 +34,7 @@ This module uses `window.performance.getEntriesByType('resource')` to check the 
 | `instreamTracking.pollingFreq` | Optional | Integer |The frequency of polling. Default: `500`ms |
 | `instreamTracking.urlPattern` | Optional | RegExp | Regex for cache url patterns, to avoid false positives. |
 
-#### Basic Example
+### Basic Example
 
 ```javascript
 pbjs.setConfig({
@@ -44,7 +44,7 @@ pbjs.setConfig({
 });
 ```
 
-#### Example with urlPattern
+### Example with urlPattern
 
 While checking for URLs having `videoCacheKey`, there are chances of false positives. To avoid those cases, we can set `instreamTracking.urlPattern: /REGEX_PATTERN/`.
 
@@ -61,13 +61,13 @@ pbjs.setConfig({
 
 To install the module, follow these instructions:
 
-#### Step 1: Prepare the base Prebid file
+### Step 1: Prepare the base Prebid file
 
 * Option 1: Use Prebid [Download](/download.html) page to build the prebid package. Ensure that you do check *Instream Tracking* module
 
 * Option 2: From the command line, run `gulp build --modules=instreamTracking,...`
 
-#### Step 2: Set configuration
+### Step 2: Set configuration
 
 Enable `instreamTracking` using `pbjs.setConfig`
 

--- a/dev-docs/modules/intersectionRtdProvider.md
+++ b/dev-docs/modules/intersectionRtdProvider.md
@@ -24,28 +24,28 @@ The Intersection module provides intersection for ad slots on the page using
 
 Implementation works like this:
 
- 1) Build the Intersection module into the Prebid.js package with:
+1. Build the Intersection module into the Prebid.js package with:
 
-```
-gulp build --modules=intersectionRtdProvider&...
-```
+    ```bash
+    gulp build --modules=intersectionRtdProvider&...
+    ```
 
-2) Use `setConfig` to instruct the browser to obtain the intersection data
+2. Use `setConfig` to instruct the browser to obtain the intersection data
 
 ## Configuration
 
 This module is configured as part of the `realTimeData.dataProviders` object:
 
-```
-    pbjs.setConfig({
-        "realTimeData": {
-            auctionDelay: 100,
-            dataProviders:[{          
-                "name": "intersection",
-                "waitForIt": true
-            }]
-        }
-    });
+```javascript
+pbjs.setConfig({
+    "realTimeData": {
+        auctionDelay: 100,
+        dataProviders:[{          
+            "name": "intersection",
+            "waitForIt": true
+        }]
+    }
+});
 ```
 
 ## Output
@@ -53,7 +53,7 @@ This module is configured as part of the `realTimeData.dataProviders` object:
 For each bidder, the module adds intersection in a JSON format.
 Example:
 
-```
+```javascript
 {
   "intersection":{
     'boundingClientRect': {

--- a/dev-docs/modules/jwplayerRtdProvider.md
+++ b/dev-docs/modules/jwplayerRtdProvider.md
@@ -25,69 +25,71 @@ To use this module, you'll need to work with [JW Player](https://www.jwplayer.co
 
 ## Implementation for Publishers
 
-1) Compile the JW Player RTD Provider into your Prebid build:
+1. Compile the JW Player RTD Provider into your Prebid build:
 
-`gulp build --modules=jwplayerRtdProvider`
+    ```bash
+    gulp build --modules=jwplayerRtdProvider
+    ```
 
-2) Publishers must register JW Player as a Real Time Data provider by using `setConfig` to load a Prebid Config containing a `realTimeData.dataProviders` array:
+2. Publishers must register JW Player as a Real Time Data provider by using `setConfig` to load a Prebid Config containing a `realTimeData.dataProviders` array:
 
-```javascript
-pbjs.setConfig({
-    ...,
-    realTimeData: {
-      auctionDelay: 100,
-      dataProviders: [{
-          name: "jwplayer",
-          waitForIt: true,
-          params: {
-            mediaIDs: ['abc', 'def', 'ghi', 'jkl']
+    ```javascript
+    pbjs.setConfig({
+        ...,
+        realTimeData: {
+          auctionDelay: 100,
+          dataProviders: [{
+              name: "jwplayer",
+              waitForIt: true,
+              params: {
+                mediaIDs: ['abc', 'def', 'ghi', 'jkl']
+              }
+          }]
+        }
+    });
+    ```
+
+3. Optionally, if you would like to prefetch the targeting information for certain media, you must include the media IDs in `params.mediaIDs`, as displayed above. You must also set `waitForIt` to `true` and make sure that a value is set to `realTimeData.auctionDelay`.
+
+    `waitForIt` is required to ensure the auction waits for the prefetching of the relvant targeting information to complete. It signals to Prebid that you allow the module to delay the auction if necessary.
+    Setting an `auctionDelay` in the `realTimeData` object is required to ensure the auction waits for prefetching to complete. The `auctionDelay` is the max time in ms that the auction will wait for the requested targeting information.
+
+    **Note:** Though prefetch is optional, we highly recommend enabling it to ensure that the targeting information is available before bids are requested.
+
+    **Config Syntax details:**
+
+    {: .table .table-bordered .table-striped }
+    | Name  |Type | Description   | Notes  |
+    | :------------ | :------------ | :------------ |:------------ |
+    | name | String | Real time data module name | Always 'jwplayer' |
+    | waitForIt | Boolean | Required to ensure that the auction is delayed until prefetch is complete | Optional. Defaults to false |
+    | params | Object | | |
+    | params.mediaIDs | Array of Strings | Media Ids for prefetching | Optional |
+
+4. Include the content's media ID and/or the player's ID in the matching AdUnit's `fpd.context.data.jwTargeting` before calling `addAdUnits`:
+
+    ```javascript
+    const adUnit = {1
+      code: '/19968336/prebid_native_example_1',
+      ...,
+      ortb2Imp: {
+        ext: {
+          data: {
+            jwTargeting: {
+              // Note: the following Ids are placeholders and should be replaced with your Ids.
+              playerID: 'abcd',
+              mediaID: '1234'
+            }
           }
-      }]
-    }
-});
-```
+        }
+      }
+    };
 
-3) Optionally, if you would like to prefetch the targeting information for certain media, you must include the media IDs in `params.mediaIDs`, as displayed above. You must also set `waitForIt` to `true` and make sure that a value is set to `realTimeData.auctionDelay`.
-
-`waitForIt` is required to ensure the auction waits for the prefetching of the relvant targeting information to complete. It signals to Prebid that you allow the module to delay the auction if necessary.
-Setting an `auctionDelay` in the `realTimeData` object is required to ensure the auction waits for prefetching to complete. The `auctionDelay` is the max time in ms that the auction will wait for the requested targeting information.
-
-**Note:** Though prefetch is optional, we highly recommend enabling it to ensure that the targeting information is available before bids are requested.
-
-**Config Syntax details:**
-
-{: .table .table-bordered .table-striped }
-| Name  |Type | Description   | Notes  |
-| :------------ | :------------ | :------------ |:------------ |
-| name | String | Real time data module name | Always 'jwplayer' |
-| waitForIt | Boolean | Required to ensure that the auction is delayed until prefetch is complete | Optional. Defaults to false |
-| params | Object | | |
-| params.mediaIDs | Array of Strings | Media Ids for prefetching | Optional |
-
-4) Include the content's media ID and/or the player's ID in the matching AdUnit's `fpd.context.data.jwTargeting` before calling `addAdUnits`:
-
-```javascript
-   const adUnit = {
-     code: '/19968336/prebid_native_example_1',
-     ...,
-     ortb2Imp: {
-       ext: {
-         data: {
-           jwTargeting: {
-             // Note: the following Ids are placeholders and should be replaced with your Ids.
-             playerID: 'abcd',
-             mediaID: '1234'
-           }
-         }
-       }
-     }
-   };
-   
-   pbjs.que.push(function() {
-       pbjs.addAdUnits([adUnit]);
-       pbjs.requestBids({...});
-   });
-```
+    pbjs.que.push(function() {
+        pbjs.addAdUnits([adUnit]);
+        pbjs.requestBids({...});
+    });
+    ```
 
 **Note**: You may also include `jwTargeting` information in the prebid config's `ortb2.site.ext.data`. Information provided in the adUnit will always supersede the information in the config; use the config to set fallback information or information that applies to all adUnits.
 
@@ -107,7 +109,7 @@ This section contains guidelines for bid adapters that are working with JW Playe
 Those bidders should implement the `buildRequests` function. When it is called, the `bidRequests` param will be an array of bids.
 Each bidRequest for which targeting information was found will conform to the following object structure:
 
-```json
+```javascript
 {
   adUnitCode: 'xyz',
   bidId: 'abc',

--- a/dev-docs/modules/konduit.md
+++ b/dev-docs/modules/konduit.md
@@ -18,7 +18,7 @@ The Konduit Accelerate module applies the [Konduit](https://konduitvideo.com/) v
 
 To install the module, follow these instructions:
 
-### Step 1: Prepare the base Prebid file
+## Step 1: Prepare the base Prebid file
 
 Build your Prebid.js package in one of two ways:
 
@@ -27,7 +27,7 @@ Build your Prebid.js package in one of two ways:
 - From the command line, run  
    `gulp build --modules=konduitWrapper,...`
 
-### Step 2: Implement module code on page
+## Step 2: Implement module code on page
 
 - Add konduitId as config using `setConfig` prebid method (`pbjs.setConfig({ konduit: { konduitId: your_konduit_id } })`)
 
@@ -57,7 +57,7 @@ pbjs.setConfig({
 
 Please refer to [Publisher API Reference (Send All Bids)](/dev-docs/publisher-api-reference/setConfig.html#setConfig-Send-All-Bids) for more information on the Send All Bids settings.
 
-### Step 3: Configure Google Ad Manager (GAM)
+## Step 3: Configure Google Ad Manager (GAM)
 
 In order for Konduit’s module to be completely integrated, line item creatives need to be adjusted in GAM.
 Please contact [support@konduit.me](mailto:support@konduit.me) for assistance.
@@ -88,7 +88,7 @@ Note that the creative URL contains a few custom macros that allow Konduit platf
 Refer to the following documentation for more information on Google Ad Manager setup:  
 [Step By Step Guide to Google Ad Manager Setup](https://prebid.org/adops/step-by-step.html)  
 
-### Sample Code
+## Sample Code
 
 We recommended using the Konduit module function call in the `bidsBackHandler` callback function.
 
@@ -121,10 +121,7 @@ pbjs.que.push(function() {
 });
 ```
 
-​
+# Further Reading
 
-## Further Reading
-
-​
-[Getting Started Example]({{site.baseurl}}/dev-docs/getting-started.html)  
-[Prebid.js for Video]({{site.baseurl}}/prebid-video/video-overview.html)
+- [Getting Started Example]({{site.baseurl}}/dev-docs/getting-started.html)
+- [Prebid.js for Video]({{site.baseurl}}/prebid-video/video-overview.html)

--- a/dev-docs/modules/mass.md
+++ b/dev-docs/modules/mass.md
@@ -46,7 +46,7 @@ You can specify your own `dealIdPattern` and `renderUrl` by adding one or more e
 
 Build the MASS module into the Prebid.js package with:
 
-```
+```bash
 gulp build --modules=mass,...
 ```
 
@@ -148,17 +148,17 @@ There are two options to view the integration example:
 
 To view the integration example:
 
-1) Build Prebid using the following required options
+1. Build Prebid using the following required options
 
-```
-gulp build --modules=ixBidAdapter,mass
-```
+    ```bash
+    gulp build --modules=ixBidAdapter,mass
+    ```
 
-2) Use a http server with a valid hostname to access its content. It is not advised to run the bid simulation using localhost or 127.0.0.1
+2. Use a http server with a valid hostname to access its content. It is not advised to run the bid simulation using localhost or 127.0.0.1
 
-```
-http://hostname/integrationExamples/mass/index.html
-```
+    ```text
+    http://hostname/integrationExamples/mass/index.html
+    ```
 
 ### Option 2 - Hosted online
 
@@ -176,7 +176,7 @@ The bidsim tool ships with working DSP example tags that can be found under the 
 
 A quick way to test the Integration test page in combination with the official bootloader is to use the following command:
 
-```
+```bash
 node bidsim --inject --bid 2000 --width 300 --height 250 --dealid 'MASS' --tag "tags/inskin-housead-desktop.js" -o https://demo.massplatform.net/ix/prebid
 ```
 
@@ -184,7 +184,7 @@ node bidsim --inject --bid 2000 --width 300 --height 250 --dealid 'MASS' --tag "
 
 Third-parties that wish to integrate with the official MASS bootloader can get started by running the following command:
 
-```
+```bash
 node bidsim --inject --bid 2000 --width 300 --height 250 --dealid 'MASS' --tag "tags/test.js" -o https://demo.massplatform.net/ix/prebid
 ```
 

--- a/dev-docs/modules/medianetRtdProvider.md
+++ b/dev-docs/modules/medianetRtdProvider.md
@@ -40,7 +40,7 @@ This module is configured as part of the `realTimeData.dataProviders` object.
 | `params`      | required |  | | `Object` |
 | `params.cid`      | required | The customer id is provided by Media.net. | `'8CUX0H51C'` | `string` |
 
-#### Basic Example
+### Basic Example
 
 ```javascript
 pbjs.setConfig({
@@ -93,13 +93,13 @@ var targeting = {
 
 To install the module, follow these instructions:
 
-#### Step 1: Prepare the base Prebid file
+### Step 1: Prepare the base Prebid file
 
 * Option 1: Use Prebid [Download](/download.html) page to build the prebid package. Ensure that you do check *Media.net Realtime Module* module
 
 * Option 2: From the command line, run `gulp build --modules=medianetRtdProvider,...`
 
-#### Step 2: Set configuration
+### Step 2: Set configuration
 
 Enable Media.net Real Time Module using `pbjs.setConfig`
 

--- a/dev-docs/modules/mgidRtdProvider.md
+++ b/dev-docs/modules/mgidRtdProvider.md
@@ -34,7 +34,7 @@ This module is configured as part of the `realTimeData.dataProviders` object.
 | `params.clientSiteId`      | required | The client site id provided by Mgid. | `'123456'` | `string` |
 | `params.timeout`      | optional | Maximum amount of milliseconds allowed for module to finish working | `1000` | `number` |
 
-#### Example
+### Example
 
 ```javascript
 pbjs.setConfig({
@@ -53,12 +53,12 @@ pbjs.setConfig({
 
 To install the module, follow these instructions:
 
-#### Step 1: Prepare the base Prebid file
+### Step 1: Prepare the base Prebid file
 
 * Option 1: Use Prebid [Download](/download.html) page to build the prebid package. Ensure that you do check *Mgid Realtime Module* module
 
 * Option 2: From the command line, run `gulp build --modules=mgidRtdProvider,...`
 
-#### Step 2: Set configuration
+### Step 2: Set configuration
 
 Enable Mgid Real Time Module using `pbjs.setConfig`. Example is provided in Configuration section.

--- a/dev-docs/modules/multibid.md
+++ b/dev-docs/modules/multibid.md
@@ -32,13 +32,13 @@ highest bid will be considered for sending to the ad server.
 
 There are two specific actions enabled by this module:
 
-1) It tells bidders how many bids will be considered. If [useBidCache](https://docs.prebid.org/dev-docs/publisher-api-reference.html#setConfig-Use-Bid-Cache) is on, more than one bid response per adapter can be registered. (Note that this is the case even without this module, but bid adapters might not know they can supply extra bids without the `multibid` config.)
+1. It tells bidders how many bids will be considered. If [useBidCache](https://docs.prebid.org/dev-docs/publisher-api-reference.html#setConfig-Use-Bid-Cache) is on, more than one bid response per adapter can be registered. (Note that this is the case even without this module, but bid adapters might not know they can supply extra bids without the `multibid` config.)
 
-2) It expands the number of ad server targeting values that can go to the ad server.
+2. It expands the number of ad server targeting values that can go to the ad server.
 
 Here's an example configuration:
 
-```
+```javascript
 pbjs.setConfig({
     multibid: [{
         bidder: "bidderA",
@@ -81,7 +81,7 @@ become subject to the `maxBids` limit.
 
 The MultiBid module is not included with Prebid.js by default. To get this behavior, you must include the module in the build:
 
-```
+```bash
 gulp build --modules=multibid,exampleBidAdapter
 ```
 

--- a/dev-docs/modules/oneKeyRtdProvider.md
+++ b/dev-docs/modules/oneKeyRtdProvider.md
@@ -27,6 +27,7 @@ Both modules are required. This module will pass transmission requests to your p
 while the oneKeyIdSystem will pass the oneKeyData.
 
 Background information:
+
 * [OneKey-Network/addressability-framework](https://github.com/OneKey-Network/addressability-framework)
 * [OneKey-Network/OneKey-implementation](https://github.com/OneKey-Network/OneKey-implementation)
 
@@ -34,30 +35,31 @@ Background information:
 
 ### Integration
 
-1) Compile the OneKey RTD Provider and the OneKey UserID sub-module into your Prebid build.
+1. Compile the OneKey RTD Provider and the OneKey UserID sub-module into your Prebid build.
 
-{: .alert.alert-info :}
-gulp build --modules=rtdModule,oneKeyRtdProvider
+    ```bash
+    gulp build --modules=rtdModule,oneKeyRtdProvider
+    ```
 
-2) Publishers must register OneKey RTD Provider as a Real Time Data provider by using `setConfig`
+2. Publishers must register OneKey RTD Provider as a Real Time Data provider by using `setConfig`
 to load a Prebid Config containing a `realTimeData.dataProviders` array:
 
-```javascript
-pbjs.setConfig({
-    ...,
-    realTimeData: {
-      auctionDelay: 100,
-      dataProviders: [
-            {
-              name: 'oneKey',
-              waitForIt: true
-            }
-        ]
-    }
-});
-```
+    ```javascript
+    pbjs.setConfig({
+        ...,
+        realTimeData: {
+        auctionDelay: 100,
+        dataProviders: [
+                {
+                name: 'oneKey',
+                waitForIt: true
+                }
+            ]
+        }
+    });
+    ```
 
-3) Configure the OneKey RTD Provider with the bidders that are part of the OneKey community. If there is no bidders specified, the RTD provider
+3. Configure the OneKey RTD Provider with the bidders that are part of the OneKey community. If there is no bidders specified, the RTD provider
 will share OneKey data with all adapters.
 
 ⚠️ This module works with a User Id sub-module. Both must be configured. See the [OneKey Id Sub-Module](/dev-docs/modules/userId.html#onekey-ids--preferences).

--- a/dev-docs/modules/optimeraRtdProvider.md
+++ b/dev-docs/modules/optimeraRtdProvider.md
@@ -19,15 +19,15 @@ Optimera Real Time Data Module. Provides targeting for ad requests from data col
 
 ## Integration
 
-1) Compile the Optimera RTD Provider into your Prebid build:
+1. Compile the Optimera RTD Provider into your Prebid build:
 
-```
-`gulp build --modules=rtdModule,optimeraRtdProvider`...
-```
+    ```bash
+    gulp build --modules=rtdModule,optimeraRtdProvider
+    ```
 
-Note: You must include rtdModule in the build list.
+    Note: You must include `rtdModule` in the build list.
 
-2) Use `setConfig` to instruct Prebid.js to initialize the optimera module, as specified below.
+2. Use `setConfig` to instruct Prebid.js to initialize the optimera module, as specified below.
 
 ## Configuration
 
@@ -36,20 +36,21 @@ This module is configured as part of the `realTimeData.dataProviders` object.
 Configuration example for using RTD module with the `optimeraRTD` provider:
 
 ```javascript
-  pbjs.setConfig({
-    realTimeData: {
-      dataProviders: [
-        {
-          name: 'optimeraRTD',
-          waitForIt: true,
-          params: {
-            clientID: '9999',
-            optimeraKeyName: 'optimera',
-            device: 'de'
-          }
+pbjs.setConfig({
+  realTimeData: {
+    dataProviders: [
+      {
+        name: 'optimeraRTD',
+        waitForIt: true,
+        params: {
+          clientID: '9999',
+          optimeraKeyName: 'optimera',
+          device: 'de'
         }
-      ]
-    }
+      }
+    ]
+  }
+})
 ```
 
 ## Migration From the Optimera Bidder Adapter
@@ -74,16 +75,16 @@ Contact Optimera to get assistance with the params.
 
 To view an integration example:
 
-1) in your cli run:
+1. in your cli run:
 
-```
-gulp serve --modules=appnexusBidAdapter,optimeraRtdProvider`
-```
+    ```bash
+    gulp serve --modules=appnexusBidAdapter,optimeraRtdProvider`
+    ```
 
-2) in your browser, navigate to:
+2. in your browser, navigate to:
 
-```
-http://localhost:9999/integrationExamples/gpt/optimeraRtdProvider_example.html
-```
+    ```text
+    http://localhost:9999/integrationExamples/gpt/optimeraRtdProvider_example.html
+    ```
 
 You will be able to see targeting set for each ad request with the 'optimera' key name.

--- a/dev-docs/modules/oxxionRtdProvide.md
+++ b/dev-docs/modules/oxxionRtdProvide.md
@@ -24,15 +24,15 @@ Make sure to have the following modules listed while building prebid : `rtdModul
 `rtbModule` is required to activate real-time-data submodules.
 For example :
 
-```
+```bash
 gulp build --modules=rtdModule,oxxionRtdProvider
 ```
 
 Then add the oxxion Rtd module to your prebid configuration :
 
-```
-pbjs.setConfig(
-  ...
+```javascript
+pbjs.setConfig({
+  //...
   realTimeData: {
     auctionDelay: 200,
     dataProviders: [
@@ -46,8 +46,8 @@ pbjs.setConfig(
        }
     ]
   }
-  ...
-)
+  // ...
+});
 ```
 
 ## setConfig Parameters

--- a/dev-docs/modules/permutiveRtdProvider.md
+++ b/dev-docs/modules/permutiveRtdProvider.md
@@ -28,7 +28,7 @@ This module reads cohorts from Permutive and attaches them as targeting keys to 
 
 Compile the Permutive RTD module into your Prebid build:
 
-```
+```bash
 gulp build --modules=rtdModule,permutiveRtdProvider
 ```
 
@@ -69,14 +69,14 @@ as well as enabling settings for specific use cases mentioned above (e.g. acbidd
 | params.acBidders       | String[]             | An array of bidder codes to share cohorts with in certain versions of Prebid, see below                         | `[]`               |
 | params.maxSegs         | Integer              | Maximum number of cohorts to be included in either the `permutive` or `p_standard` key-value. | `500`              |
 
-#### Context
+### Context
 
 Permutive is not listed as a TCF vendor as all data collection is on behalf of the publisher and based on consent the publisher has received from the user.
 Rather than through the TCF framework, this consent is provided to Permutive when the user gives the relevant permissions on the publisher website which allow the Permutive SDK to run.
 This means that if GDPR enforcement is configured _and_ the user consent isn’t given for Permutive to fire, no cohorts will populate.
 As Prebid utilizes TCF vendor consent, for the Permutive RTD module to load, Permutive needs to be labeled within the Vendor Exceptions
 
-#### Instructions
+### Instructions
 
 1. Publisher enables rules within Prebid GDPR module
 2. Label Permutive as an exception, as shown below.

--- a/dev-docs/modules/reconciliationRtdProvider.md
+++ b/dev-docs/modules/reconciliationRtdProvider.md
@@ -29,30 +29,30 @@ Contact us: <consultation@tagtoday.net>
 
 Implementation works like this:
 
-1) Build the Reconciliation module into the Prebid.js package with:
+1. Build the Reconciliation module into the Prebid.js package with:
 
-```
-gulp build --modules=reconciliationRtdProvider&...
-```
+    ```bash
+    gulp build --modules=reconciliationRtdProvider&...
+    ```
 
-2) Use `setConfig` to pass parameters to module
+2. Use `setConfig` to pass parameters to module
 
 ## Configuration
 
 This module is configured as part of the `realTimeData.dataProviders` object:
 
-```
-    pbjs.setConfig({
-        "realTimeData": {
-            dataProviders:[{          
-                name: "reconciliation",
-                params: {
-                    publisherMemberId: "test_prebid_publisher",
-                    allowAccess: true, //optional - false by default
-                }
-            }]
-        }
-    });
+```javascript
+pbjs.setConfig({
+    "realTimeData": {
+        dataProviders:[{          
+            name: "reconciliation",
+            params: {
+                publisherMemberId: "test_prebid_publisher",
+                allowAccess: true, //optional - false by default
+            }
+        }]
+    }
+});
 ```
 
 Syntax details:
@@ -72,7 +72,7 @@ The module also tracks AdUnit initialization and impressions ('impression' messa
 
 Custom targetings example:
 
-```
+```json
 {
   "slotA":{
       "RSDK_AUID": "/slotA-Unit",

--- a/dev-docs/modules/relevadRtdProvider.md
+++ b/dev-docs/modules/relevadRtdProvider.md
@@ -30,9 +30,9 @@ Compile the Relevad RTD module (`relevaddRtdProvider`) into your Prebid build, a
 
 Next we configure the module, via `pbjs.setConfig`. See the **Parameter Descriptions** below for more detailed information of the configuration parameters.
 
-```js
-pbjs.setConfig(
-    ...
+```javascript
+pbjs.setConfig({
+    //...
     realTimeData: {
       auctionDelay: 1000,
       dataProviders: [
@@ -56,8 +56,8 @@ pbjs.setConfig(
       }
     ]
   }
- ...
-}
+ // ...
+});
 ```
 
 ## Parameter Descriptions
@@ -97,7 +97,7 @@ gulp serve-fast --modules=rtdModule,relevadRtdProvider
 
 Then in your browser access:
 
-```
+```text
 http://localhost:9999/integrationExamples/gpt/relevadRtdProvider_example.html
 ```
 

--- a/dev-docs/modules/s2sTesting.md
+++ b/dev-docs/modules/s2sTesting.md
@@ -24,7 +24,7 @@ additional options for controlling how requests are sent:
 
 The package is built by specifying the `s2sTesting` module on the build command. For example:
 
-```
+```bash
 gulp build --modules=rubiconBidAdapter,appnexusAstBidAdapter,prebidServerBidAdapter,s2sTesting
 ```
 
@@ -40,7 +40,7 @@ With the Server-to-Server Testing module, the following enhancements are provide
 
 New 'bidderControl' options in s2sConfig. E.g.
 
-```
+```javascript
 pbjs.setConfig(
   s2sConfig: {
      bidders: [ "rubicon", "appnexus" ],
@@ -72,19 +72,19 @@ additional Key Value Pair (KVP) to the ad server. This will allow reporting
 to confirm the ratio of client-vs-server administered requests, as well as
 more advanced reporting.
 
-```
+```javascript
 hb_source_BIDDER=client
 ```
 
 OR
 
-```
+```javascript
 hb_source_BIDDER=s2s
 ```
 
 There's also a new `bidSource` option in AdUnits that overrides the global bidSource. E.g.
 
-```
+```javascript
 AdUnit={
     [...]
     bids=[{
@@ -114,7 +114,7 @@ I don't want to modify AdUnits because that's time consuming in the CMS.*
 
 Example S2S Config defining that 10% of Rubicon requests and 100% of AppNexus requests go through the server:
 
-```
+```javascript
 pbjs.setConfig(
   s2sConfig: {
      account: "PREBID-SERVER-ACCOUNT",
@@ -140,7 +140,7 @@ but we want to do this on a small number of AdUnits.*
 
 Example S2S Config defining that the client route is the default path for the rubicon adapter:
 
-```
+```javascript
 pbjs.setConfig(
   s2sConfig: {
      account: "PREBID-SERVER-ACCOUNT",
@@ -158,7 +158,7 @@ pbjs.setConfig(
 
 And then changes to override one particular AdUnit for server testing:
 
-```
+```javascript
 AdUnit={
     [...]
     bids=[{
@@ -184,7 +184,7 @@ For best results, all bidders/bids in the 'A/B test group' should be configured 
 
 Example S2S Config defining that 5% of the time all bid requests will go 'server' and 95% of the time a mix of 'server' and 'client':
 
-```
+```javascript
 pbjs.setConfig(
   s2sConfig: {
      account: "PREBID-SERVER-ACCOUNT",
@@ -222,6 +222,7 @@ AdUnit={
 5% of the time rubicon, and criteo will use s2s bid requests while index does not bid, and the other 95% of the time rubicon, criteo, and index use client bid requests.
 
 Addtional details:
+
 * If a bidder is always 100% server-side -- i.e. doesn't have either `s2sConfig.bidderControl` or `AdUnit.bids[].bidSource`, then it will not affect `testServerOnly`. i.e. It's going on the server path will not exclude client side adapters.
 
 ### 4. Turn on Test KVP, but no server requests
@@ -233,7 +234,7 @@ the server test isn't running.*
 
 Example S2S Config defining that client is the default path for the rubicon adapter:
 
-```
+```javascript
 pbjs.setConfig(
   s2sConfig: {
      ...

--- a/dev-docs/modules/schain.md
+++ b/dev-docs/modules/schain.md
@@ -30,7 +30,7 @@ Two modes are supported:
 
 First, build the schain module into your Prebid.js package:
 
-```
+```bash
 gulp build --modules=schain,...
 ```
 

--- a/dev-docs/modules/sirdataRtdProvider.md
+++ b/dev-docs/modules/sirdataRtdProvider.md
@@ -50,9 +50,9 @@ Should you want to allow a SSP or a partner to curate your media and operate cro
 
 #### Minimal configuration
 
-```
-pbjs.setConfig(
-    ...
+```javascript
+pbjs.setConfig({
+    // ...
     realTimeData: {
         auctionDelay: 1000,
         dataProviders: [
@@ -66,15 +66,15 @@ pbjs.setConfig(
             }
         ]
     }
-    ...
-}
+    // ...
+});
 ```
 
 #### Advanced configuration
 
-```
-pbjs.setConfig(
-    ...
+```javascript
+pbjs.setConfig({
+    // ...
     realTimeData: {
         auctionDelay: 1000,
         dataProviders: [
@@ -105,8 +105,8 @@ pbjs.setConfig(
             }
         ]
     }
-    ...
-}
+    // ...
+});
 ```
 
 ### Parameter Descriptions for the Sirdata Configuration Section
@@ -137,9 +137,9 @@ Bidders can receive common setting :
 As indicated above, it is possible to provide your own bid augmentation functions. This is useful if you know a bid adapter's API supports segment fields which aren't specifically being added to request objects in the Prebid bid adapter.
 
 Please see the following example, which provides a function to modify bids for a bid adapter called ix and overrides the appnexus.
-
-```
 data Object format for usage in this kind of function :
+
+```json
 {
   "segments": [
     111111,
@@ -192,7 +192,7 @@ data Object format for usage in this kind of function :
 }
 ```
 
-```
+```javascript
 function overrideAppnexus (adUnit, segmentsArray, dataObject, bid) {
     for (var i = 0; i < segmentsArray.length; i++) {
         if (segmentsArray[i]) {
@@ -201,8 +201,8 @@ function overrideAppnexus (adUnit, segmentsArray, dataObject, bid) {
     }
 }
 
-pbjs.setConfig(
-    ...
+pbjs.setConfig({
+    // ...
     realTimeData: {
         auctionDelay: 1000,
         dataProviders: [
@@ -231,15 +231,17 @@ pbjs.setConfig(
         ]
     }
     ...
-}
+});
 ```
 
 ### Testing
 
 To view an example of available segments returned by Sirdata's backends:
 
-`gulp serve --modules=rtdModule,sirdataRtdProvider,appnexusBidAdapter`
+```bash
+gulp serve --modules=rtdModule,sirdataRtdProvider,appnexusBidAdapter
+```
 
 and then point your browser at:
 
-`http://localhost:9999/integrationExamples/gpt/sirdataRtdProvider_example.html`
+[http://localhost:9999/integrationExamples/gpt/sirdataRtdProvider_example.html]

--- a/dev-docs/modules/sizeMappingV2.md
+++ b/dev-docs/modules/sizeMappingV2.md
@@ -162,6 +162,7 @@ Note that the labels are assumed to be passed in via [`pbjs.requestBids()`](/dev
 Here are two requests and how they would be handled in this scenario:
 
 I. A request originating in the US, viewport size: `[1400px, 800px]`
+
 * Steps for **bidderA**:
   1. AdUnit passes label check.
   2. Size bucket `[1200, 0]` gets activated. Sizes: `[[970, 400], [300, 200], [300, 250]]` are active at AdUnit level.
@@ -175,6 +176,7 @@ I. A request originating in the US, viewport size: `[1400px, 800px]`
   4. No bid request is sent for bidderB.
 
 II. A request originating in the UK, viewport size: `[1700px, 900px]`
+
 * Steps for both bidders:
   1. AdUnit passes label check.
   2. Size bucket `[1600, 0]` gets activated. Sizes is `[]`, and an empty array indicates no sizes for the current viewport, which disables the Ad Unit.
@@ -235,12 +237,14 @@ II. A request originating in the UK, viewport size: `[1700px, 900px]`
 Here are two requests and how they would be handled in this scenario:
 
 I. A mobile device with viewport size: `[460px, 300px]`
+
 * Steps for both bidders:
     1. Size bucket `[0, 0]` activates for all three media types. Banner is deactivated due to `sizes: []`. Video is deactivated since `playerSize: []`. Native is deactivated since `active: false`.
     2. Since no media type is active, the AdUnit is deactivated.
     3. No request is sent for either bidder, even though bidderB's minViewPort would have allowed video or native.
 
 II. A tablet with viewport size: `[1100px, 980px]`
+
 * Steps for **bidderA**:
   1. Size bucket `[900, 0]` activates for banner media type, so the associated sizes are active. Size bucket `[0, 0]` activates for video media type. Its associated property is `playerSize: []`, so the video media type gets disabled. Size bucket `[600, 0]` activates for native media type. Its associated property is `active: true`, which keeps native media type active at the AdUnit level.
   2. At the Bidder level, size bucket `[700, 0]` activates. Associated property `relevantMediaTypes` is set to `['banner']`.

--- a/dev-docs/modules/timeoutRtdProvider.md
+++ b/dev-docs/modules/timeoutRtdProvider.md
@@ -17,7 +17,7 @@ certain features. It supports rules dynamically retrieved from a timeout provide
 set directly via configuration.
 Build the timeout RTD module into the Prebid.js package with:
 
-```
+```bash
 gulp build --modules=timeoutRtdProvider,rtdModule...
 ```
 
@@ -32,9 +32,9 @@ The timeout RTD module provides an interface of dynamically fetching timeout rul
 a data provider just before the auction begins. The endpoint url is set in the config just as in
 the example below, and the timeout data will be used when making bid requests.
 
-```
+```javascript
 pbjs.setConfig({
-    ...
+    // ...
     "realTimeData": {
         "dataProviders": [{
             "name": 'timeout',
@@ -49,19 +49,19 @@ pbjs.setConfig({
     // This value below will be modified by the timeout RTD module if it successfully 
     // fetches the timeout data.  
     "bidderTimeout": 1500, 
-    ...
+    // ...
 });
 ```
 
 Sample Endpoint Response:
 
-```
+```json
 {
     "rules": {
         "includesVideo": {
             "true": 200,
             "false": 50
-          },
+            },
         "numAdUnits" : {
             "1-5": 100,
             "6-10": 200,
@@ -78,6 +78,7 @@ Sample Endpoint Response:
             "fast": 50,
             "unknown": 10
         },
+    }
 }
 ```
 
@@ -88,7 +89,7 @@ the user's deviceType, connection speed, etc. These rules can also be configured
 Note that the timeout Module will ignore the static rules if an endpoint url is provided. The timeout rules follow the
 format:
 
-```
+```javascript
 {
   '<feature>': {
     '<key>': <milliseconds to be added to timeout>
@@ -109,7 +110,7 @@ Currently supported features:
 
 If there are multiple rules set, all of them would be used and any that apply will be added to the base timeout. For example, if the rules object contains:
 
-```
+```javascript
 {
   "includesVideo": {
       "true": 200,
@@ -126,9 +127,9 @@ and there are 3 ad units in the auction, all of which are banner, then the timeo
 
 Full example:  
 
-```
+```javascript
 pbjs.setConfig({
-    ...
+    // ...
     "realTimeData": {
         "dataProviders": [{
             "name": 'timeout',
@@ -156,11 +157,12 @@ pbjs.setConfig({
                     }
                 }
             }
-        ]}
+        }]
     }
-    ...
+    // ...
     // The timeout RTD module will add time to `bidderTimeout` based on the rules set above.  
     "bidderTimeout": 1500, 
+})
 ```
 
 ## Timeout Providers

--- a/dev-docs/modules/topicsFpdModule.md
+++ b/dev-docs/modules/topicsFpdModule.md
@@ -23,7 +23,7 @@ the configuration needed to override topics Iframe Default implementation
 Publishers wishing to enable must compile Prebid.js with support for this module.
 This is accomplished by adding the `topicsFpdModule` module to the list of modules they are already using:
 
-```
+```bash
 gulp build --modules=topicsFpdModule,...
 ```
 
@@ -34,7 +34,7 @@ The intent of the Topics API is to provide callers (including third-party ad-tec
 Topics Module(topicsFpdModule) should be included in prebid final package to call topics API.
 Module topicsFpdModule helps to call the Topics API which will send topics data in bid stream (onto user.data)
 
-```
+```javascript
 try {
     if ('browsingTopics' in document && document.featurePolicy.allowsFeature('browsing-topics')) {
         topics = document.browsingTopics();
@@ -50,10 +50,10 @@ Topics iframe implementation is the enhancements of existing module under topics
 
 Below are the configuration which can be used to configure and override the default config maintained in the module.
 
-```
+```javascript
 pbjs.setConfig({
     userSync: {
-        ...,
+        // ...,
         topics: { 
             maxTopicCaller: 3, // SSP rotation 
             bidders: [{
@@ -70,7 +70,7 @@ pbjs.setConfig({
                 expiry: 7 // Configurable expiry days
             }]
         }
-        ....
+        // ...
     }
 })
 ```

--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -104,7 +104,7 @@ Use the optional `bidders` parameter to define an array of bidder codes to which
 
 In this example the SharedID sub adapter is only allowed to be sent to the Rubicon adapter.
 
-```
+```javascript
 userIds: [
   {
     name: "sharedId",
@@ -126,10 +126,10 @@ userIds: [
 
 The Rubicon bid adapter would then receive
 
-```
+```javascript
 {
   "bidder": "rubicon",
-  ...
+  // ...
   "userId": {
     "sharedid": {
       "id": "01*******",
@@ -150,7 +150,7 @@ The Rubicon bid adapter would then receive
       ]
     }
   ],
-  ...
+  // ...
 }
 ```
 

--- a/dev-docs/modules/userid-submodules/33across.md
+++ b/dev-docs/modules/userid-submodules/33across.md
@@ -32,7 +32,7 @@ The following configuration parameters are available:
 
 ## 33Across ID Example
 
-```
+```javascript
 pbjs.setConfig({
   userSync: {
     userIds: [{

--- a/dev-docs/modules/userid-submodules/admixer.md
+++ b/dev-docs/modules/userid-submodules/admixer.md
@@ -28,25 +28,25 @@ gulp build --modules=admixerIdSystem
 
 ## AdmixerID Examples
 
-1) Individual params may be set for the Admixer ID Submodule.
+### Individual params may be set for the Admixer ID Submodule
 
 ```javascript
-   pbjs.setConfig({
-       userSync: {
-           userIds: [{
-               name: "admixerId",
-               storage: {
-                   name: "admixerId",
-                   type: "cookie",
-                   expires: 30
-               },
-               params: {
-                   pid: "4D393FAC-B6BB-4E19-8396-0A4813607316", // example id
-                   e: "3d400b57e069c993babea0bd9efa79e5dc698e16c042686569faae20391fd7ea", // example hashed email (sha256)
-                   p: "05de6c07eb3ea4bce45adca4e0182e771d80fbb99e12401416ca84ddf94c3eb9" //example hashed phone (sha256)
-               }
-           }],
-           auctionDelay: 50             // 50ms maximum auction delay, applies to all userId modules
-       }
-   });
+pbjs.setConfig({
+    userSync: {
+        userIds: [{
+            name: "admixerId",
+            storage: {
+                name: "admixerId",
+                type: "cookie",
+                expires: 30
+            },
+            params: {
+                pid: "4D393FAC-B6BB-4E19-8396-0A4813607316", // example id
+                e: "3d400b57e069c993babea0bd9efa79e5dc698e16c042686569faae20391fd7ea", // example hashed email (sha256)
+                p: "05de6c07eb3ea4bce45adca4e0182e771d80fbb99e12401416ca84ddf94c3eb9" //example hashed phone (sha256)
+            }
+        }],
+        auctionDelay: 50             // 50ms maximum auction delay, applies to all userId modules
+    }
+});
 ```

--- a/dev-docs/modules/userid-submodules/britepool.md
+++ b/dev-docs/modules/userid-submodules/britepool.md
@@ -33,26 +33,26 @@ The BritePool privacy policy is at [https://britepool.com/services-privacy-notic
 
 ## BritePool Examples
 
-1) Individual params may be set for the BritePool User ID Submodule. At least one identifier must be set in the params.
+### Individual params may be set for the BritePool User ID Submodule. At least one identifier must be set in the params
 
 ```javascript
-   pbjs.setConfig({
-       userSync: {
-           userIds: [{
-               name: "britepoolId",
-               storage: {
-                   name: "britepoolid",
-                   type: "cookie",
-                   expires: 30
-               },
-               params: {
-                   url: "https://sandbox-api.britepool.com/v1/britepool/id", // optional. used for testing
-                   api_key: "xxx", // provided by britepool
-                   hash: "yyyy", // example identifier
-                   ssid: "r894hvfnviurfincdejkencjcv" // example identifier
-               }
-           }],
-           syncDelay: 3000 // 3 seconds after the first auction
-       }
-   });
+pbjs.setConfig({
+    userSync: {
+        userIds: [{
+            name: "britepoolId",
+            storage: {
+                name: "britepoolid",
+                type: "cookie",
+                expires: 30
+            },
+            params: {
+                url: "https://sandbox-api.britepool.com/v1/britepool/id", // optional. used for testing
+                api_key: "xxx", // provided by britepool
+                hash: "yyyy", // example identifier
+                ssid: "r894hvfnviurfincdejkencjcv" // example identifier
+            }
+        }],
+        syncDelay: 3000 // 3 seconds after the first auction
+    }
+});
 ```

--- a/dev-docs/modules/userid-submodules/deepintent.md
+++ b/dev-docs/modules/userid-submodules/deepintent.md
@@ -27,37 +27,37 @@ DPES ID is free to use and requires a simple registration with DeepIntent. Pleas
 
 ## Deepintent DPES ID Examples
 
-1) Publisher stores the hashed identity from healthcare identity in cookie
+1. Publisher stores the hashed identity from healthcare identity in cookie
 
-```javascript
-pbjs.setConfig({
-  userSync: {
-    userIds: [{
-      name: 'deepintentId',
-      storage: {
-        type: 'cookie',           // "html5" is the required storage type option is "html5"
-        name: '_dpes_id',
-        expires: 90             // storage lasts for 90 days, optional if storage type is html5
+    ```javascript
+    pbjs.setConfig({
+      userSync: {
+        userIds: [{
+          name: 'deepintentId',
+          storage: {
+            type: 'cookie',           // "html5" is the required storage type option is "html5"
+            name: '_dpes_id',
+            expires: 90             // storage lasts for 90 days, optional if storage type is html5
+          }
+        }],
+        auctionDelay: 50             // 50ms maximum auction delay, applies to all userId modules
       }
-    }],
-    auctionDelay: 50             // 50ms maximum auction delay, applies to all userId modules
-  }
-});
-```
+    });
+    ```
 
-2) Publisher stores the hashed identity from healthcare identity in localstorage
+2. Publisher stores the hashed identity from healthcare identity in localstorage
 
-```javascript
-pbjs.setConfig({
-  userSync: {
-    userIds: [{
-      name: 'deepintentId',
-      storage: {
-        type: 'html5'           // "html5" is the required storage type option is "html5"
-        name: '_dpes_id'
+    ```javascript
+    pbjs.setConfig({
+      userSync: {
+        userIds: [{
+          name: 'deepintentId',
+          storage: {
+            type: 'html5'           // "html5" is the required storage type option is "html5"
+            name: '_dpes_id'
+          }
+        }],
+        auctionDelay: 50             // 50ms maximum auction delay, applies to all userId modules
       }
-    }],
-    auctionDelay: 50             // 50ms maximum auction delay, applies to all userId modules
-  }
-});
-```
+    });
+    ```

--- a/dev-docs/modules/userid-submodules/fabrick.md
+++ b/dev-docs/modules/userid-submodules/fabrick.md
@@ -45,44 +45,44 @@ Please reach out to [FabrickIntegrations@team.neustar](mailto:FabrickIntegration
 
 ## Fabrick Examples
 
-1) Publisher passes an apiKey and hashed email address and elects to store the Fabrick ID envelope in a cookie.
+1. Publisher passes an apiKey and hashed email address and elects to store the Fabrick ID envelope in a cookie.
 
-```javascript
-pbjs.setConfig({
-    userSync: {
-        userIds: [{
-            name: 'fabrickId',
-            params: {
-                apiKey: '123456789', // provided to you by Neustar
-                e: '31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66' // example hashed email address (sha256)
-            },
-            storage: {
-                name: 'pbjs_fabrickId',
-                type: 'cookie',
-                expires: 7
-            }
-        }]
-    }
-});
-```
+    ```javascript
+    pbjs.setConfig({
+        userSync: {
+            userIds: [{
+                name: 'fabrickId',
+                params: {
+                    apiKey: '123456789', // provided to you by Neustar
+                    e: '31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66' // example hashed email address (sha256)
+                },
+                storage: {
+                    name: 'pbjs_fabrickId',
+                    type: 'cookie',
+                    expires: 7
+                }
+            }]
+        }
+    });
+    ```
 
-2) Publisher passes an apiKey and hashed email address and elects to store the fabrickId envelope in HTML5 localStorage.
+2. Publisher passes an apiKey and hashed email address and elects to store the fabrickId envelope in HTML5 localStorage.
 
-```javascript
-pbjs.setConfig({
-    userSync: {
-        userIds: [{
-            name: 'fabrickId',
-            params: {
-                apiKey: '123456789', // provided to you by Neustar
-                e: '31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66' // example hashed email address (sha256)
-            },
-            storage: {
-                type: "html5",
-                name: "pbjs_fabrickId",
-                expires: 7
-            }
-        }]
-    }
-});
-```
+    ```javascript
+    pbjs.setConfig({
+        userSync: {
+            userIds: [{
+                name: 'fabrickId',
+                params: {
+                    apiKey: '123456789', // provided to you by Neustar
+                    e: '31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66' // example hashed email address (sha256)
+                },
+                storage: {
+                    type: "html5",
+                    name: "pbjs_fabrickId",
+                    expires: 7
+                }
+            }]
+        }
+    });
+    ```

--- a/dev-docs/modules/userid-submodules/hadron.md
+++ b/dev-docs/modules/userid-submodules/hadron.md
@@ -17,7 +17,7 @@ gulp build --modules=userId,hadronIdSystem
 
 Add HadronId to the userSync configuration.
 
-```
+```javascript
 pbjs.setConfig({
     userSync: {
         userIds: [{
@@ -36,7 +36,7 @@ pbjs.setConfig({
 
 The `request.userId.hadronId` will contain the Audigent HadronId:
 
-```
+```json
 {
   "hadronId": "0201chpvai07jv2yg08xizqr0bwpa1w0evvmq014d2ykn0b5oe"
 }

--- a/dev-docs/modules/userid-submodules/liveintent.md
+++ b/dev-docs/modules/userid-submodules/liveintent.md
@@ -17,7 +17,7 @@ gulp build --modules=userId,liveIntentIdSystem
 
 The `request.userId.lipb` object would look like:
 
-```
+```json
 {
   "lipbid": "T7JiRRvsRAmh88",
   "segments": ["999"]
@@ -76,10 +76,8 @@ The attributes 'uid2', 'medianet' or 'bidswitch' are treated specially by LiveIn
 For example, in case 'uid2' is configured to be requested - additionally to the nonID - the `request.userId` object would look like this:
 
 ```javascript
-```
-
 {
-    ...
+    // ...
     "lipb" : {
         "lipbid": "sample-nonid-value",
         "segments": ["999"],
@@ -88,10 +86,8 @@ For example, in case 'uid2' is configured to be requested - additionally to the 
     "uid2" : {
         "id" : "sample-uid2-value"
     }
-    ...
+    //...
 }
-
-```
 ```
 
 Note that 'uid2' is exposed as part of 'lipb' as well as separately as 'uid2'. 'medianet' and 'bidswitch' behave the same way.
@@ -148,74 +144,74 @@ NOTE: For optimal performance, the LiveIntent ID module should be called at ever
 
 1. To receive the LiveIntent ID, the setup looks like this.
 
-```
-pbjs.setConfig({
-    userSync: {
-        userIds: [{
-            name: "liveIntentId",
-            params: {
-              publisherId: "9896876"
-            },
-            storage: {
-            type: “cookie”,
-            name: “pbjs_li_nonid”,    //create a cookie with this name
-            expires: 1                // cookie is stored for 1 day
-            }
-        }]
-    }
-})
-```
+    ```javascript
+    pbjs.setConfig({
+        userSync: {
+            userIds: [{
+                name: "liveIntentId",
+                params: {
+                publisherId: "9896876"
+                },
+                storage: {
+                type: “cookie”,
+                name: “pbjs_li_nonid”,    //create a cookie with this name
+                expires: 1                // cookie is stored for 1 day
+                }
+            }]
+        }
+    })
+    ```
 
 2. If you are passing additional identifiers that you want to resolve to the LiveIntent ID, add those under the `identifiersToResolve` array in the configuration parameters.
 
-```
-pbjs.setConfig({
-    userSync: {
-        userIds: [{
-            name: "liveIntentId",
-            params: {
-              publisherId: "9896876",
-              identifiersToResolve: ["my-own-cookie"]
-            },
-            storage: {
-            type: “cookie”,
-            name: “pbjs_li_nonid”,    //create a cookie with this name
-            expires: 1                // cookie is stored for 1 day
-            }
-        }]
-    }
-})
-```
+    ```javascript
+    pbjs.setConfig({
+        userSync: {
+            userIds: [{
+                name: "liveIntentId",
+                params: {
+                publisherId: "9896876",
+                identifiersToResolve: ["my-own-cookie"]
+                },
+                storage: {
+                type: “cookie”,
+                name: “pbjs_li_nonid”,    //create a cookie with this name
+                expires: 1                // cookie is stored for 1 day
+                }
+            }]
+        }
+    })
+    ```
 
 3. If all the supported configuration params are passed, then the setup looks like this.
 
-```
-pbjs.setConfig({
-    userSync: {
-        userIds: [{
-            name: "liveIntentId",
-            params: {
-              publisherId: "9896876",
-              distributorId: "did-0123",
-              identifiersToResolve: ["my-own-cookie"],
-              url: "https://publisher.liveintent.com/idex",
-              partner: "prebid",
-              ajaxTimeout: 1000,
-              liCollectConfig: {
-                fpiStorageStrategy: "cookie",
-                fpiExpirationDays: 730,
-                collectorUrl: "https://rp.liadm.com",
-                appId: "a-0012"
-              }
-            },
-            storage: {
-            type: “cookie”,
-            name: “pbjs_li_nonid”,    //create a cookie with this name
-            expires: 1                // cookie is stored for 1 day
-            }
-        }]
-    }
-})
-```
+    ```javascript
+    pbjs.setConfig({
+        userSync: {
+            userIds: [{
+                name: "liveIntentId",
+                params: {
+                publisherId: "9896876",
+                distributorId: "did-0123",
+                identifiersToResolve: ["my-own-cookie"],
+                url: "https://publisher.liveintent.com/idex",
+                partner: "prebid",
+                ajaxTimeout: 1000,
+                liCollectConfig: {
+                    fpiStorageStrategy: "cookie",
+                    fpiExpirationDays: 730,
+                    collectorUrl: "https://rp.liadm.com",
+                    appId: "a-0012"
+                }
+                },
+                storage: {
+                type: “cookie”,
+                name: “pbjs_li_nonid”,    //create a cookie with this name
+                expires: 1                // cookie is stored for 1 day
+                }
+            }]
+        }
+    })
+    ```
 
 Please note: the distributorId will be ignored when liCollectConfig.appId is present.

--- a/dev-docs/modules/userid-submodules/mediawallah.md
+++ b/dev-docs/modules/userid-submodules/mediawallah.md
@@ -32,7 +32,7 @@ MediaWallah requires the creation of an accountId a partnerId in order to take a
 
 ## MediaWallah OpenLinkID Examples
 
-```
+```javascript
 pbjs.setConfig({
     userSync: {
         userIds: [{

--- a/dev-docs/modules/userid-submodules/netid.md
+++ b/dev-docs/modules/userid-submodules/netid.md
@@ -12,7 +12,7 @@ The EnID is a non-profit organization which is open to any contributing party on
 
 ## netID Examples
 
-1) Publisher stores netID via his own logic
+1. Publisher stores netID via his own logic
 
 ```javascript
 pbjs.setConfig({

--- a/dev-docs/modules/userid-submodules/pubprovided.md
+++ b/dev-docs/modules/userid-submodules/pubprovided.md
@@ -10,54 +10,54 @@ The PubProvided Id module allows publishers to set and pass a first party user i
 
 1. The module supports a user defined function, that generates an eids-style object:
 
-```
-pbjs.setConfig({
-    userSync: {
-        userIds: [{
-            name: "pubProvidedId",
-            params: {
-                eidsFunction: getIdsFn   // any function that exists in the page
-            }
-        }]
-    }
-});
-```
+    ```javascript
+    pbjs.setConfig({
+        userSync: {
+            userIds: [{
+                name: "pubProvidedId",
+                params: {
+                    eidsFunction: getIdsFn   // any function that exists in the page
+                }
+            }]
+        }
+    });
+    ```
 
-Or, the eids values can be passed directly into the `setConfig` call:
+    Or, the eids values can be passed directly into the `setConfig` call:
 
-```
-pbjs.setConfig({
-    userSync: {
-        userIds: [{
-            name: "pubProvidedId",
-            params: {
-                eids: [{
-                    source: "domain.com",
-                    uids: [{
-                        id: "value read from cookie or local storage",
-                        atype: 1,
-                        ext: {
-                            stype: "ppuid"
-                        }
+    ```javascript
+    pbjs.setConfig({
+        userSync: {
+            userIds: [{
+                name: "pubProvidedId",
+                params: {
+                    eids: [{
+                        source: "domain.com",
+                        uids: [{
+                            id: "value read from cookie or local storage",
+                            atype: 1,
+                            ext: {
+                                stype: "ppuid"
+                            }
 
+                        }]
+                    }, {
+                        source: "3rdpartyprovided.com",
+                        uids: [{
+                            id: "value read from cookie or local storage",
+                            atype: 3,
+                            ext: {
+                                stype: "dmp"
+                            }
+                        }]
                     }]
-                }, {
-                    source: "3rdpartyprovided.com",
-                    uids: [{
-                        id: "value read from cookie or local storage",
-                        atype: 3,
-                        ext: {
-                            stype: "dmp"
-                        }
-                    }]
-                }]
-            }
-        }]
-    }
-});
-```
+                }
+            }]
+        }
+    });
+    ```
 
-In either case, bid adapters will receive the eid values after consent is validated.
+    In either case, bid adapters will receive the eid values after consent is validated.
 
 2. This design allows for the setting of any number of uuids in the eids object. Publishers may work with multiple ID providers and nest their own id within the same eids object.  The opportunity to link a 1st party uuid and a 3rd party generated UUID presents publishers with a unique ability to address their users in a way demand sources will understand.
 
@@ -65,9 +65,9 @@ In either case, bid adapters will receive the eid values after consent is valida
 
 4. The `eids.uids.ext.stype` "source-type" extension helps downstream entities know what do with the data. Currently defined values are:
 
-- dmp - this uid comes from the in-page dmp named in eids.source
-- ppuid - this uid comes from the publisher named in eids.source
-- other - for setting other id origin signals please use the [adCOM!](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#object--extended-identifier-uids-) `atype` spec
+    - dmp - this uid comes from the in-page dmp named in eids.source
+    - ppuid - this uid comes from the publisher named in eids.source
+    - other - for setting other id origin signals please use the [adCOM!](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#object--extended-identifier-uids-) `atype` spec
 
 5. Bid adapters listening for "userIds.pubProvidedId" will not receive a string, please use the userIdAsEids value/function to return the userid as a string.
 

--- a/dev-docs/modules/userid-submodules/ramp.md
+++ b/dev-docs/modules/userid-submodules/ramp.md
@@ -39,48 +39,48 @@ The RampID privacy policy is at [https://liveramp.com/privacy/service-privacy-po
 
 ## RampID Examples
 
-1) Publisher passes a Placement ID and elects to store the RampID envelope in a first-party cookie.
+1. Publisher passes a Placement ID and elects to store the RampID envelope in a first-party cookie.
 
-```javascript
-pbjs.setConfig({
-    userSync: {
-        userIds: [{
-            name: "identityLink",
-            params: {
-                pid: "999",             // Set your Placement ID here
-                notUse3P: false
-            },
-            storage: {
-                type: "cookie",
-                name: "idl_env",        // "idl_env" is the required storage name
-                expires: 15,            // RampID envelope can last for 15 days
-                refreshInSeconds: 1800  // RampID envelope will be updated every 30 minutes
-            }
-        }],
-        syncDelay: 3000                 // 3 seconds after the first auction
-    }
-});
-```
+    ```javascript
+    pbjs.setConfig({
+        userSync: {
+            userIds: [{
+                name: "identityLink",
+                params: {
+                    pid: "999",             // Set your Placement ID here
+                    notUse3P: false
+                },
+                storage: {
+                    type: "cookie",
+                    name: "idl_env",        // "idl_env" is the required storage name
+                    expires: 15,            // RampID envelope can last for 15 days
+                    refreshInSeconds: 1800  // RampID envelope will be updated every 30 minutes
+                }
+            }],
+            syncDelay: 3000                 // 3 seconds after the first auction
+        }
+    });
+    ```
 
-2) Publisher passes a Placement ID and elects to store the RampID envelope in HTML5 localStorage.
+2. Publisher passes a Placement ID and elects to store the RampID envelope in HTML5 localStorage.
 
-```javascript
-pbjs.setConfig({
-    userSync: {
-        userIds: [{
-            name: "identityLink",
-            params: {
-                pid: "999",             // Set your Placement ID here
-                notUse3P: false
-            },
-            storage: {
-                type: "html5",
-                name: "idl_env",        // "idl_env" is the required storage name
-                expires: 15,            // RampID envelope can last for 15 days
-                refreshInSeconds: 1800  // RampID envelope will be updated every 30 minutes
-            }
-        }],
-        syncDelay: 3000                 // 3 seconds after the first auction
-    }
-});
-```
+    ```javascript
+    pbjs.setConfig({
+        userSync: {
+            userIds: [{
+                name: "identityLink",
+                params: {
+                    pid: "999",             // Set your Placement ID here
+                    notUse3P: false
+                },
+                storage: {
+                    type: "html5",
+                    name: "idl_env",        // "idl_env" is the required storage name
+                    expires: 15,            // RampID envelope can last for 15 days
+                    refreshInSeconds: 1800  // RampID envelope will be updated every 30 minutes
+                }
+            }],
+            syncDelay: 3000                 // 3 seconds after the first auction
+        }
+    });
+    ```

--- a/dev-docs/modules/userid-submodules/sharedid.md
+++ b/dev-docs/modules/userid-submodules/sharedid.md
@@ -35,70 +35,70 @@ In addition to the parameters documented above in the Basic Configuration sectio
 
 ## SharedID Examples
 
-1) Publisher supports SharedID and first party domain cookie storage
+1. Publisher supports SharedID and first party domain cookie storage
 
-```javascript
-pbjs.setConfig({
-    userSync: {
-        userIds: [{
-            name: "sharedId",
-            storage: {
-                type: "cookie",
-                name: "_sharedid",         // create a cookie with this name
-                expires: 365             // expires in 1 years
-            }
-        }]
-    }
-});
-```
+    ```javascript
+    pbjs.setConfig({
+        userSync: {
+            userIds: [{
+                name: "sharedId",
+                storage: {
+                    type: "cookie",
+                    name: "_sharedid",         // create a cookie with this name
+                    expires: 365             // expires in 1 years
+                }
+            }]
+        }
+    });
+    ```
 
-2) Publisher supports both UnifiedID and SharedID and first party domain cookie storage
+2. Publisher supports both UnifiedID and SharedID and first party domain cookie storage
 
-```javascript
-pbjs.setConfig({
-    userSync: {
-        userIds: [{
-            name: "unifiedId",
-            params: {
-                partner: "myTtdPid"
-            },
-            storage: {
-                type: "cookie",
-                name: "pbjs-unifiedid",       // create a cookie with this name
-                expires: 60
-            }
-        },{
-            name: "sharedId",
-            params: {
-                pixelUrl: "/wp-json/pubcid/v1/extend/"
-            },
-            storage: {
-                type: "cookie",
-                name: "_sharedid",      // create a cookie with this name
-                expires: 180
-            }
-        }],
-        syncDelay: 5000       // 5 seconds after the first bidRequest()
-    }
-});
-```
+    ```javascript
+    pbjs.setConfig({
+        userSync: {
+            userIds: [{
+                name: "unifiedId",
+                params: {
+                    partner: "myTtdPid"
+                },
+                storage: {
+                    type: "cookie",
+                    name: "pbjs-unifiedid",       // create a cookie with this name
+                    expires: 60
+                }
+            },{
+                name: "sharedId",
+                params: {
+                    pixelUrl: "/wp-json/pubcid/v1/extend/"
+                },
+                storage: {
+                    type: "cookie",
+                    name: "_sharedid",      // create a cookie with this name
+                    expires: 180
+                }
+            }],
+            syncDelay: 5000       // 5 seconds after the first bidRequest()
+        }
+    });
+    ```
 
-3) Publisher supports SharedID and first party domain cookie storage initiated by a first party server
+3. Publisher supports SharedID and first party domain cookie storage initiated by a first party server
 
-```javascript
-pbjs.setConfig({
-    userSync: {
-        userIds: [{
-            name: "sharedId",
-            params: {
-                pixelUrl: "/wp-json/pubcid/v1/extend/" //pixelUrl should be specified when the server plugin is used
-            },
-            storage: {
-                type: "cookie",
-                name: "_sharedid",        // create a cookie with this name
-                expires: 365              // expires in 1 year
-            }
-        }]
-    }
-});
-```
+    ```javascript
+    pbjs.setConfig({
+        userSync: {
+            userIds: [{
+                name: "sharedId",
+                params: {
+                    pixelUrl: "/wp-json/pubcid/v1/extend/" //pixelUrl should be specified when the server plugin is used
+                },
+                storage: {
+                    type: "cookie",
+                    name: "_sharedid",        // create a cookie with this name
+                    expires: 365              // expires in 1 year
+                }
+            }]
+        }
+    });
+    ```

--- a/dev-docs/modules/userid-submodules/unified.md
+++ b/dev-docs/modules/userid-submodules/unified.md
@@ -35,61 +35,61 @@ The Unified ID privacy is covered under the [TradeDesk Services Privacy Policy](
 
 ## Unified ID Examples
 
-1) Publisher has a partner ID with The Trade Desk, and is using the default endpoint for Unified ID.
+1. Publisher has a partner ID with The Trade Desk, and is using the default endpoint for Unified ID.
 
-{: .alert.alert-warning :}
-Bug: The default URL did not support HTTPS in Prebid.js 2.10-2.14. So instead of using
-the 'partner' parameter, it's best to supply the Trade Desk URL as shown in this example.
+    {: .alert.alert-warning :}
+    Bug: The default URL did not support HTTPS in Prebid.js 2.10-2.14. So instead of using
+    the 'partner' parameter, it's best to supply the Trade Desk URL as shown in this example.
 
-```javascript
-pbjs.setConfig({
-    userSync: {
-        userIds: [{
-            name: "unifiedId",
-            params: {
-                url: "//match.adsrvr.org/track/rid?ttd_pid=MyTtidPid&fmt=json"
-            },
-            storage: {
-                type: "cookie",
-                name: "pbjs-unifiedid",       // create a cookie with this name
-                expires: 60                   // cookie can last for 60 days
-            }
-        }],
-        syncDelay: 3000              // 3 seconds after the first auction
-    }
-});
-```
+    ```javascript
+    pbjs.setConfig({
+        userSync: {
+            userIds: [{
+                name: "unifiedId",
+                params: {
+                    url: "//match.adsrvr.org/track/rid?ttd_pid=MyTtidPid&fmt=json"
+                },
+                storage: {
+                    type: "cookie",
+                    name: "pbjs-unifiedid",       // create a cookie with this name
+                    expires: 60                   // cookie can last for 60 days
+                }
+            }],
+            syncDelay: 3000              // 3 seconds after the first auction
+        }
+    });
+    ```
 
-2) Publisher supports UnifiedID with a vendor other than Trade Desk and HTML5 local storage.
+2. Publisher supports UnifiedID with a vendor other than Trade Desk and HTML5 local storage.
 
-```javascript
-pbjs.setConfig({
-    userSync: {
-        userIds: [{
-            name: "unifiedId",
-            params: {
-                url: "URL_TO_UNIFIED_ID_SERVER"
-            },
-            storage: {
-                type: "html5",
-                name: "pbjs-unifiedid",    // set localstorage with this name
-                expires: 60
-            }
-        }],
-        syncDelay: 3000
-    }
-});
-```
+    ```javascript
+    pbjs.setConfig({
+        userSync: {
+            userIds: [{
+                name: "unifiedId",
+                params: {
+                    url: "URL_TO_UNIFIED_ID_SERVER"
+                },
+                storage: {
+                    type: "html5",
+                    name: "pbjs-unifiedid",    // set localstorage with this name
+                    expires: 60
+                }
+            }],
+            syncDelay: 3000
+        }
+    });
+    ```
 
-3) Publisher has integrated with UnifiedID on their own and wants to pass the UnifiedID directly through to Prebid.js.
+3. Publisher has integrated with UnifiedID on their own and wants to pass the UnifiedID directly through to Prebid.js.
 
-```javascript
-pbjs.setConfig({
-    userSync: {
-        userIds: [{
-            name: "unifiedId",
-            value: {"tdid": "D6885E90-2A7A-4E0F-87CB-7734ED1B99A3"}
-        }]
-    }
-});
-```
+    ```javascript
+    pbjs.setConfig({
+        userSync: {
+            userIds: [{
+                name: "unifiedId",
+                value: {"tdid": "D6885E90-2A7A-4E0F-87CB-7734ED1B99A3"}
+            }]
+        }
+    });
+    ```

--- a/dev-docs/modules/userid-submodules/yahoo.md
+++ b/dev-docs/modules/userid-submodules/yahoo.md
@@ -34,7 +34,7 @@ The Yahoo-supplied publisher-specific pixel ID. | `"0000"` |
 
 ## Yahoo ConnectID Examples
 
-```
+```javascript
 // [Sample #1]: Using a hashed email only.
 
 pbjs.setConfig({
@@ -50,7 +50,7 @@ pbjs.setConfig({
 })
 ```
 
-```
+```javascript
 // [Sample #2]: Neither a hashed email nor a publisher user identifier is passed.
 
 pbjs.setConfig({
@@ -65,7 +65,7 @@ pbjs.setConfig({
 })
 ```
 
-```
+```javascript
 // [Sample #3]: Using a hashed email and a publisher user identifier such as a first-party cookie.
 
 pbjs.setConfig({
@@ -86,14 +86,14 @@ pbjs.setConfig({
 
 Follow the steps below to check that ConnectIDs are being successfully retrieved and included on ad requests.
 
-1) Open a Prebid-enabled page on the website.
-2) Open the browser console and enter pbjs.getUserIds().
-3) Verify connectId is in the list.
+1. Open a Prebid-enabled page on the website.
+2. Open the browser console and enter pbjs.getUserIds().
+3. Verify connectId is in the list.
    - If connectId is not in the list, the correct pixelId parameter is likely not being passed. Verify you are using the correct value provided by Yahoo. Reach out to [connectid.support@yahooinc.com](mailto:connectid.support@yahooinc.com) for assistance.
-4) Verify that ConnectID is successfully included in the ad requests.
+4. Verify that ConnectID is successfully included in the ad requests.
    - Go to the Network tab and search for an ad call event to any of the SSPs that you are using (e.g., “prebid-client”).
    - Navigate to the Payload tab. Check that yahoo.com is listed as a source in the user.ext.eids array.
-5) Repeat steps 1-4 after an email is provided via login or some other mechanism used to collect user registration on the website.
+5. Repeat steps 1-4 after an email is provided via login or some other mechanism used to collect user registration on the website.
 
 ## Honoring Privacy Choices
 

--- a/dev-docs/modules/validationFpdModule.md
+++ b/dev-docs/modules/validationFpdModule.md
@@ -19,13 +19,13 @@ For this reason, publishers sensitive to javascript size may want to consider ru
 
 Add it to the Prebid.js build with this command:
 
-```
+```bash
 gulp build --modules=validationFpdModule
 ```
 
 If included in the build, it will automatically perform the defined validations unless controlled with setConfig:
 
-```
+```javascript
 pbjs.setConfig({
     firstPartyData: {
         skipValidations: true    // defaults to false

--- a/faq/prebid-server-faq.md
+++ b/faq/prebid-server-faq.md
@@ -101,8 +101,8 @@ For Prebid.js-initated server requests, we've found that cookie match rates are 
 
 If a bidder adapter supplies 'nurl' in the bidResponse object, there are two paths:
 
-1) If it's cached in Prebid Cache (e.g. AMP and App), then the 'nurl' is cached along with the 'adm' and utilized by the Prebid Universal Creative.
-2) If it's not cached, the Prebid.js PrebidServerBidAdapter will append the 'nurl' to the bottom of the creative in a new div.
+1. If it's cached in Prebid Cache (e.g. AMP and App), then the 'nurl' is cached along with the 'adm' and utilized by the Prebid Universal Creative.
+2. If it's not cached, the Prebid.js PrebidServerBidAdapter will append the 'nurl' to the bottom of the creative in a new div.
 
 **Video**
 

--- a/guide.md
+++ b/guide.md
@@ -287,11 +287,11 @@ there's only one documentation file and of course one PBJS adapter file. An rela
 long bidderCode, but found it awkward to set up ad server targeting variables because GAM limits you to 20 chars, which is easy to exceed
 with a prefix like `hb_cache_host`. So they wanted to have shorter bidderCode for new customers while supporting the legacy targeting variables. In that scenario, they:
 
-1) add the shorter code as an alias in their PBJS file, which can stay the old longer name
-2) change the biddercode to the shorter name as it's the new preferred code
-3) add aliasCode so the Download page will pull in the right module
-4) optionally add prevBiddercode to add a note to the page about the legacy value
-5) optionally add filename if the bid adapter was created using a filename that's different than their bidder code. e.g. if the biddercode is "biddera" but they named the file "bidderABidAdapter", set the biddercode to "biddera" and the filename to "bidderABidAdapter".
+1. add the shorter code as an alias in their PBJS file, which can stay the old longer name
+2. change the biddercode to the shorter name as it's the new preferred code
+3. add aliasCode so the Download page will pull in the right module
+4. optionally add prevBiddercode to add a note to the page about the legacy value
+5. optionally add filename if the bid adapter was created using a filename that's different than their bidder code. e.g. if the biddercode is "biddera" but they named the file "bidderABidAdapter", set the biddercode to "biddera" and the filename to "bidderABidAdapter".
 
 ## Algolia Search
 

--- a/prebid-server/developers/add-a-module-go.md
+++ b/prebid-server/developers/add-a-module-go.md
@@ -128,106 +128,110 @@ In a module it is not necessary to implement all mentioned interfaces but at lea
 
 ### Examples
 
-1) To **update** the request in the `BidderRequest`, your implementation would return a hook result with a change set:
-```
-import (
-    "context"
+1. To **update** the request in the `BidderRequest`, your implementation would return a hook result with a change set:
 
-    "github.com/prebid/prebid-server/hooks/hookstage"
-)
+    ```go
+    import (
+        "context"
 
-type Module struct{}
+        "github.com/prebid/prebid-server/hooks/hookstage"
+    )
 
-func (m Module) HandleBidderRequestHook(
-    ctx context.Context,
-    invocationCtx hookstage.ModuleInvocationContext,
-    payload hookstage.BidderRequestPayload,
-) (hookstage.HookResult[hookstage.BidderRequestPayload], error) {
-    changeSet := hookstage.ChangeSet[hookstage.BidderRequestPayload]{}
-    changeSet.BidderRequest().BAdv().Update([]string{"a.com"})
-    
-    return hookstage.HookResult[hookstage.BidderRequestPayload]{ChangeSet: changeSet}, nil
-}
-```
+    type Module struct{}
 
-Please note, the `hookstage.ChangeSet` has a restricted set of methods, but methods can be easily extended when more use cases come up.
+    func (m Module) HandleBidderRequestHook(
+        ctx context.Context,
+        invocationCtx hookstage.ModuleInvocationContext,
+        payload hookstage.BidderRequestPayload,
+    ) (hookstage.HookResult[hookstage.BidderRequestPayload], error) {
+        changeSet := hookstage.ChangeSet[hookstage.BidderRequestPayload]{}
+        changeSet.BidderRequest().BAdv().Update([]string{"a.com"})
+        
+        return hookstage.HookResult[hookstage.BidderRequestPayload]{ChangeSet: changeSet}, nil
+    }
+    ```
 
-For more complex payload updates, you can choose another method:
-```
-func (m Module) HandleBidderRequestHook(
-    ctx context.Context,
-    invocationCtx hookstage.ModuleInvocationContext,
-    payload hookstage.BidderRequestPayload,
-) (hookstage.HookResult[hookstage.BidderRequestPayload], error) {
-    battrByImp := map[string][]adcom1.CreativeAttribute{"imp_ID1": []adcom1.CreativeAttribute{adcom1.AttrAudioAuto}}
-    changeSet := hookstage.ChangeSet[hookstage.BidderRequestPayload]{}
-    changeSet.AddMutation(func(payload hookstage.BidderRequestPayload) (hookstage.BidderRequestPayload, error) {
-        for i, imp := range payload.BidRequest.Imp {
-            if battr, ok := battrByImp[imp.ID]; ok {
-                imp.Banner.BAttr = battr
-                payload.BidRequest.Imp[i] = imp
+    Please note, the `hookstage.ChangeSet` has a restricted set of methods, but methods can be easily extended when more use cases come up.
+
+    For more complex payload updates, you can choose another method:
+
+    ```go
+    func (m Module) HandleBidderRequestHook(
+        ctx context.Context,
+        invocationCtx hookstage.ModuleInvocationContext,
+        payload hookstage.BidderRequestPayload,
+    ) (hookstage.HookResult[hookstage.BidderRequestPayload], error) {
+        battrByImp := map[string][]adcom1.CreativeAttribute{"imp_ID1": []adcom1.CreativeAttribute{adcom1.AttrAudioAuto}}
+        changeSet := hookstage.ChangeSet[hookstage.BidderRequestPayload]{}
+        changeSet.AddMutation(func(payload hookstage.BidderRequestPayload) (hookstage.BidderRequestPayload, error) {
+            for i, imp := range payload.BidRequest.Imp {
+                if battr, ok := battrByImp[imp.ID]; ok {
+                    imp.Banner.BAttr = battr
+                    payload.BidRequest.Imp[i] = imp
+                }
             }
-        }
-        return payload, nil
-    }, hookstage.MutationUpdate, "bidrequest", "imp", "banner", "battr")
-    
-    return hookstage.HookResult[hookstage.BidderRequestPayload]{ChangeSet: changeSet}, nil
-}
-```
+            return payload, nil
+        }, hookstage.MutationUpdate, "bidrequest", "imp", "banner", "battr")
+        
+        return hookstage.HookResult[hookstage.BidderRequestPayload]{ChangeSet: changeSet}, nil
+    }
+    ```
 
-2) To **reject** the bidder in the `BidderRequest`, your hook implementation would return a hook result with a reject flag and an NBR code:
-```
-func (m Module) HandleBidderRequestHook(
-    ctx context.Context,
-    invocationCtx hookstage.ModuleInvocationContext,
-    payload hookstage.BidderRequestPayload,
-) (hookstage.HookResult[hookstage.BidderRequestPayload], error) {
-    return hookstage.HookResult[hookstage.BidderRequestPayload]{Reject: true, NbrCode: 7}, nil
-}
-```
+2. To **reject** the bidder in the `BidderRequest`, your hook implementation would return a hook result with a reject flag and an NBR code:
 
-Refer [here](https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/OpenRTB%20v3.0%20FINAL.md#list--no-bid-reason-codes-) for a list of available No Bid Response Codes.
+    ```go
+    func (m Module) HandleBidderRequestHook(
+        ctx context.Context,
+        invocationCtx hookstage.ModuleInvocationContext,
+        payload hookstage.BidderRequestPayload,
+    ) (hookstage.HookResult[hookstage.BidderRequestPayload], error) {
+        return hookstage.HookResult[hookstage.BidderRequestPayload]{Reject: true, NbrCode: 7}, nil
+    }
+    ```
 
-3) To supply [analytics tags](/prebid-server/developers/module-atags.html) in the `BidderRequest`, your hook implementation would return a hook result with analytics tags:
-```
-import (
-    "context"
+    Refer [here](https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/OpenRTB%20v3.0%20FINAL.md#list--no-bid-reason-codes-) for a list of available No Bid Response Codes.
 
-    "github.com/prebid/prebid-server/hooks/hookstage"
-    "github.com/prebid/prebid-server/hooks/hookanalytics"
-)
+3. To supply [analytics tags](/prebid-server/developers/module-atags.html) in the `BidderRequest`, your hook implementation would return a hook result with analytics tags:
 
-func (m Module) HandleBidderRequestHook(
-    ctx context.Context,
-    invocationCtx hookstage.ModuleInvocationContext,
-    payload hookstage.BidderRequestPayload,
-) (hookstage.HookResult[hookstage.BidderRequestPayload], error) {
-    return hookstage.HookResult[hookstage.BidderRequestPayload]{
-        AnalyticsTags: hookanalytics.Analytics{
-            Activities: []hookanalytics.Activity{
-                {
-                    Name:   "enforce_blocking",
-                    Status: hookanalytics.ActivityStatusSuccess,
-                    Results: []hookanalytics.Result{
-                        {
-                            Status: hookanalytics.ResultStatusBlock,
-                            Values: map[string]interface{}{
-                                "attributes": []string{"bcat"},
-                                "bcat":       []string{"IAB-1"},
+    ```go
+    import (
+        "context"
+
+        "github.com/prebid/prebid-server/hooks/hookstage"
+        "github.com/prebid/prebid-server/hooks/hookanalytics"
+    )
+
+    func (m Module) HandleBidderRequestHook(
+        ctx context.Context,
+        invocationCtx hookstage.ModuleInvocationContext,
+        payload hookstage.BidderRequestPayload,
+    ) (hookstage.HookResult[hookstage.BidderRequestPayload], error) {
+        return hookstage.HookResult[hookstage.BidderRequestPayload]{
+            AnalyticsTags: hookanalytics.Analytics{
+                Activities: []hookanalytics.Activity{
+                    {
+                        Name:   "enforce_blocking",
+                        Status: hookanalytics.ActivityStatusSuccess,
+                        Results: []hookanalytics.Result{
+                            {
+                                Status: hookanalytics.ResultStatusBlock,
+                                Values: map[string]interface{}{
+                                    "attributes": []string{"bcat"},
+                                    "bcat":       []string{"IAB-1"},
+                                },
+                                AppliedTo: hookanalytics.AppliedTo{Bidder: "appnexus", ImpIds: []string{"imp_ID1"}},
                             },
-                            AppliedTo: hookanalytics.AppliedTo{Bidder: "appnexus", ImpIds: []string{"imp_ID1"}},
-                        },
-                        {
-                            Status:    hookanalytics.ResultStatusAllow,
-                            AppliedTo: hookanalytics.AppliedTo{Bidder: "appnexus", ImpIds: []string{"imp_ID2"}},
+                            {
+                                Status:    hookanalytics.ResultStatusAllow,
+                                AppliedTo: hookanalytics.AppliedTo{Bidder: "appnexus", ImpIds: []string{"imp_ID2"}},
+                            },
                         },
                     },
                 },
             },
-        },
-    }, nil
-}
-```
+        }, nil
+    }
+    ```
 
 More test implementations for each hook can be found in unit-tests at [https://github.com/prebid/prebid-server/tree/master/modules/prebid/ortb2blocking](https://github.com/prebid/prebid-server/tree/master/modules/prebid/ortb2blocking) folder.
 

--- a/prebid-server/developers/add-a-module-java.md
+++ b/prebid-server/developers/add-a-module-java.md
@@ -129,50 +129,53 @@ Each hook interface internally extends org.prebid.server.hooks.v1.Hook basic int
 
 ### Examples
 
-1) To **update** the request in the `RawAuctionRequestHook` you would return:
-```
-Future.succeededFuture(
-    InvocationResultImpl.<AuctionRequestPayload>builder()
-        .status(InvocationStatus.success)
-        .action(InvocationAction.update)
-        .payloadUpdate(payload ->
-          AuctionRequestPayloadImpl.of(payload.bidRequest().toBuilder()
-                  .id("updated request ID")
-                  .build()))
-    .build()
-);
-```
+1. To **update** the request in the `RawAuctionRequestHook` you would return:
 
-Please note that the `InvocationStatus` is only considered when the status is set to `InvocationStatus.success`. That means the `payloadUpdate` is only applied with `InvocationStatus.success` **and** `InvocationAction.update`
+    ```java
+    Future.succeededFuture(
+        InvocationResultImpl.<AuctionRequestPayload>builder()
+            .status(InvocationStatus.success)
+            .action(InvocationAction.update)
+            .payloadUpdate(payload ->
+              AuctionRequestPayloadImpl.of(payload.bidRequest().toBuilder()
+                      .id("updated request ID")
+                      .build()))
+        .build()
+    );
+    ```
 
-2) To **reject** the request in the `RawAuctionRequestHook` you would return:
-```
-Future.succeededFuture(
-    InvocationResultImpl.rejected(“The rejection reason”)
-);
-```
+    Please note that the `InvocationStatus` is only considered when the status is set to `InvocationStatus.success`. That means the `payloadUpdate` is only applied with `InvocationStatus.success` **and** `InvocationAction.update`
 
-3) To supply [analytics tags](/prebid-server/developers/module-atags.html) in the `RawAuctionRequestHook` you would return:
-```
-Future.succeededFuture(
-    InvocationResultImpl.<AuctionRequestPayload>builder()
-        ...
-        .analyticsTags(TagsImpl.of(
-            Collections.singletonList(ActivityImpl.of(
-                "device-id",
-                "success",
-                Collections.singletonList(ResultImpl.of(
+2. To **reject** the request in the `RawAuctionRequestHook` you would return:
+
+    ```java
+    Future.succeededFuture(
+        InvocationResultImpl.rejected(“The rejection reason”)
+    );
+    ```
+
+3. To supply [analytics tags](/prebid-server/developers/module-atags.html) in the `RawAuctionRequestHook` you would return:
+
+    ```java
+    Future.succeededFuture(
+        InvocationResultImpl.<AuctionRequestPayload>builder()
+            ...
+            .analyticsTags(TagsImpl.of(
+                Collections.singletonList(ActivityImpl.of(
+                    "device-id",
                     "success",
-                    mapper.mapper().createObjectNode()
-                        .put("some-field", "some-value"),
-                AppliedToImpl.builder()
-                       .impIds(Collections.singletonList("impId1"))
-                       .request(true)
-                       .build()))))))
-        ...
-    .build()
-);
-```
+                    Collections.singletonList(ResultImpl.of(
+                        "success",
+                        mapper.mapper().createObjectNode()
+                            .put("some-field", "some-value"),
+                    AppliedToImpl.builder()
+                          .impIds(Collections.singletonList("impId1"))
+                          .request(true)
+                          .build()))))))
+            ...
+        .build()
+    );
+    ```
 
 More test implementations for each hook can be found in unit-tests at https://github.com/prebid/prebid-server-java/tree/master/src/test/java/org/prebid/server/it/hooks folder.
 

--- a/prebid-server/developers/add-new-bidder-java.md
+++ b/prebid-server/developers/add-new-bidder-java.md
@@ -737,58 +737,58 @@ Here are 3 key points to consider:
 
 If you need to convert floor prices from one currency into something your endpoint expects, you can use the convertCurrency function from CurrencyConversionService component.
 
-1) Inject CurrencyConversionService to your {bidder}Configuration class and pass it to your bidder constructor.
+1. Inject CurrencyConversionService to your {bidder}Configuration class and pass it to your bidder constructor.
 
-```java
-@Autowired
-private CurrencyConversionService currencyConversionService;
+    ```java
+    @Autowired
+    private CurrencyConversionService currencyConversionService;
 
-... 
+    ... 
 
-.bidderCreator(() -> new {bidder}Bidder(configProperties.getEndpoint(), currencyConversionService, mapper))
-```
+    .bidderCreator(() -> new {bidder}Bidder(configProperties.getEndpoint(), currencyConversionService, mapper))
+    ```
 
-2) Create additional class variable `private final CurrencyConversionService currencyConversionService;` and update constructor in your {bidder}Bidder class to set this variable.
+2. Create additional class variable `private final CurrencyConversionService currencyConversionService;` and update constructor in your {bidder}Bidder class to set this variable.
 
-```java
-private final CurrencyConversionService currencyConversionService;
-private final String endpointUrl;
-private final JacksonMapper mapper;
+    ```java
+    private final CurrencyConversionService currencyConversionService;
+    private final String endpointUrl;
+    private final JacksonMapper mapper;
 
-public {bidder}Bidder(String endpointUrl,  CurrencyConversionService currencyConversionService, JacksonMapper mapper) {
-        this.endpointUrl = HttpUtil.validateUrl(Objects.requireNonNull(endpointUrl));
-        this.currencyConversionService = Objects.requireNonNull(currencyConversionService);
-        this.mapper = Objects.requireNonNull(mapper);
-    }
-```
+    public {bidder}Bidder(String endpointUrl,  CurrencyConversionService currencyConversionService, JacksonMapper mapper) {
+            this.endpointUrl = HttpUtil.validateUrl(Objects.requireNonNull(endpointUrl));
+            this.currencyConversionService = Objects.requireNonNull(currencyConversionService);
+            this.mapper = Objects.requireNonNull(mapper);
+        }
+    ```
 
-3) Use `currencyConversionService.convertCurrency(BigDecimal price, BidRequest bidRequest, String fromCurrency, String toCurrency)` for currency converting in {bidder}Bidder class.
+3. Use `currencyConversionService.convertCurrency(BigDecimal price, BidRequest bidRequest, String fromCurrency, String toCurrency)` for currency converting in {bidder}Bidder class.
 
-<details markdown="1">
-  <summary>Example: Updating bidFloor currency.</summary>
+    <details markdown="1">
+      <summary>Example: Updating bidFloor currency.</summary>
 
-```java
-  private Imp makeImp(Imp imp, BidRequest bidRequest) {
-        return imp.toBuilder().bidfloor(resolveBidFloor(imp, bidRequest)).build();
-    }
+    ```java
+      private Imp makeImp(Imp imp, BidRequest bidRequest) {
+            return imp.toBuilder().bidfloor(resolveBidFloor(imp, bidRequest)).build();
+        }
 
-  private BigDecimal resolveBidFloor(Imp imp, BidRequest bidRequest) {
-        final String bidFloorCurrency = resolveBidFloorCurrency(imp);
-        final BigDecimal bidFloor = imp.getBidfloor();
-        return convertBidFloorCurrency(imp, bidRequest, bidFloor, bidFloorCurrency);
-    }
-    
-  private BigDecimal convertBidFloorCurrency(Imp imp, BidRequest bidRequest, BigDecimal bidFloor, String bidFloorCurrency) {
-      try {
-            return currencyConversionService.convertCurrency(bidFloor, bidRequest,
-                    bidFloorCurrency, "NEEDED_CURRENCY");
-      } catch (PreBidException ex) {
-            throw new PreBidException(String.format("Failed to convert bidfloor with a reason: %s", ex.getMessage()));
+      private BigDecimal resolveBidFloor(Imp imp, BidRequest bidRequest) {
+            final String bidFloorCurrency = resolveBidFloorCurrency(imp);
+            final BigDecimal bidFloor = imp.getBidfloor();
+            return convertBidFloorCurrency(imp, bidRequest, bidFloor, bidFloorCurrency);
+        }
+        
+      private BigDecimal convertBidFloorCurrency(Imp imp, BidRequest bidRequest, BigDecimal bidFloor, String bidFloorCurrency) {
+          try {
+                return currencyConversionService.convertCurrency(bidFloor, bidRequest,
+                        bidFloorCurrency, "NEEDED_CURRENCY");
+          } catch (PreBidException ex) {
+                throw new PreBidException(String.format("Failed to convert bidfloor with a reason: %s", ex.getMessage()));
+          }
       }
-  }
-```
-</details>
-<p></p>
+    ```
+    </details>
+    <p></p>
 
 ### Price Floors
 
@@ -798,91 +798,91 @@ However, as described in the feature documentation, some adapters may benefit fr
 
 Here are the instructions:
 
-1) Inject `PriceFloorResolver` to your {bidder}Configuration class and pass it to your bidder constructor.
+1. Inject `PriceFloorResolver` to your {bidder}Configuration class and pass it to your bidder constructor.
 
-```java
-BidderDeps {bidder}BidderDeps(BidderConfigurationProperties {bidder}ConfigurationProperties,
-                              @NotBlank @Value("${external-url}") String externalUrl,
-                              PriceFloorResolver floorResolver,
-                              JacksonMapper mapper) {
+    ```java
+    BidderDeps {bidder}BidderDeps(BidderConfigurationProperties {bidder}ConfigurationProperties,
+                                  @NotBlank @Value("${external-url}") String externalUrl,
+                                  PriceFloorResolver floorResolver,
+                                  JacksonMapper mapper) {
 
-...
+    ...
 
-.bidderCreator(() -> new {bidder}Bidder(configProperties.getEndpoint(), floorResolver, mapper))
-```
+    .bidderCreator(() -> new {bidder}Bidder(configProperties.getEndpoint(), floorResolver, mapper))
+    ```
 
-2) Create an additional class variable `private final PriceFloorResolver floorResolver` and update constructor in your {bidder}Bidder class to set this variable.
+2. Create an additional class variable `private final PriceFloorResolver floorResolver` and update constructor in your {bidder}Bidder class to set this variable.
 
-```java
-private final PriceFloorResolver floorResolver;
-private final String endpointUrl;
-private final JacksonMapper mapper;
+    ```java
+    private final PriceFloorResolver floorResolver;
+    private final String endpointUrl;
+    private final JacksonMapper mapper;
 
-public {bidder}Bidder(String endpointUrl, PriceFloorResolver floorResolver, JacksonMapper mapper) {
-        this.endpointUrl = HttpUtil.validateUrl(Objects.requireNonNull(endpointUrl));
-        this.floorResolver = Objects.requireNonNull(floorResolver);
-        this.mapper = Objects.requireNonNull(mapper);
-    }
-```
+    public {bidder}Bidder(String endpointUrl, PriceFloorResolver floorResolver, JacksonMapper mapper) {
+            this.endpointUrl = HttpUtil.validateUrl(Objects.requireNonNull(endpointUrl));
+            this.floorResolver = Objects.requireNonNull(floorResolver);
+            this.mapper = Objects.requireNonNull(mapper);
+        }
+    ```
 
-3) Use `floorResolver.resolve(BidRequest bidRequest,
+3. Use `floorResolver.resolve(BidRequest bidRequest,
    PriceFloorRules floorRules,
    Imp imp,
    ImpMediaType mediaType,
    Format format,
    List<String> warnings)` for resolving specific floor values in your {bidder}Bidder class.
 
-<details markdown="1">
-  <summary>Example: Updating bidFloor values.</summary>
+    <details markdown="1">
+      <summary>Example: Updating bidFloor values.</summary>
 
-```java
-  private Imp makeImp(Imp imp, BidRequest bidRequest) {
-        final PriceFloorResult priceFloorResult = resolvePriceFloors(
-                bidRequest, 
-                imp,                        // com.iab.openrtb.request.Imp
-                specificMediatype,          // org.prebid.server.proto.openrtb.ext.request.ImpMediaType
-                specificFormat,             // com.iab.openrtb.request.Format (size)
-                priceFloorsWarnings);
-                
-        return imp.toBuilder()
-                .bidfloor(ObjectUtil.getIfNotNull(priceFloorResult, PriceFloorResult::getFloorValue))
-                .bidfloorcur(ObjectUtil.getIfNotNull(priceFloorResult, PriceFloorResult::getCurrency))
-                .build();
-    }
-    
-  private PriceFloorResult resolvePriceFloors(BidRequest bidRequest,
-                                                Imp imp,
-                                                ImpMediaType mediaType,
-                                                Format format,
-                                                List<String> warnings) {
+    ```java
+      private Imp makeImp(Imp imp, BidRequest bidRequest) {
+            final PriceFloorResult priceFloorResult = resolvePriceFloors(
+                    bidRequest, 
+                    imp,                        // com.iab.openrtb.request.Imp
+                    specificMediatype,          // org.prebid.server.proto.openrtb.ext.request.ImpMediaType
+                    specificFormat,             // com.iab.openrtb.request.Format (size)
+                    priceFloorsWarnings);
+                    
+            return imp.toBuilder()
+                    .bidfloor(ObjectUtil.getIfNotNull(priceFloorResult, PriceFloorResult::getFloorValue))
+                    .bidfloorcur(ObjectUtil.getIfNotNull(priceFloorResult, PriceFloorResult::getCurrency))
+                    .build();
+        }
+        
+      private PriceFloorResult resolvePriceFloors(BidRequest bidRequest,
+                                                    Imp imp,
+                                                    ImpMediaType mediaType,
+                                                    Format format,
+                                                    List<String> warnings) {
 
-        return floorResolver.resolve(
-                bidRequest,
-                extractFloorRules(bidRequest),
-                imp,
-                mediaType,
-                format,
-                warnings);
-    }
-```
-</details>
+            return floorResolver.resolve(
+                    bidRequest,
+                    extractFloorRules(bidRequest),
+                    imp,
+                    mediaType,
+                    format,
+                    warnings);
+        }
+    ```
+    </details>
 
-4) Let the Price Floors feature know about the floors you're using. To do that, enrich BidderBid with `priceFloorInfo`
+4. Let the Price Floors feature know about the floors you're using. To do that, enrich BidderBid with `priceFloorInfo`
 
-```java
-private static BidderBid createBidderBid(Bid bid, Imp imp, BidType bidType, String currency) {
+    ```java
+    private static BidderBid createBidderBid(Bid bid, Imp imp, BidType bidType, String currency) {
 
-        return BidderBid.builder()
-                .bid(bid)
-                .type(bidType)
-                .bidCurrency(currency)
-                .priceFloorInfo(imp != null ? PriceFloorInfo.of(imp.getBidfloor(), imp.getBidfloorcur()) : null)
-                .build();
-    }
-```
-<p></p>
+            return BidderBid.builder()
+                    .bid(bid)
+                    .type(bidType)
+                    .bidCurrency(currency)
+                    .priceFloorInfo(imp != null ? PriceFloorInfo.of(imp.getBidfloor(), imp.getBidfloorcur()) : null)
+                    .build();
+        }
+    ```
+    <p></p>
 
-2. Test: 
+5. Test: 
 
 ## Test Your Adapter
 
@@ -946,278 +946,286 @@ adapters.{bidder}.usersync.url=//{bidder}-usersync
 Go to test resources `org.prebid.server.it.openrtb2` and create directory with `{bidder}` name.
 Add files with content specific to your case:
 
-1) `test-auction-{bidder}-request.json`
-```json
-{
-  "id": "tid",
-  "imp": [
+1. `test-auction-{bidder}-request.json`
+
+    ```json
     {
-      "id": "impId001",
-      "banner": {
-        "format": [
-          {
-            "w": 300,
-            "h": 250
-          }
-        ]
-      },
-      "ext": {
-        "{bidder}": {
-          "param": "paramValue"
-        }
-      }
-    }
-  ],
-  "device": {
-    "pxratio": 4.2,
-    "dnt": 2,
-    "language": "en",
-    "ifa": "ifaId"
-  },
-  "site": {
-    "publisher": {
-      "id": "publisherId"
-    }
-  },
-  "at": 1,
-  "tmax": 5000,
-  "cur": [
-    "USD"
-  ],
-  "source": {
-    "fd": 1,
-    "tid": "tid"
-  },
-  "ext": {
-    "prebid": {
-      "targeting": {
-        "pricegranularity": {
-          "precision": 2,
-          "ranges": [
-            {
-              "max": 20,
-              "increment": 0.1
-            }
-          ]
-        }
-      },
-      "cache": {
-        "bids": {}
-      },
-      "auctiontimestamp": 1000
-    }
-  },
-  "regs": {
-    "ext": {
-      "gdpr": 0
-    }
-  }
-}
-```
-2) `test-auction-{bidder}-response.json`
-```json
-{
-  "id": "tid",
-  "seatbid": [
-    {
-      "bid": [
+      "id": "tid",
+      "imp": [
         {
-          "id": "bid001",
-          "impid": "impId001",
-          "price": 3.33,
-          "adm": "adm001",
-          "adid": "adid001",
-          "cid": "cid001",
-          "crid": "crid001",
-          "w": 300,
-          "h": 250,
-          "ext": {
-            "prebid": {
-              "type": "banner",
-              "targeting": {
-                "hb_pb": "3.30",
-                "hb_size_{bidder}": "300x250",
-                "hb_bidder_{bidder}": "{bidder}",
-                "hb_cache_path": "{{ cache.path }}",
-                "hb_size": "300x250",
-                "hb_cache_host_{bidder}": "{{ cache.host }}",
-                "hb_cache_path_{bidder}": "{{ cache.path }}",
-                "hb_cache_id_{bidder}": "f0ab9105-cb21-4e59-b433-70f5ad6671cb",
-                "hb_bidder": "{bidder}",
-                "hb_cache_id": "f0ab9105-cb21-4e59-b433-70f5ad6671cb",
-                "hb_pb_{bidder}": "3.30",
-                "hb_cache_host": "{{ cache.host }}"
-              },
-              "cache": {
-                "bids": {
-                  "url": "{{ cache.resource_url }}f0ab9105-cb21-4e59-b433-70f5ad6671cb",
-                  "cacheId": "f0ab9105-cb21-4e59-b433-70f5ad6671cb"
-                }
+          "id": "impId001",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
               }
+            ]
+          },
+          "ext": {
+            "{bidder}": {
+              "param": "paramValue"
             }
           }
         }
       ],
-      "seat": "{bidder}",
-      "group": 0
-    }
-  ],
-  "cur": "USD",
-  "ext": {
-    "responsetimemillis": {
-      "{bidder}": " {bidder}.response_time_ms }}",
-      "cache": "{{ cache.response_time_ms }}"
-    },
-    "prebid": {
-      "auctiontimestamp": 1000
-    },
-    "tmaxrequest": 5000
-  }
-}
-```
-
-3) `test-{bidder}-bid-request.json`
-```json
-{
-  "id": "tid",
-  "imp": [
-    {
-      "id": "impId001",
-      "banner": {
-        "format": [
-          {
-            "w": 300,
-            "h": 250
-          }
-        ]
+      "device": {
+        "pxratio": 4.2,
+        "dnt": 2,
+        "language": "en",
+        "ifa": "ifaId"
+      },
+      "site": {
+        "publisher": {
+          "id": "publisherId"
+        }
+      },
+      "at": 1,
+      "tmax": 5000,
+      "cur": [
+        "USD"
+      ],
+      "source": {
+        "fd": 1,
+        "tid": "tid"
       },
       "ext": {
-        "bidder": {
-          "param": "paramValue"
+        "prebid": {
+          "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            }
+          },
+          "cache": {
+            "bids": {}
+          },
+          "auctiontimestamp": 1000
+        }
+      },
+      "regs": {
+        "ext": {
+          "gdpr": 0
         }
       }
     }
-  ],
-  "site": {
-    "domain": "example.com",
-    "page": "http://www.example.com",
-    "publisher": {
-      "id": "publisherId"
-    },
-    "ext": {
-      "amp": 0
-    }
-  },
-  "device": {
-    "ua": "userAgent",
-    "dnt": 2,
-    "ip": "193.168.244.1",
-    "pxratio": 4.2,
-    "language": "en",
-    "ifa": "ifaId"
-  },
-  "user": {
-    "buyeruid" : "BTW-UID"
-  },
-  "at": 1,
-  "tmax": 5000,
-  "cur": [
-    "USD"
-  ],
-  "source": {
-    "fd": 1,
-    "tid": "tid"
-  },
-  "regs": {
-    "ext": {
-      "gdpr": 0
-    }
-  },
-  "ext": {
-    "prebid": {
-      "targeting": {
-        "pricegranularity": {
-          "precision": 2,
-          "ranges": [
+    ```
+2. `test-auction-{bidder}-response.json`
+
+    ```json
+    {
+      "id": "tid",
+      "seatbid": [
+        {
+          "bid": [
             {
-              "max": 20,
-              "increment": 0.1
+              "id": "bid001",
+              "impid": "impId001",
+              "price": 3.33,
+              "adm": "adm001",
+              "adid": "adid001",
+              "cid": "cid001",
+              "crid": "crid001",
+              "w": 300,
+              "h": 250,
+              "ext": {
+                "prebid": {
+                  "type": "banner",
+                  "targeting": {
+                    "hb_pb": "3.30",
+                    "hb_size_{bidder}": "300x250",
+                    "hb_bidder_{bidder}": "{bidder}",
+                    "hb_cache_path": "{{ cache.path }}",
+                    "hb_size": "300x250",
+                    "hb_cache_host_{bidder}": "{{ cache.host }}",
+                    "hb_cache_path_{bidder}": "{{ cache.path }}",
+                    "hb_cache_id_{bidder}": "f0ab9105-cb21-4e59-b433-70f5ad6671cb",
+                    "hb_bidder": "{bidder}",
+                    "hb_cache_id": "f0ab9105-cb21-4e59-b433-70f5ad6671cb",
+                    "hb_pb_{bidder}": "3.30",
+                    "hb_cache_host": "{{ cache.host }}"
+                  },
+                  "cache": {
+                    "bids": {
+                      "url": "{{ cache.resource_url }}f0ab9105-cb21-4e59-b433-70f5ad6671cb",
+                      "cacheId": "f0ab9105-cb21-4e59-b433-70f5ad6671cb"
+                    }
+                  }
+                }
+              }
             }
-          ]
+          ],
+          "seat": "{bidder}",
+          "group": 0
+        }
+      ],
+      "cur": "USD",
+      "ext": {
+        "responsetimemillis": {
+          "{bidder}": " {bidder}.response_time_ms }}",
+          "cache": "{{ cache.response_time_ms }}"
         },
-        "includewinners": true,
-        "includebidderkeys": true
-      },
-      "cache": {
-        "bids": {}
-      },
-      "auctiontimestamp": 1000,
-      "channel" : {
-        "name" : "web"
+        "prebid": {
+          "auctiontimestamp": 1000
+        },
+        "tmaxrequest": 5000
       }
     }
-  }
-}
-```
-4) `test-{bidder}-bid-response.json`
-```json
-{
-  "id": "tid",
-  "seatbid": [
+    ```
+
+3. `test-{bidder}-bid-request.json`
+
+    ```json
     {
-      "bid": [
+      "id": "tid",
+      "imp": [
         {
-          "id": "bid001",
-          "impid": "impId001",
-          "price": 3.33,
-          "adid": "adid001",
-          "crid": "crid001",
-          "cid": "cid001",
-          "adm": "adm001",
-          "h": 250,
-          "w": 300
+          "id": "impId001",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "param": "paramValue"
+            }
+          }
+        }
+      ],
+      "site": {
+        "domain": "example.com",
+        "page": "http://www.example.com",
+        "publisher": {
+          "id": "publisherId"
+        },
+        "ext": {
+          "amp": 0
+        }
+      },
+      "device": {
+        "ua": "userAgent",
+        "dnt": 2,
+        "ip": "193.168.244.1",
+        "pxratio": 4.2,
+        "language": "en",
+        "ifa": "ifaId"
+      },
+      "user": {
+        "buyeruid" : "BTW-UID"
+      },
+      "at": 1,
+      "tmax": 5000,
+      "cur": [
+        "USD"
+      ],
+      "source": {
+        "fd": 1,
+        "tid": "tid"
+      },
+      "regs": {
+        "ext": {
+          "gdpr": 0
+        }
+      },
+      "ext": {
+        "prebid": {
+          "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": true,
+            "includebidderkeys": true
+          },
+          "cache": {
+            "bids": {}
+          },
+          "auctiontimestamp": 1000,
+          "channel" : {
+            "name" : "web"
+          }
+        }
+      }
+    }
+    ```
+
+4. `test-{bidder}-bid-response.json`
+
+    ```json
+    {
+      "id": "tid",
+      "seatbid": [
+        {
+          "bid": [
+            {
+              "id": "bid001",
+              "impid": "impId001",
+              "price": 3.33,
+              "adid": "adid001",
+              "crid": "crid001",
+              "cid": "cid001",
+              "adm": "adm001",
+              "h": 250,
+              "w": 300
+            }
+          ]
         }
       ]
     }
-  ]
-}
+    ```
 
-```
-5) `test-cache-{bidder}-request.json`
-```json
-{
-  "puts": [
-    {
-      "type": "json",
-      "value": {
-        "id": "bid001",
-        "impid": "impId001",
-        "price": 3.33,
-        "adm": "adm001",
-        "adid": "adid001",
-        "cid": "cid001",
-        "crid": "crid001",
-        "w": 300,
-        "h": 250
-      }
-    }
-  ]
-}
-```
+5. `test-cache-{bidder}-request.json`
 
-6) `test-cache-{bidder}-response.json`
-```json
-{
-  "responses": [
+    ```json
     {
-      "uuid": "f0ab9105-cb21-4e59-b433-70f5ad6671cb"
+      "puts": [
+        {
+          "type": "json",
+          "value": {
+            "id": "bid001",
+            "impid": "impId001",
+            "price": 3.33,
+            "adm": "adm001",
+            "adid": "adid001",
+            "cid": "cid001",
+            "crid": "crid001",
+            "w": 300,
+            "h": 250
+          }
+        }
+      ]
     }
-  ]
-}
-```
+    ```
+
+6. `test-cache-{bidder}-response.json`
+
+    ```json
+    {
+      "responses": [
+        {
+          "uuid": "f0ab9105-cb21-4e59-b433-70f5ad6671cb"
+        }
+      ]
+    }
+    ```
 
 
 Create class `{bidder}Test`in test directory in package `org.prebid.server.it`. Extend `IntegrationTest` class with following content
+
 ```java
 package org.prebid.server.it;
 
@@ -1282,7 +1290,7 @@ Human readable documentation for bid adapters is required in the separate [prebi
 1. If you already have a Prebid.js bid adapter, update your existing bidder file in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders to add the `pbs: true` variable in the header section. If your Prebid Server bidding parameters are different from your Prebid.js parameters, please include the differences in this document for publishers to be aware.
 1. If you don't have a Prebid.js bid adapter, create a new file in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders using this template:
 
-```
+```markdown
 ---
 layout: bidder
 title: {bidder}

--- a/prebid-server/developers/pbs-cookie-sync.md
+++ b/prebid-server/developers/pbs-cookie-sync.md
@@ -34,50 +34,50 @@ Here's how these IDs get placed in the cookie from Prebid.js:
 ![Prebid Server Cookie Sync](/assets/images/prebid-server/pbs-cookie-sync.png){:class="pb-lg-img"}
 
 
-1) Prebid.js starts by calling the Prebid Server [`/cookie_sync`](/prebid-server/endpoints/pbs-endpoint-cookieSync.html), letting it know which server-side bidders will be participating in the header bidding auction.
+1. Prebid.js starts by calling the Prebid Server [`/cookie_sync`](/prebid-server/endpoints/pbs-endpoint-cookieSync.html), letting it know which server-side bidders will be participating in the header bidding auction.
 
-```
-POST https://prebid-server.example.com/cookie_sync
+    ```text
+    POST https://prebid-server.example.com/cookie_sync
 
-{"bidders":["bidderA","bidderB"], "gdpr":1, "gdpr_consent":"...", "us_privacy": "..."}
-```
+    {"bidders":["bidderA","bidderB"], "gdpr":1, "gdpr_consent":"...", "us_privacy": "..."}
+    ```
 
-2) If privacy regulations allow, Prebid Server will look at the `uids` cookie in the host domain and determine whether any bidders are missing or need to be refreshed. It responds with an array of pixel syncs. e.g.
+2. If privacy regulations allow, Prebid Server will look at the `uids` cookie in the host domain and determine whether any bidders are missing or need to be refreshed. It responds with an array of pixel syncs. e.g.
 
-```
-{"status":"ok","bidder_status":[{"bidder":"bidderA","no_cookie":true,"usersync":{"url":"//biddera.com/getuid?https%3A%2F%2Fprebid-server.example.com%2Fsetuid%3Fbidder%3DbidderA%26gdpr%3D%26gdpr_consent%3D%26us_privacy%3D%26uid%3D%24UID","type":"redirect","supportCORS":false}},{"bidder":"bidderB","no_cookie":true,"usersync":{"url":"https://bidderB.com/u/match?gdpr=&euconsent=&us_privacy=&redir=https%3A%2F%2Fprebid-server.example.com%2Fsetuid%3Fbidder%3DbidderB%26gdpr%3D%26gdpr_consent%3D%26us_privacy%3D%26uid%3D","type":"redirect","supportCORS":false}}]}
-```
+    ```
+    {"status":"ok","bidder_status":[{"bidder":"bidderA","no_cookie":true,"usersync":{"url":"//biddera.com/getuid?https%3A%2F%2Fprebid-server.example.com%2Fsetuid%3Fbidder%3DbidderA%26gdpr%3D%26gdpr_consent%3D%26us_privacy%3D%26uid%3D%24UID","type":"redirect","supportCORS":false}},{"bidder":"bidderB","no_cookie":true,"usersync":{"url":"https://bidderB.com/u/match?gdpr=&euconsent=&us_privacy=&redir=https%3A%2F%2Fprebid-server.example.com%2Fsetuid%3Fbidder%3DbidderB%26gdpr%3D%26gdpr_consent%3D%26us_privacy%3D%26uid%3D","type":"redirect","supportCORS":false}}]}
+    ```
 
-3) When it receives the response, Prebid.js loops through each element of `bidder_status[]`, dropping a pixel for each `bidder_status[].usersync.url`.
+3. When it receives the response, Prebid.js loops through each element of `bidder_status[]`, dropping a pixel for each `bidder_status[].usersync.url`.
 
-4) The bidder-specific endpoints read the users' cookie for the bidder's domain and respond with a redirect back to Prebid Server's [`/setuid` endpoint](/prebid-server/endpoints/pbs-endpoint-setuid.html)
+4. The bidder-specific endpoints read the users' cookie for the bidder's domain and respond with a redirect back to Prebid Server's [`/setuid` endpoint](/prebid-server/endpoints/pbs-endpoint-setuid.html)
 
-5) When the browser receives this redirect, it contacts Prebid Server, which will once again check the privacy settings and if allowed,  update the `uids` cookie.
+5. When the browser receives this redirect, it contacts Prebid Server, which will once again check the privacy settings and if allowed,  update the `uids` cookie.
 
 ### Setting the uids cookie from AMP
 
 Cookie sync for AMP works in a way quite similar to Prebid.js.
 
-1) The Prebid Server hosting company places the [load-cookie.html](#manually-initiating-a-sync) file onto a CDN. This script is part of the [Prebid Universal Creative](https://github.com/prebid/prebid-universal-creative/blob/master/src/cookieSync.js) repo.
+1. The Prebid Server hosting company places the [load-cookie.html](#manually-initiating-a-sync) file onto a CDN. This script is part of the [Prebid Universal Creative](https://github.com/prebid/prebid-universal-creative/blob/master/src/cookieSync.js) repo.
 
 See [the AMP implementation guide](/dev-docs/show-prebid-ads-on-amp-pages.html#user-sync) for more information.
 
-2) The publisher places the 'load-cookie' iframe into the page:
+2. The publisher places the 'load-cookie' iframe into the page:
 
-```
-<amp-iframe width="1" title="User Sync"
-  height="1"
-  sandbox="allow-scripts allow-same-origin"
-  frameborder="0"
-  src="https://PROVIDED_BY_HOSTCOMPANY/load-cookie.html?source=amp&endpoint=HOSTCOMPANY&max_sync_count=5">
-  <amp-img layout="fill" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" placeholder></amp-img>
-</amp-iframe>
-```
+    ```html
+    <amp-iframe width="1" title="User Sync"
+      height="1"
+      sandbox="allow-scripts allow-same-origin"
+      frameborder="0"
+      src="https://PROVIDED_BY_HOSTCOMPANY/load-cookie.html?source=amp&endpoint=HOSTCOMPANY&max_sync_count=5">
+      <amp-img layout="fill" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" placeholder></amp-img>
+    </amp-iframe>
+    ```
 
 {: .alert.alert-info :}
 If the publisher has an AMP Consent Management Platform, they should use `load-cookie-with-consent.html`.
 
-3) At runtime, the `load-cookie` script just calls the Prebid Server /cookie_sync endpoint. The rest works similar to what's described for Prebid.js above. One difference is that the bidders are not known on the AMP page so those aren't passed. Another difference is that AMP doesn't support iframe syncs, so load-cookie passes instructions to PBS so only pixel syncs are returned.
+3. At runtime, the `load-cookie` script just calls the Prebid Server /cookie_sync endpoint. The rest works similar to what's described for Prebid.js above. One difference is that the bidders are not known on the AMP page so those aren't passed. Another difference is that AMP doesn't support iframe syncs, so load-cookie passes instructions to PBS so only pixel syncs are returned.
 
 ### Cooperative Syncing
 
@@ -86,7 +86,8 @@ Prebid Server supports a 'Cooperative Syncing' mode where all enabled bidders ma
 Cooperative syncing can be configured at the host level. See the doc for [PBS-Java](https://github.com/prebid/prebid-server-java/blob/master/docs/config-app.md) and [PBS-Go](https://github.com/prebid/prebid-server/blob/master/config/usersync.go).
 
 This is how to control the coop syncing behavior from Prebid.js:
-```
+
+```javascript
 pbjs.setConfig({
   s2sConfig: {
     ...
@@ -94,6 +95,7 @@ pbjs.setConfig({
     userSyncLimit: 5
     ...
   }
+});
 ```
 
 ## Bidder Instructions for Building a Sync Endpoint
@@ -112,7 +114,8 @@ Bidders must implement an endpoint under their domain which accepts an encoded U
 The specific attributes can differ for your endpoint. For instance, you could choose to receive gdprConsent rather than gdpr_consent.
 
 Here's an example that shows the privacy macros as configured in PBS-Go:
-```
+
+```yaml
 userSync:
   redirect:
     url: https://some-bidder-domain.com/usersync-url?gdpr={%raw%}{{.GDPR}}{%endraw%}&consent={%raw%}{{.GDPRConsent}}{%endraw%}&us_privacy={%raw%}{{.USPrivacy}}{%endraw%}&redirect={%raw%}{{.RedirectURL}}{%endraw%}
@@ -120,7 +123,8 @@ userSync:
 ```
 
 PBS-Java uses slightly different macros in the bidder config:
-```
+
+```yaml
 usersync:
   url: https://some-bidder-domain.com/usersync-url?gdpr={%raw%}{{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}{%endraw%}&redirectUri=
   redirect-url: /setuid?bidder=acuityads&gdpr={%raw%}{{gdpr}}{%endraw%}&gdpr_consent={%raw%}{{gdpr_consent}}{%endraw%}&us_privacy={%raw%}{{us_privacy}}{%endraw%}&uid=YOURMACRO
@@ -146,13 +150,14 @@ Where Prebid.js isn't present, like in the AMP scenario, the call to /cookie_syn
 If there are scenarios where Prebid.js isn't around to initiate the /cookie_sync call, publishers can choose to put an iframe on their page.
 Here's how you could invoke it with an iframe:
 
-```
+```html
 <iframe
   height="1"
   frameborder="0"
   src="https://HOST/HTMLFILE?endpoint=PBSHOST&max_sync_count=5">
 >
 ```
+
 Where:
 - HOST is the location where the HTMLFILE is stored
 - HTMLFILE can be load-cookie.html or load-cookie-with-consent.html, which interacts with an AMP-compatible CMP.

--- a/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.md
+++ b/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.md
@@ -636,33 +636,34 @@ unless `request.ext.prebid.targeting` is also set in the request.
 
 If the `ext.prebid.cache.bids` object is present, Prebid Server will make a best effort to cache the entire bid object server-side and return the cache location in two places:
 
-1) OpenRTB seatbid.bid.ext.prebid.cache.bids
-```
-    {
-      "seatbid": [
-        "bid": [
-          ...
-          "ext": {
-            "prebid": {
-              "cache": {
-                "bids": {
-                  "url": "https://example.com:443/cache?uuid=385b283c-22cb-49a0-8c0b-8b88c49d9fe9",
-                  "cacheId": "385b283c-22cb-49a0-8c0b-8b88c49d9fe9"
+1. OpenRTB seatbid.bid.ext.prebid.cache.bids
+
+    ```json
+        {
+          "seatbid": [
+            "bid": [
+              ...
+              "ext": {
+                "prebid": {
+                  "cache": {
+                    "bids": {
+                      "url": "https://example.com:443/cache?uuid=385b283c-22cb-49a0-8c0b-8b88c49d9fe9",
+                      "cacheId": "385b283c-22cb-49a0-8c0b-8b88c49d9fe9"
+                    }
+                  }
                 }
               }
-            }
-          }
-        ]
-      ]
-    }
-```
+            ]
+          ]
+        }
+    ```
 
-2) Extra `bid.ext.prebid.targeting` keys:
+2. Extra `bid.ext.prebid.targeting` keys:
 
-- `hb_cache_id`: the cache ID for the highest overall bid in each imp.
-- `hb_cache_host`: the hostname where the cacheId may be retrieved.
-- `hb_cache_path`: the path where the cacheId may be retrieved. https://hb_cache_host/hb_cache_path?uuid=hb_cacheId
-- `hb_cache_id_{bidderName}`: the cache ID for the highest bid from {bidderName} in each imp.
+    - `hb_cache_id`: the cache ID for the highest overall bid in each imp.
+    - `hb_cache_host`: the hostname where the cacheId may be retrieved.
+    - `hb_cache_path`: the path where the cacheId may be retrieved. https://hb_cache_host/hb_cache_path?uuid=hb_cacheId
+    - `hb_cache_id_{bidderName}`: the cache ID for the highest bid from {bidderName} in each imp.
 
 If caching succeeded, the value will be a UUID which can be used to fetch Bid JSON from [Prebid Cache](https://github.com/prebid/prebid-cache).
 The keys may not exist if the host company's cache is full, having connection problems, etc.
@@ -675,33 +676,34 @@ This option is mainly intended for video players that need a URL that returns a 
 
 If the `ext.prebid.cache.vastxml` object is present, Prebid Server will make a best effort to cache just the VAST XML server-side and return the cache location in two places:
 
-1) OpenRTB seatbid.bid.ext.prebid.cache.vastXml
-```
-    {
-      "seatbid": [
-        "bid": [
-          ...
-          "ext": {
-            "prebid": {
-              "cache": {
-                "vastXml": {
-                  "url": "https://example.com:443/cache?uuid=385b283c-22cb-49a0-8c0b-8b88c49d9fe9",
-                  "cacheId": "385b283c-22cb-49a0-8c0b-8b88c49d9fe9"
+1. OpenRTB seatbid.bid.ext.prebid.cache.vastXml
+
+    ```json
+        {
+          "seatbid": [
+            "bid": [
+              ...
+              "ext": {
+                "prebid": {
+                  "cache": {
+                    "vastXml": {
+                      "url": "https://example.com:443/cache?uuid=385b283c-22cb-49a0-8c0b-8b88c49d9fe9",
+                      "cacheId": "385b283c-22cb-49a0-8c0b-8b88c49d9fe9"
+                    }
+                  }
                 }
               }
-            }
-          }
-        ]
-      ]
-    }
-```
+            ]
+          ]
+        }
+    ```
 
-2) Extra `bid.ext.prebid.targeting` keys:
+2. Extra `bid.ext.prebid.targeting` keys:
 
-- `hb_uuid`: the cache ID for the highest overall video bid in each imp.
-- `hb_cache_host`: the hostname where the UUID may be retrieved.
-- `hb_cache_path`: the path where the UUID may be retrieved. ex: https://hb_cache_host/hb_cache_path?uuid=hb_uuid
-- `hb_uuid_{bidderName}`: the cache ID for the highest video bid from {bidderName} in each imp.
+    - `hb_uuid`: the cache ID for the highest overall video bid in each imp.
+    - `hb_cache_host`: the hostname where the UUID may be retrieved.
+    - `hb_cache_path`: the path where the UUID may be retrieved. ex: https://hb_cache_host/hb_cache_path?uuid=hb_uuid
+    - `hb_uuid_{bidderName}`: the cache ID for the highest video bid from {bidderName} in each imp.
 
 In addition to the caveats noted for cache.bids, these will exist only if there are video bids.
 If the keys exist, the values can be used to fetch the bid's VAST XML from Prebid Cache directly.
@@ -723,7 +725,8 @@ Additional support for interstitials is enabled through the addition of two fiel
 The values will be numbers that indicate the minimum allowed size for the ad, as a percentage of the base side. For example, a width of 600 and `"minwidthperc": 60` would allow ads with widths from 360 to 600 pixels inclusive.
 
 Example:
-```
+
+```json
 {
   "imp": [{
     ...
@@ -755,14 +758,14 @@ PBS with interstitial support will come preconfigured with a list of common ad s
 
 To set the desired 'ad server currency', use the standard OpenRTB `cur` attribute. Note that Prebid Server only looks at the first currency in the array.
 
-```
+```json
 "cur": ["USD"]
 ```
 
 If you want or need to define currency conversion rates (e.g. for currencies that your Prebid Server doesn't support),
 define ext.prebid.currency.rates.
 
-```
+```json
 "ext": {
   "prebid": {
     "currency": {
@@ -800,7 +803,7 @@ If there's already an source.ext.schain and a bidder is named in ext.prebid.scha
 
 Prebid Server adapters can support the [Prebid.js User ID modules](/dev-docs/modules/userId.html) by reading the following extensions and passing them through to their server endpoints:
 
-```
+```json
 {
   "user": {
     "ext": {
@@ -826,7 +829,7 @@ Prebid Server adapters can support the [Prebid.js User ID modules](/dev-docs/mod
 
 Publishers can constrain which bidders receive which user.ext.eids entries. See the [Prebid.js user ID permissions](/dev-docs/modules/userId.html#permissions) reference for background.
 
-```
+```json
 {
   "ext": {
     "prebid": {
@@ -888,7 +891,8 @@ When a storedauctionresponse ID is specified:
 - the response retrieved from the stored-response-id is assumed to be the entire contents of the seatbid object corresponding to that impression.
 
 This request:
-```
+
+```json
 {
   "test": 1,
   "tmax": 500,
@@ -924,7 +928,8 @@ This request:
 ```
 
 will result in this response, assuming that the ids exist in the appropriate DB table read by Prebid Server:
-```
+
+```json
 {
   "id": "test-auction-id",
   "seatbid": [
@@ -950,7 +955,8 @@ will result in this response, assuming that the ids exist in the appropriate DB 
 
 In this scenario, the contents of the storedauctionresponse entry is
 an array of ortb2 seatbid objects. e.g.
-```
+
+```json
 [
   {
     "bid": [{
@@ -983,6 +989,7 @@ in imp.ext.prebid.bidder that's doesn't have a storedbidresponse specified,
 the adapter will be called as usual.
 
 For example, this request:
+
 ```
 {
   "test": 1,

--- a/prebid-server/versions/pbs-versions-java.md
+++ b/prebid-server/versions/pbs-versions-java.md
@@ -43,26 +43,26 @@ important architectural considerations, then follow the instructions for [Instal
 
 There are a few test requests in sample/requests that work with prebid-config-file-bidders.yaml and the files in the samples/stored directory.
 
-1) Follow the instructions in the root-level README.txt file to build the server
+1. Follow the instructions in the root-level README.txt file to build the server
 
-2) Start the server pointing to a config in the sample directory. e.g.
+2. Start the server pointing to a config in the sample directory. e.g.
 
-```
-java -jar target/prebid-server.jar --spring.config.additional-location=sample/prebid-config.yaml
-```
+    ```bash
+    java -jar target/prebid-server.jar --spring.config.additional-location=sample/prebid-config.yaml
+    ```
 
-3) Use one of the stored requests in the sample directory with curl:
+3. Use one of the stored requests in the sample directory with curl:
 
-```bash
-cd sample
-curl --header "X-Forwarded-For: 151.101.194.216" -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36' -H 'Referer: https://example.com/demo/' -H "Content-Type: application/json" http://localhost:8080/openrtb2/auction --data @FILENAME
-```
+    ```bash
+    cd sample
+    curl --header "X-Forwarded-For: 151.101.194.216" -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36' -H 'Referer: https://example.com/demo/' -H "Content-Type: application/json" http://localhost:8080/openrtb2/auction --data @FILENAME
+    ```
 
-Where FILENAME is one of:
+    Where FILENAME is one of:
 
-- rubicon-storedresponse.json - this is a request that calls for a stored-auction-response.
-- appnexus-disabled-gdpr.json - this is a request that actually calls the appnexus endpoint after disabling GDPR by setting regs.ext.gdpr:0
-- pbs-stored-req-test-video.json - this is a stored-request/response chain returning a VAST document
+    - rubicon-storedresponse.json - this is a request that calls for a stored-auction-response.
+    - appnexus-disabled-gdpr.json - this is a request that actually calls the appnexus endpoint after disabling GDPR by setting regs.ext.gdpr:0
+    - pbs-stored-req-test-video.json - this is a stored-request/response chain returning a VAST document
 
 ## References
 

--- a/troubleshooting/pbs-troubleshooting.md
+++ b/troubleshooting/pbs-troubleshooting.md
@@ -35,29 +35,29 @@ POST https://prebid-server.rubiconproject.com/openrtb2/auction
 
 If you're invoking Prebid Server from Prebid.js, turn on the OpenRTB `test` flag from Prebid.js using one of these options:
 
-1) Add **?pbjs_debug=true** to the URL of the page. This will cause the pbsBidAdapter to send `ext.prebid.debug:true` to PBS, which will turn on additional debugging.
+1. Add **?pbjs_debug=true** to the URL of the page. This will cause the pbsBidAdapter to send `ext.prebid.debug:true` to PBS, which will turn on additional debugging.
 
-2) Add the following `setConfig` to the page to get the same result:
+2. Add the following `setConfig` to the page to get the same result:
 
-    ```bash
-        pbjs.setConfig({"debug":true});
+    ```javascript
+    pbjs.setConfig({"debug":true});
     ```
 
-3) If instead of ext.prebid.debug you would like to set the OpenRTB 2.5 'test' flag, you can set that using the 'ortb2' approach:
+3. If instead of ext.prebid.debug you would like to set the OpenRTB 2.5 'test' flag, you can set that using the 'ortb2' approach:
 
-```bash
+    ```javascript
     pbjs.setConfig({
         "ortb2": {
             "test":1
         }
     });
-```
+    ```
 
 ### Invoked from AMP
 
 If you're invoking Prebid Server from AMP, you'll be unable to get debug info from the AMP page. However, you can capture the Prebid Server AMP call and append `&debug=1` to it:
 
-```bash
+```text
 https://my-prebid-server.com/openrtb2/amp?tag_id=1111111111111&w=300&h=50&...&debug=1
 ```
 


### PR DESCRIPTION
Another round for linting error fixes.  This in particular replaces all `1)` style list with regular markdown list. Formatting of code examples inside those lists is brittle otherwise.

## Relates to

- https://github.com/prebid/prebid.github.io/pull/4646
- https://github.com/prebid/prebid.github.io/pull/4620
- https://github.com/prebid/prebid.github.io/pull/4653