### PR TITLE
Add codespaces documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           files: '**/*.md'
           separator: ","
-      - uses: DavidAnson/markdownlint-cli2-action@v11
+      - uses: DavidAnson/markdownlint-cli2-action@v13
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
           globs: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/guide.md
+++ b/guide.md
@@ -94,7 +94,7 @@ Jekyll requires adherence to a certain directory structure to generate the site.
 For the Prebid.org site the following directories are used:
 
 **_data**  
-Jekyll was originally designed specifically for creation of blogging websites and not for dynamic, data-driven sites. However, by including the _data directory we can mimic a database structure to create a more robust site. Files in this directory can be saved in either *json*, *yml* or *csv* format. For Prebid.org they have been saved in *yml*.
+Jekyll was originally designed specifically for creation of blogging websites and not for dynamic, data-driven sites. However, by including the _data directory we can mimic a database structure to create a more robust site. Files in this directory can be saved in either _json_, _yml_ or _csv_ format. For Prebid.org they have been saved in _yml_.
 
 Learn more about YML [here](https://yaml.org/start.html)
 

--- a/guide.md
+++ b/guide.md
@@ -16,6 +16,22 @@ Updated Feb 9, 2023
 - TOC
 {:toc}
 
+## Getting started
+
+The easiest way to setup an environment to contribute to the docs or review pull requests is [Github Codespaces](https://github.com/features/codespaces).
+
+1. Open [github.com/prebid/prebid.github.io](https://github.com/prebid/prebid.github.io)
+2. Click on the `Code` drop down menu and select "create new codespace from master". If you have no access to prebid.github.io, then you should do this on your fork of the repository
+3. Install the [markdownlint extension](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
+    1. go to _Extensions_
+    2. search for _markdownlint_ and hit install
+    3. now you get direct feedback on linting errors
+4. Start the jekyll build as described in the `TERMINAL` of your codespace
+    1. `bundle install`
+    2. `JEKYLL_ENV=production bundle exec jekyll serve --watch --incremental`
+    3. Codespaces will display a notification to open the running instance in the browser.
+5. In the `PORTS` tab you find the running instance
+
 ## Reviewing Pull Requests and Issues
 
 Being a reviewer means you're in weekly rotation where you keep an eye on pull requests (PRs) and issues opened in this repo.


### PR DESCRIPTION
Getting started on how to contribute to the docs via codespaces. Fixes #4914

## 🏷 Type of documentation

- [x] text edit only (wording, typos)

## Images

I have also these images. Should we add those as well?



![codespaces_01](https://github.com/prebid/prebid.github.io/assets/647727/f33e7bf6-4182-4f25-a6be-4a233bca40ce)
![codespaces_02](https://github.com/prebid/prebid.github.io/assets/647727/704e7e16-2c0b-44cd-8bc7-75280c65b842)
![codespaces_03](https://github.com/prebid/prebid.github.io/assets/647727/a0eac03f-4b7a-4f8c-83c8-48445dd04f83)
![codespaces_04](https://github.com/prebid/prebid.github.io/assets/647727/2981e568-9acb-44ae-8fd8-920d045933ef)
