### PR TITLE
PBJS activity-controls: fixed typo

### DIFF
--- a/dev-docs/activity-controls.md
+++ b/dev-docs/activity-controls.md
@@ -171,7 +171,7 @@ So this means that when `priority` is omitted from `allowActivities` configurati
 
 ```javascript
 pbjs.setConfig({
-    deviceAccess: false,      // this would have the effect of disabling device storage, but... 
+    accessDevice: false,      // this would have the effect of disabling device storage, but... 
     allowActivities: {
         accessDevice: {
             rules: [


### PR DESCRIPTION
changed deviceAccess to accessDevice