### PR TITLE
Update pair.md to remove `_custom` string in examples

### DIFF
--- a/dev-docs/modules/userid-submodules/pair.md
+++ b/dev-docs/modules/userid-submodules/pair.md
@@ -22,7 +22,7 @@ gulp build --modules=pairIdSystem
 | name | Required | String | The name of PAIR ID user ID module. | `"pairId"` |
 | params | Optional | Object | Container of all module params. |  |
 | params.liveramp | Optional | Object | Container of all liveramp cleanroom specified params. |  |
-| params.liveramp.storageKey | Optional | String | storage key to fetch liveramp provided PAIR Id, the default value is `"_lr_pairId"` | `"_lr_pairId_custom"` |
+| params.liveramp.storageKey | Optional | String | storage key to fetch liveramp provided PAIR Id, the default value is `"_lr_pairId"` | `"_lr_pairId"` |
 
 ## PAIR ID Examples
 
@@ -53,7 +53,7 @@ pbjs.setConfig({
         name: 'pairId',
         params: {
                 liveramp: {
-                    storageKey: '_lr_pairId_custom'
+                    storageKey: '_lr_pairId'
                 }
             },
       }]


### PR DESCRIPTION
Remove the `_custom` string in pair examples, as according to LiveRamp's feedback, it's confusing to some users.

<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.
-->

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [x] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
