### PR TITLE
AdOcean: add gvl_id and Prebid Server parameters

### DIFF
--- a/dev-docs/bidders/adocean.md
+++ b/dev-docs/bidders/adocean.md
@@ -5,7 +5,8 @@ description: Prebid AdOcean Bidder Adaptor
 pbjs: true
 pbs: true
 biddercode: adocean
-tcfeu_supported: false
+tcfeu_supported: true
+gvl_id: 328
 sidebarType: 1
 ---
 
@@ -13,7 +14,7 @@ sidebarType: 1
 
 The AdOcean bid adapter may require an additional setup from the AdOcean team. Please contact with your local Technical Support team or by visiting [AdOcean website](https://adocean-global.com/en/contact/).
 
-### Bid Params
+### Prebid.JS Bid Params
 
 {: .table .table-bordered .table-striped }
 | Name     | Scope    | Description       | Example                                            | Type     |
@@ -21,3 +22,12 @@ The AdOcean bid adapter may require an additional setup from the AdOcean team. P
 | slaveId  | required | slave ID          | `'adoceanmyaozpniqismex'`                          | `string` |
 | masterId | required | master ID         | `'tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7'` | `string` |
 | emiter   | required | traffic source id | `'myao.adocean.pl'`                                | `string` |
+
+### Prebid Server Bid Params
+
+{: .table .table-bordered .table-striped }
+| Name          | Scope    | Description                                           | Example                                            | Type     |
+|---------------|----------|-------------------------------------------------------|----------------------------------------------------|----------|
+| slaveId       | required | slave ID                                              | `'adoceanmyaozpniqismex'`                          | `string` |
+| masterId      | required | master ID                                             | `'tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7'` | `string` |
+| emitterPrefix | required | AdOcean emitter prefix                                | `'myao'`                                           | `string` |


### PR DESCRIPTION
AdOcean:
- add gvl_id and set tcfeu_supported to true
- add Prebid Server parameters to reflect changes in: https://github.com/prebid/prebid-server/pull/2910

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked -> https://github.com/prebid/prebid-server/pull/2910
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
