### PR TITLE
[Criteo] Documentation Fastbid OptOut on Criteo Prebid Docs

### DIFF
--- a/dev-docs/bidders/criteo.md
+++ b/dev-docs/bidders/criteo.md
@@ -109,6 +109,18 @@ var adUnits = [
 
 ### Additional Config (Optional)
 
+If you don't want to use the FastBid adapter feature, you can disable it via this configuration:
+
+```javascript
+pbjs.setConfig({
+  'criteo': {
+    fastBidVersion: 'none',
+  }
+});
+```
+
+Criteo teams are planning to completely remove this feature with Prebid 9.0
+
 Criteo Bid Adapter supports the collection of the user's hashed email, if available.
 
 Please consider passing it to the adapter, following [these guidelines](https://publisherdocs.criteotilt.com/prebid/#hashed-emails).


### PR DESCRIPTION
## 🏷 Type of documentation
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [x] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Summary
The Criteo bid adapter contains the "FastBid" feature.
This change documents how a publisher can opt out of this feature.
For info, Criteo teams are planning to completely remove this feature with Prebid 9.0.