### PR TITLE
Integr8 Bid Adapter: added optional parameter

### DIFF
--- a/dev-docs/bidders/integr8.md
+++ b/dev-docs/bidders/integr8.md
@@ -15,4 +15,5 @@ sidebarType: 1
 |---------------|----------|------------------------------------------------------------------------|--------------------|-----------|
 | `propertyId`  | required |Property id                                                             | `"12345"`          | `string`  |
 | `placementId` | required |Placement id                                                            | `"54321"`          | `string`  |
+| `deliveryUrl` | optional |Custom endpoint url for the bid request                                 | `"https://central.sea.integr8.digital/bid"`     | `string`  |
 | `data`        | optional |Catalog data (contents) and/or inventory data (custom key/value pairs)  | `{catalogs: [{ catalogId: "699229", items: ["193", "4", "1"] }], inventory: { category: ["tech"], query: ["iphone 12"] }}` | `object` |


### PR DESCRIPTION
Added an optional `deliveryUrl` parameter to the Integr8 Bid Adapter documentation, allowing users to specify a custom endpoint URL for bid requests.

This enhancement provides greater adaptability and paves the way for future customization, such as supporting different endpoints for various regions or environments. It maintains backward compatibility while offering users more control over their bidding strategies.

## 🏷 Type of documentation
- [x] update bid adapter
- [x] text edit only (wording, typos)

## 📋 Checklist
- [ ] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
