### PR TITLE
appnexus bidder - update first party data note

### DIFF
--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -200,7 +200,7 @@ keywords: {
 
 Publishers should use the `ortb2` method of setting [First Party Data](https://docs.prebid.org/features/firstPartyData.html).
 
-At this time however, the `appnexus` bidder only reads the First Party Data when using the Prebid Server and Prebid Server Premium endpoints.  The client-side version of the `appnexus` bidder does not use the values from the First Party Data fields.
+At this time however, the `appnexus` bidder only fully reads the First Party Data when using the Prebid Server and Prebid Server Premium endpoints.  The client-side version of the `appnexus` bidder has partial support to read all the various keywords parameters from the First Party Data fields.  There is also some special support with the segment fields but only from known sources which are specifically configured.  All other First Party Data fields are not read at this time.
 
 PBS/PSP supports all first party data fields: site, user, segments, and imp-level first party data.
 

--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -200,7 +200,7 @@ keywords: {
 
 Publishers should use the `ortb2` method of setting [First Party Data](https://docs.prebid.org/features/firstPartyData.html).
 
-At this time however, the `appnexus` bidder only fully reads the First Party Data when using the Prebid Server and Prebid Server Premium endpoints.  The client-side version of the `appnexus` bidder has partial support to read all the various keywords parameters from the First Party Data fields.  There is also some special support with the segment fields but only from known sources which are specifically configured.  All other First Party Data fields are not read at this time.
+At this time however, the `appnexus` bidder fully reads the First Party Data when using the Prebid Server and Prebid Server Premium endpoints.  The client-side version of the `appnexus` bidder has partial support to read all the various keywords parameters from the First Party Data fields.  There is also some special support with the segment fields but only from known sources which are specifically configured.  All other First Party Data fields are not read at this time.
 
 PBS/PSP supports all first party data fields: site, user, segments, and imp-level first party data.
 


### PR DESCRIPTION


## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] update bid adapter

This PR updates the status of the client-side appnexus bid adapter's ability to read Prebid.js First Party Data.
