### PR TITLE
GPP and COPPA support for Medianet Bidder Adapter

### DIFF
--- a/dev-docs/bidders/medianet.md
+++ b/dev-docs/bidders/medianet.md
@@ -4,8 +4,10 @@ title: Media.net
 description: Prebid Media.net Bidder Adaptor
 biddercode: medianet
 gdpr_supported: true
-media_types: banner,native,video
 usp_supported: true
+coppa_supported: true
+gpp_supported: true
+media_types: banner,native,video
 userIds: britepoolId, criteo, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
 prebid_member: true
 pbjs: true


### PR DESCRIPTION
## 🏷 Type of documentation
- [x] new feature

## Description
- added support for gpp (supported since: https://github.com/prebid/Prebid.js/pull/8607)
- added support for coppa (supported since: https://github.com/prebid/Prebid.js/pull/5195)