### PR TITLE
updating linter rules

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,7 @@
 {
     "default": true,
     "MD013": false,
+    "MD022": false,
     "MD024": false,
     "MD025": false,
     "MD033": false,


### PR DESCRIPTION
Found a reference that explained to set    "MD022": false, // Headers should be surrounded by blank lines disabled so that {: .no_toc } is next to its heading
