### PR TITLE
appnexus bidder - remove notice on HTTP1

### DIFF
--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -22,7 +22,6 @@ sidebarType: 1
 
 ### Table of Contents
 
-- [Disclosure:](#disclosure)
 - [Table of Contents](#table-of-contents)
   - [Bid Params](#bid-params)
   - [Video Object](#video-object)

--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -20,10 +20,6 @@ gvl_id: 32
 sidebarType: 1
 ---
 
-### Disclosure
-
-This adapter is known to use an HTTP 1 endpoint. Header bidding often generates multiple requests to the same host and bidders are encouraged to change to HTTP 2 or above to help improve publisher page performance via multiplexing.
-
 ### Table of Contents
 
 - [Disclosure:](#disclosure)


### PR DESCRIPTION


## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] update bid adapter

Our endpoints were recently updated to support HTTP2, so I'm removing this notice that was added to our bidder page.

I'm not sure if there are any other changes needed.  If so, please let me know and I'll update.