### PR TITLE
Fix #5032 by adding a disclaimer to bidders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
         with:
           files: '**/*.md'
           separator: ","
-      - uses: DavidAnson/markdownlint-cli2-action@v13
+      - uses: DavidAnson/markdownlint-cli2-action@v15
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
-          globs: ${{ steps.changed-files.outputs.all_changed_files }}
+          globs: "${{ steps.changed-files.outputs.all_changed_files }},!_includes"
           separator: ","
           config: '.markdownlint.json'

--- a/_includes/dev-docs/pbjs-adapter-required-for-pbs.md
+++ b/_includes/dev-docs/pbjs-adapter-required-for-pbs.md
@@ -1,0 +1,3 @@
+{: .alert.alert-warning :}
+This bidder requires the client side Prebid.js adapter to work on Prebid Server due to the dependency on the `transformBidParams` function.
+See [prebid.js #6361](https://github.com/prebid/Prebid.js/issues/6361) for more details.

--- a/dev-docs/bidders/adtelligent.md
+++ b/dev-docs/bidders/adtelligent.md
@@ -18,6 +18,10 @@ gvl_id: 410
 sidebarType: 1
 ---
 
+### Prebid Server Note
+
+{% include dev-docs/pbjs-adapter-required-for-pbs.md %}
+
 ### Bid params
 
 {: .table .table-bordered .table-striped }

--- a/dev-docs/bidders/adxcg.md
+++ b/dev-docs/bidders/adxcg.md
@@ -15,6 +15,8 @@ sidebarType: 1
 
 ### Note
 
+{% include dev-docs/pbjs-adapter-required-for-pbs.md %}
+
 Prebid-server activation requires setup and approval before beginning. Please reach out to your account manager or <info@adxcg.com> for more details.
 
 ### Bid Params

--- a/dev-docs/bidders/connectad.md
+++ b/dev-docs/bidders/connectad.md
@@ -20,6 +20,8 @@ sidebarType: 1
 
 ### Prebid Server Note
 
+{% include dev-docs/pbjs-adapter-required-for-pbs.md %}
+
 Please reach out to your ConnectAd Account Manager before configuring the S2S adapter for approval and setup.
 
 ### Bid Params

--- a/dev-docs/bidders/ix-server.md
+++ b/dev-docs/bidders/ix-server.md
@@ -70,6 +70,8 @@ The following table lists the media types that Index supports. For information a
 
 ## Setup instructions to call Index through Prebid Server
 
+{% include dev-docs/pbjs-adapter-required-for-pbs.md %}
+
 **Note:** If you are hosting your own Prebid Server instance, you must contact your Index Exchange Representative to get an endpoint and setup instructions.
 
 If you are using an existing Prebid Server instance that is already configured to call Index, depending on whether you want to call Index from the browser, mobile app, CTV, or long-form video, follow any of the below sections to complete the Index-specific configuration.

--- a/dev-docs/bidders/mediafuse.md
+++ b/dev-docs/bidders/mediafuse.md
@@ -15,6 +15,10 @@ pbs: true
 sidebarType: 1
 ---
 
+### Prebid Server Note
+
+{% include dev-docs/pbjs-adapter-required-for-pbs.md %}
+
 #### Prebid Server Test Request
 
 The following test parameters can be used to verify that Prebid Server is working properly with the server-side Mediafuse adapter. This example includes an Mediafuse test placement ID and sizes that would match with the test creative.

--- a/dev-docs/bidders/openweb.md
+++ b/dev-docs/bidders/openweb.md
@@ -17,6 +17,10 @@ gvl_id: 280
 sidebarType: 1
 ---
 
+### Prebid Server Notes
+
+{% include dev-docs/pbjs-adapter-required-for-pbs.md %}
+
 ### Bid params
 
 {: .table .table-bordered .table-striped }

--- a/dev-docs/bidders/openweb.md
+++ b/dev-docs/bidders/openweb.md
@@ -35,7 +35,7 @@ OpenWeb header bidding adapter provides solution for accessing banner demand.
 
 ### Test Parameters
 
-```
+```javascript
 var adUnits = [
     // Banner adUnit
     {

--- a/dev-docs/bidders/openx.md
+++ b/dev-docs/bidders/openx.md
@@ -29,6 +29,10 @@ After the transition openxOrtbBidAdapter will replace openxBidAdapter.
 
 IMPORTANT: only include either openxBidAdapter or openxOrtbBidAdapter in your build.
 
+### Prebid Server Note
+
+{% include dev-docs/pbjs-adapter-required-for-pbs.md %}
+
 ### Bid Parameters
 
 #### Banner

--- a/dev-docs/bidders/pubmatic.md
+++ b/dev-docs/bidders/pubmatic.md
@@ -23,6 +23,10 @@ multiformat_supported: will-bid-on-one
 sidebarType: 1
 ---
 
+### Prebid Server Note
+
+{% include dev-docs/pbjs-adapter-required-for-pbs.md %}
+
 ### Bid Params
 
 {: .table .table-bordered .table-striped }

--- a/dev-docs/bidders/pubmatic.md
+++ b/dev-docs/bidders/pubmatic.md
@@ -32,21 +32,21 @@ sidebarType: 1
 {: .table .table-bordered .table-striped }
 | Name          | Scope    | Description        | Example                      | Type     |
 |---------------|----------|--------------------|------------------------------|----------|
-| `publisherId` | required | Publisher ID          | `'32572'`                 | `string` |
+| `publisherId` | required | Publisher ID       | `'32572'`                    | `string` |
 | `adSlot`      | optional | Ad Slot Name (see below)| `'38519891'`            | `string` |
-| `pmzoneid`    | optional | Zone ID               | `'zone1,zone2'`           | `string` |
-| `lat`         | optional | Latitude <br/> (Supported until Prebid version 7.54.4 and starting from Prebid version 8.11.0 we have option to configure this using ortb2.(device OR user))              | `'40.712775'`             | `string` |
+| `pmzoneid`    | optional | Zone ID            | `'zone1,zone2'`              | `string` |
+| `lat`         | optional | Latitude <br/> (Supported until Prebid version 7.54.4 and starting from Prebid version 8.11.0 we have option to configure this using ortb2.(device OR user))             | `'40.712775'`             | `string` |
 | `lon`         | optional | Longitude <br/> (Supported until Prebid version 7.54.4 and starting from Prebid version 8.11.0 we have option to configure this using ortb2.(device OR user))            | `'-74.005973'`            | `string` |
-| `yob`         | optional | Year of Birth         | `'1982'`                  | `string` |
-| `gender`      | optional | Gender                | `'M'`                     | `string` |
-| `kadpageurl`  | optional | Overrides Page URL    |  `'http://www.yahoo.com/'`| `string` |
-| `kadfloor`    | optional | Bid Floor             | `'1.75'`                  | `string` |
-| `currency`    | optional | Bid currency           | `'AUD'` (Value configured only in the 1st adunit will be passed on. <br/> Values if present in subsequent adunits, will be ignored.)                    | `string` |
-| `dctr`        | optional | Deal Custom Targeting <br/> (Value configured in each adunit will be passed on inside adunit configs i.e. imp.ext) | `'key1=123|key2=345'`        | `string` |
-| `acat`    | optional | Allowed categories  <br/> (List of allowed categories for a given auction to be sent in either using ortb2 config (request.ext.prebid.bidderparams.pubmatic.acat) or using slot level params. If categories sent using both then priority will be given to ortb2 over slot level params.) | `[ 'IAB1-5', 'IAB1-6', 'IAB1-7' ]` | `array of strings` |
-| `bcat`    | optional | Blocked IAB Categories  <br/> (Values from all slots will be combined and only unique values will be passed. An array of strings only. Each category should be a string of a length of more than 3 characters.) | `[ 'IAB1-5', 'IAB1-6', 'IAB1-7' ]`     | `array of strings` |
-| `deals`    | optional | PMP deals  <br/> (Values from each slot will be passed per slot. An array of strings only. Each deal-id should be a string of a length of more than 3 characters.) | `[ 'deal-id-5', 'deal-id-6', 'deal-id-7' ]`     | `array of strings` |
-| `outstreamAU`    | optional | Oustream AdUnit described in Blue BillyWig UI. This field is mandatory if mimeType is described as video and context is outstream (i.e., for outstream videos)           | `'renderer_test_pubmatic'`           | `string` |
+| `yob`         | optional | Year of Birth      | `'1982'`                     | `string` |
+| `gender`      | optional | Gender             | `'M'`                        | `string` |
+| `kadpageurl`  | optional | Overrides Page URL |  `'http://www.yahoo.com/'`   | `string` |
+| `kadfloor`    | optional | Bid Floor          | `'1.75'`                     | `string` |
+| `currency`    | optional | Bid currency       | `'AUD'` (Value configured only in the 1st adunit will be passed on. <br/> Values if present in subsequent adunits, will be ignored.)                | `string` |
+| `dctr`        | optional | Deal Custom Targeting <br/> (Value configured in each adunit will be passed on inside adunit configs i.e. imp.ext), `'key1=123|key2=345'`                                | `string` |
+| `acat`        | optional | Allowed categories  <br/> (List of allowed categories for a given auction to be sent in either using ortb2 config (request.ext.prebid.bidderparams.pubmatic.acat) or using slot level params. If categories sent using both then priority will be given to ortb2 over slot level params.) | `[ 'IAB1-5', 'IAB1-6', 'IAB1-7' ]` | `array of strings` |
+| `bcat`        | optional | Blocked IAB Categories  <br/> (Values from all slots will be combined and only unique values will be passed. An array of strings only. Each category should be a string of a length of more than 3 characters.) | `[ 'IAB1-5', 'IAB1-6', 'IAB1-7' ]`     | `array of strings` |
+| `deals`       | optional | PMP deals  <br/> (Values from each slot will be passed per slot. An array of strings only. Each deal-id should be a string of a length of more than 3 characters.)       | `[ 'deal-id-5', 'deal-id-6', 'deal-id-7' ]`     | `array of strings` |
+| `outstreamAU` | optional | Oustream AdUnit described in Blue BillyWig UI. This field is mandatory if mimeType is described as video and context is outstream (i.e., for outstream videos)           | `'renderer_test_pubmatic'`           | `string` |
 
 ### Configuration
 

--- a/dev-docs/bidders/pulsepoint.md
+++ b/dev-docs/bidders/pulsepoint.md
@@ -21,6 +21,10 @@ ortb_blocking_supported: true
 multiformat_supported: will-bid-on-one
 ---
 
+### Prebid Server Note
+
+{% include dev-docs/pbjs-adapter-required-for-pbs.md %}
+
 ### Bid Params
 
 {: .table .table-bordered .table-striped }

--- a/dev-docs/bidders/trafficgate.md
+++ b/dev-docs/bidders/trafficgate.md
@@ -24,6 +24,8 @@ safeframes_ok: true
 
 ### Note
 
+{% include dev-docs/pbjs-adapter-required-for-pbs.md %}
+
 The TrafficGate Bidding adapter requires setup before beginning. Please contact us at <support@bidscube.com>
 
 ### Bid Params


### PR DESCRIPTION
Adds a disclaimer for bidders that require the client adapter in order to work server-side due to the `transformBidParams` function.