### PR TITLE
improve video links

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -1746,7 +1746,7 @@
 
 - sbSecId: 6
   title: Video
-  link: /prebid-video/video-overview.html
+  link: /formats/video.html
   isHeader: 0
   isSectionHeader: 0
   sectionTitle:

--- a/formats/video.md
+++ b/formats/video.md
@@ -5,14 +5,11 @@ description: Prebid Video
 sidebarType: 6
 ---
 
-<script src="/assets/js/dynamicTable.js" type="text/javascript"></script>
-
 # Prebid Video Ads
 
-{:.no_toc}
-
 Welcome to Prebid video ad support. This is a collection of resources covering
-how Prebid can help you monetize video.
+how Prebid can help you monetize video. If you're new to Prebid video, a
+good place to start would be the [Prebid.js-focused training video overview](/prebid-video/video-overview-video.html).
 
 ## Instream
 


### PR DESCRIPTION
The video format page didn't link out to the new video and the navbar highlight wasn't working because it linked out to PBJS-video.