### PR TITLE
Update instruction for usage of tmax in PBS-GO

### DIFF
--- a/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.md
+++ b/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.md
@@ -257,17 +257,23 @@ PBS won't send a request to the bidder if the calculated bidder_tmax is less tha
 To summarize the process:
 
 - If request.tmax is 0:
+
   ```
   tmax = auction_timeouts_ms.default
   ```
+
 - If request.tmax is set to a large value, PBS attempts to cap tmax:
+
   ```
   tmax = min(request.tmax, auction_timeouts_ms.max)
   ```
+
 - bidder_tmax is calculated as follows:
+
   ```
   bidder_tmax = tmax - request_processing_time - bidder_network_latency_buffer_ms - bidder_response_duration_min_ms
   ```
+
 - If bidder_tmax is less than pbs_response_preparation_duration_ms, the request is not sent to the bidder server.
 - In case tmax_adjustments.enabled is set to false, PBS continues to apply its rules for determining tmax, but bidder_tmax will not be calculated, and PBS will consistently send the request to the bidder server.
 ##### PBS-Java

--- a/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.md
+++ b/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.md
@@ -237,12 +237,14 @@ This field is used in different ways by PBS-Go and PBS-Java:
 Hosts can configure `auction_timeouts_ms` and `tmax_adjustments` to enable the utilization of tmax in auction endpoints.
 
 The `auction_timeouts_ms` parameter comprises default and max values. These values serve the purpose of determining the tmax duration PBS has for processing an auction request.
+
 - If tmax value is not specified or is set to 0 in the auction request, PBS will use the default value configured by the host (auction_timeouts_ms.default) as the tmax.
 - If tmax value specified in the auction request exceeds the maximum value defined by the host (auction_timeouts_ms.max), PBS will use host defined max (auction_timeouts_ms.max) as tmax.
 
 The resultant tmax, as determined by the above rules is employed in conjunction with the `tmax_adjustments` to estimate the tmax value for bidders i.e `bidder_tmax`. This estimated value indicates the time allotted for bidders to respond to a bid request.
 
 The `tmax_adjustments` parameter encompasses the following values:
+
 - enabled (required): indicates whether the estimation of bidder_tmax should be enabled or not. Hosts can set it to "false" to disable the estimation of bidder_tmax.
 - bidder_network_latency_buffer_ms: accounts for network delays that may occur between PBS and the bidder servers. A value of 0 indicates that no network latency buffer should be accounted for bidder_tmax calculation.
 - bidder_response_duration_min_ms (required): minimum amount of time that PBS can expect to receive response from a bidder server.
@@ -253,6 +255,7 @@ Additionally, PBS takes into account the request_processing_time when estimating
 PBS won't send a request to the bidder if the calculated bidder_tmax is less than the pbs_response_preparation_duration_ms.
 
 To summarize the process:
+
 - If request.tmax is 0:
   ```
   tmax = auction_timeouts_ms.default

--- a/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.md
+++ b/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.md
@@ -275,7 +275,9 @@ To summarize the process:
   ```
 
 - If bidder_tmax is less than pbs_response_preparation_duration_ms, the request is not sent to the bidder server.
+
 - In case tmax_adjustments.enabled is set to false, PBS continues to apply its rules for determining tmax, but bidder_tmax will not be calculated, and PBS will consistently send the request to the bidder server.
+
 ##### PBS-Java
 
 Core concepts:

--- a/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.md
+++ b/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.md
@@ -258,19 +258,19 @@ To summarize the process:
 
 - If request.tmax is 0:
 
-  ```
+  ```text
   tmax = auction_timeouts_ms.default
   ```
 
 - If request.tmax is set to a large value, PBS attempts to cap tmax:
 
-  ```
+  ```text
   tmax = min(request.tmax, auction_timeouts_ms.max)
   ```
 
 - bidder_tmax is calculated as follows:
 
-  ```
+  ```text
   bidder_tmax = tmax - request_processing_time - bidder_network_latency_buffer_ms - bidder_response_duration_min_ms
   ```
 


### PR DESCRIPTION
PBS-GO has made a change in how tmax is utilized in auction endpoints. PR adds instructions to assist PBS-GO hosts in configuring their PBS settings to align with this updated usage of tmax.

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] new feature
- [x] text edit only (wording, typos)
- [x] new examples
