### PR TITLE
Adquery: added info about supporting pbs

### DIFF
--- a/dev-docs/bidders/adquery.md
+++ b/dev-docs/bidders/adquery.md
@@ -3,6 +3,7 @@ layout: bidder
 title: Adquery
 description: Prebid Adquery Bidder Adaptor
 pbjs: true
+pbs: true
 biddercode: adquery
 tcfeu_supported: true
 usp_supported: true


### PR DESCRIPTION
Added `pbs:true`
https://github.com/prebid/prebid-server/pull/3020

## 🏷 Type of documentation
- [x] update bid adapter
- [x] new feature

## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
