### PR TITLE
Sharethrough: Remove Native media type because it's only supported in Prebid Server, not Prebid.js

### DIFF
--- a/dev-docs/bidders/sharethrough.md
+++ b/dev-docs/bidders/sharethrough.md
@@ -6,7 +6,7 @@ description: Prebid Sharethrough Adaptor
 gdpr_supported: true
 coppa_supported: true
 floors_supported: true
-media_types: banner, video, native
+media_types: banner, video
 safeframes_ok: true
 schain_supported: true
 gvl_id: 80


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.
-->

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [x] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
