### PR TITLE
Improve activity control examples

### DIFF
--- a/dev-docs/activity-controls.md
+++ b/dev-docs/activity-controls.md
@@ -73,7 +73,7 @@ pbjs.setConfig({
               },
               allow: true
            }]
-       }`
+       }
    }
 })
 ```
@@ -264,7 +264,7 @@ pbjs.setConfig({
             default: false,
             rules: [{
                 condition({syncUrl}) {
-                    return DOMAINLIST.find(domain => syncUrl.startsWith(domain))
+                    return DOMAINLIST.some(domain => syncUrl.startsWith(domain));
                 },
                 allow: true
             }]


### PR DESCRIPTION
There was an invalid backtick and `find` returns the actual element and not a `boolean`, which vanilla javascript is okay with, but not typescript if properly typed.

## 🏷 Type of documentation

- [x] bugfix (code examples)
