### PR TITLE
rm gvl id text

### DIFF
--- a/dev-docs/bidders/indiecue.md
+++ b/dev-docs/bidders/indiecue.md
@@ -5,7 +5,7 @@ description: Indicue Bidder Adapter
 biddercode: indicue
 aliasCode: adtelligent
 media_types: video,banner
-gvl_id: 410 (adtelligent)
+gvl_id: 410
 tcfeu_supported: true
 gpp_supported: true
 userIds: britepoolId, criteo, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId

--- a/dev-docs/bidders/indiecue.md
+++ b/dev-docs/bidders/indiecue.md
@@ -5,7 +5,6 @@ description: Indicue Bidder Adapter
 biddercode: indicue
 aliasCode: adtelligent
 media_types: video,banner
-gvl_id: 410
 tcfeu_supported: true
 gpp_supported: true
 userIds: britepoolId, criteo, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId

--- a/dev-docs/bidders/indiecue.md
+++ b/dev-docs/bidders/indiecue.md
@@ -5,7 +5,7 @@ description: Indicue Bidder Adapter
 biddercode: indicue
 aliasCode: adtelligent
 media_types: video,banner
-tcfeu_supported: true
+tcfeu_supported: false
 gpp_supported: true
 userIds: britepoolId, criteo, id5Id, identityLink, liveIntentId, netId, parrableId, pubCommonId, unifiedId
 schain_supported: true


### PR DESCRIPTION
## 🏷 Type of documentation
- [x] text edit only (wording, typos)

Indicue is in process of obtaining their own vendor id, 410 would not be a correct one here, since all ad serving and cookies are with Indicue infrastructure.
They want to have this field empty, until the submission of the proper GVL ID.

But it see that all aliases now contain some kind of "inherited" id in docs, started from here
#4725 
@bretg is it possible to merge?