### PR TITLE
Sparteo bid adapter: modify required fields and bidder parameters

### DIFF
--- a/dev-docs/bidders/sparteo.md
+++ b/dev-docs/bidders/sparteo.md
@@ -37,7 +37,7 @@ Sparteo Header Bidding adapter requires setup and approval. Please reach out to 
 | Name   | Scope    | Description                                            | Example      | Type      |
 |--------|----------|--------------------------------------------------------|--------------|-----------|
 | `size` | required | The size (width, height) of the banner, in pixels.     | `[640, 480]` | `String`  |
-| `pos`  | required | The position of the banner following the OpenRTB spec. | `0`          | `integer` |
+| `pos`  | optional | The position of the banner following the OpenRTB spec. | `0`          | `integer` |
 
 ### Video Object
 
@@ -46,13 +46,13 @@ Sparteo Header Bidding adapter requires setup and approval. Please reach out to 
 |------------------|----------|--------------------------------------------------------------------------|----------------|------------------|
 | `context`        | required | The video context, either 'instream', 'outstream'.                       | `'instream'`     | `String`         |
 | `playerSize`     | required | The size (width, height) of the video player on the page, in pixels.     | `[640, 480]`   | `Array<integer>` |
-| `playbackmethod` | required | Defines how the video inventory is initiated following the OpenRTB spec. | `[4, 5]`       | `Array<integer>` |
-| `protocols`      | required | Defines the video protocols allowed.                                     | `[1, 2]`       | `Array<integer>` |
-| `api`            | required | Defines the video api allowed.                                           | `[1, 2]`       | `Array<integer>` |
-| `mimes`          | required | Defines the video mimes allowed.                                         | `['video/mp4']` | `Array<String>`  |
-| `skip`           | required | Defines if skip is allowed.                                              | `1`            | `integer`        |
-| `startdelay`     | required | Defines the startDelay.                                                  | `0`            | `integer`        |
-| `placement`      | required | Defines the placement.                                                   | `1`            | `integer`        |
-| `linearity`      | required | Defines the linearity.                                                   | `1`            | `integer`        |
-| `minduration`    | required | Defines the video minduration.                                           | `1`            | `integer`        |
-| `maxduration`    | required | Defines the video maxduration.                                           | `160`          | `integer`        |
+| `playbackmethod` | optional | Defines how the video inventory is initiated following the OpenRTB spec. | `[4, 5]`       | `Array<integer>` |
+| `protocols`      | optional | Defines the video protocols allowed.                                     | `[1, 2]`       | `Array<integer>` |
+| `api`            | optional | Defines the video api allowed.                                           | `[1, 2]`       | `Array<integer>` |
+| `mimes`          | optional | Defines the video mimes allowed.                                         | `['video/mp4']` | `Array<String>`  |
+| `skip`           | optional | Defines if skip is allowed.                                              | `1`            | `integer`        |
+| `startdelay`     | optional | Defines the startDelay.                                                  | `0`            | `integer`        |
+| `placement`      | optional | Defines the placement.                                                   | `1`            | `integer`        |
+| `linearity`      | optional | Defines the linearity.                                                   | `1`            | `integer`        |
+| `minduration`    | optional | Defines the video minduration.                                           | `1`            | `integer`        |
+| `maxduration`    | optional | Defines the video maxduration.                                           | `160`          | `integer`        |

--- a/dev-docs/bidders/sparteo.md
+++ b/dev-docs/bidders/sparteo.md
@@ -27,9 +27,12 @@ Sparteo Header Bidding adapter requires setup and approval. Please reach out to 
 ### Bid params
 
 {: .table .table-bordered .table-striped }
-| Name        | Scope    | Description                                                                                 | Example    | Type      |
-|-------------|----------|---------------------------------------------------------------------------------------------|------------|-----------|
-| `pid`       | required | Your publisher ID. This information will be given to you by the Sparteo team.               | `1234`     | `integer` |
+| Name          | Scope    | Description                                                                             | Example    | Type      |
+|---------------|----------|-----------------------------------------------------------------------------------------|------------|-----------|
+| `publisherId` | required | Your publisher ID. This information will be given to you by the Sparteo team.           | `1234`     | `integer` |
+| `networkId`   | required | Your network ID. This information will be given to you by the Sparteo team.             | `1234`     | `integer` |
+
+Only the `publisherId` OR `networkId` is required.
 
 ### Banner Object
 


### PR DESCRIPTION
The parameters of the bidder ere not up to date in the documentation.
The necessary changes have been done.

## 🏷 Type of documentation
- [x] update bid adapter
