### PR TITLE
Replace load external js with include

### DIFF
--- a/_includes/dev-docs/loads-external-javascript.md
+++ b/_includes/dev-docs/loads-external-javascript.md
@@ -1,0 +1,2 @@
+{: .alert.alert-warning :}
+Disclosure: This module loads external code that is not open source and has not been reviewed by Prebid.org.

--- a/dev-docs/modules/a1MediaRtdProvider.md
+++ b/dev-docs/modules/a1MediaRtdProvider.md
@@ -13,8 +13,7 @@ sidebarType : 1
 
 # A1Media RTD Module
 
-{: .alert.alert-warning :}
-Disclosure: This module loads external code that is not open source and has not been reviewed by Prebid.org.
+{% include dev-docs/loads-external-javascript.md %}
 
 The A1Media RTD module loads a script for obtaining A1Media user segments, providing the user segment data to bid-requests.
 

--- a/dev-docs/modules/aaxBlockmeterRtdProvider.md
+++ b/dev-docs/modules/aaxBlockmeterRtdProvider.md
@@ -24,8 +24,7 @@ The module enables publishers with an AAX relationship to measure traffic coming
 
 AAX can also help publishers monetize this traffic by allowing them to serve [acceptable ads](https://acceptableads.com/about/) to these adblock visitors and recover their lost revenue. [Reach out to us](https://www.aax.media/try-blockmeter/) to know more.
 
-{: .alert.alert-warning :}
-Disclosure: This module loads external code that is not open source and has not been reviewed by Prebid.org.
+{% include dev-docs/loads-external-javascript.md %}
 
 ## Configuration
 

--- a/dev-docs/modules/arcspanRtdProvider.md
+++ b/dev-docs/modules/arcspanRtdProvider.md
@@ -22,8 +22,7 @@ sidebarType : 1
 
 ArcSpan is a real-time audience monetization platform focused on the needs of the world’s finest publishers and retailers. Unlock the true value of your first-party audience data while providing advertisers the targeting performance they need.
 
-{: .alert.alert-warning :}
-Disclosure: This module loads external code that is not open source and has not been reviewed by Prebid.org.
+{% include dev-docs/loads-external-javascript.md %}
 
 ### Usage
 

--- a/dev-docs/modules/geoedgeRtdProvider.md
+++ b/dev-docs/modules/geoedgeRtdProvider.md
@@ -23,8 +23,7 @@ sidebarType : 1
 The Geoedge Realtime module lets publishers block bad ads such as automatic redirects, malware, offensive creatives and landing pages.
 To use this module, you'll need to work with [Geoedge](https://www.geoedge.com/publishers-real-time-protection/) to get an account and cutomer key.
 
-{: .alert.alert-warning :}
-Disclosure: This module loads external code that is not open source and has not been reviewed by Prebid.org.
+{% include dev-docs/loads-external-javascript.md %}
 
 ## Integration
 

--- a/dev-docs/modules/medianetRtdProvider.md
+++ b/dev-docs/modules/medianetRtdProvider.md
@@ -26,8 +26,7 @@ The module currently provisions Media.net's Intelligent Refresh configured by th
 
 Intelligent Refresh (IR) module lets publisher refresh their ad inventory without affecting page experience of visitors through configured criteria. The module optionally provides tracking of refresh inventory and appropriate targeting in GAM. Publisher configured criteria is fetched via an external JS payload.
 
-{: .alert.alert-warning :}
-Disclosure: This module loads external code that is not open source and has not been reviewed by Prebid.org.
+{% include dev-docs/loads-external-javascript.md %}
 
 ## Configuration
 


### PR DESCRIPTION

## 🏷 Type of documentation

- [x] new feature
- [x] text edit only (wording, typos)

## Description

This adds a new include for modules that load external javascript.

Usage:

```liquid
{% include dev-docs/loads-external-javascript.md %}
```