### PR TITLE
adding mobileResize explanation

### DIFF
--- a/adops/gam-creative-banner-sbs.md
+++ b/adops/gam-creative-banner-sbs.md
@@ -80,6 +80,8 @@ In top-price mode, you can make use of the GAM `TARGETINGMAP` feature instead of
   ucTagData.pubUrl = "%%PATTERN:url%%";
   ucTagData.targetingMap = %%PATTERN:TARGETINGMAP%%;
   ucTagData.hbPb = "%%PATTERN:hb_pb%%";
+  // mobileResize needed for mobile GAM only
+  ucTagData.mobileResize = "hb_size:%%PATTERN:hb_size_BIDDERCODE%%";
 
   try {
     ucTag.renderAd(document, ucTagData);

--- a/adops/gam-creative-banner-sbs.md
+++ b/adops/gam-creative-banner-sbs.md
@@ -65,6 +65,9 @@ Be sure to replace BIDDERCODE with the appropriate bidder. For example, if the b
 </script>
 ```
 
+{: .alert.alert-info :}
+Note: the `mobileResize` parameter is a workaround to a bug in the Google Mobile Ads SDK. The Prebid SDK uses the existence of the "hb_size" string that's provided in %%PATTERN:TARGETINGMAP%%, but this bidder-specific version of the creative doesn't utilize the TARGETINGMAP, so the value is added here. The important part is the value that contains `hb_size:`.
+
 {: .alert.alert-danger :}
 Warning: Be sure none of the attribute names are longer than 20 characters. See [Send All Bids Key Value Pairs](/adops/send-all-vs-top-price.html#key-value-pairs) for more information.
 
@@ -80,8 +83,6 @@ In top-price mode, you can make use of the GAM `TARGETINGMAP` feature instead of
   ucTagData.pubUrl = "%%PATTERN:url%%";
   ucTagData.targetingMap = %%PATTERN:TARGETINGMAP%%;
   ucTagData.hbPb = "%%PATTERN:hb_pb%%";
-  // mobileResize needed for mobile GAM only
-  ucTagData.mobileResize = "hb_size:%%PATTERN:hb_size_BIDDERCODE%%";
 
   try {
     ucTag.renderAd(document, ucTagData);


### PR DESCRIPTION
I believe this is still needed for the mobile PUC scenario. It was there for the Send-All-Bidders example, but missing for Sent-Top-Bid.