### PR TITLE
privacy resources page

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -130,20 +130,6 @@
   isSectionHeader: 0
   subgroup: 2
 
-- sbSecId: 0
-  title: Prebid and MSPA
-  link: /features/mspa-usnat.html
-  isHeader: 0
-  isSectionHeader: 0
-  subgroup: 2
-
-- sbSecId: 0
-  title: Prebid and Quebec Privacy Support
-  link: /features/ac-quebec.html
-  isHeader: 0
-  isSectionHeader: 0
-  subgroup: 2
-
 #--------------Prebid.js--------------|
 
 - sbSecId: 1
@@ -1815,12 +1801,34 @@
   subgroup: 0
 
 - sbSecId: 7
-  title: Training Videos
-  link: /videos/
-  isHeader: 0
+  title: Privacy Resources
+  link:
+  isHeader: 1
+  headerId: privacy
   isSectionHeader: 0
   sectionTitle:
-  subgroup: 0
+  subgroup: 1
+
+- sbSecId: 7
+  title: Prebid Privacy Overview
+  link: /support/privacy-resources.html
+  isHeader: 0
+  isSectionHeader: 0
+  subgroup: 1
+
+- sbSecId: 7
+  title: Prebid and MSPA
+  link: /features/mspa-usnat.html
+  isHeader: 0
+  isSectionHeader: 0
+  subgroup: 1
+
+- sbSecId: 7
+  title: Prebid and Quebec Privacy Support
+  link: /features/ac-quebec.html
+  isHeader: 0
+  isSectionHeader: 0
+  subgroup: 1
 
 - sbSecId: 7
   title: FAQs

--- a/_includes/legal-warning.html
+++ b/_includes/legal-warning.html
@@ -1,3 +1,7 @@
 <div markdown="span" class="pb-alert pb-alert-warning" role="alert">
-Important: This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under your regional regulations, including the GDPR, the ePrivacy Directive and individual state/province laws. Only a lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
+Important: This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation.
+Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice
+relating to obligations under your regional regulations, including the GDPR, the ePrivacy Directive and individual country/province/state laws. Only a
+lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be
+used as a substitute for, legal advice tailored to your business.
 </div>

--- a/_includes/legal-warning.html
+++ b/_includes/legal-warning.html
@@ -1,0 +1,3 @@
+<div markdown="span" class="pb-alert pb-alert-warning" role="alert">
+Important: This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under your regional regulations, including the GDPR, the ePrivacy Directive and individual state/province laws. Only a lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
+</div>

--- a/dev-docs/activity-controls.md
+++ b/dev-docs/activity-controls.md
@@ -26,8 +26,7 @@ Several, but not all, of the popular consent strings have modules (eg [Prebid Ac
 
 ### Prebid Is a Toolkit
 
-{: .alert.alert-danger :}
-Important: This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under European and /or US regulations, including the GDPR, the ePrivacy Directive and CCPA. Only a lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
+{% include legal-warning.html %}
 
 1. Get a privacy lawyer.
 2. Consider all the privacy regulations your content business is subject to.

--- a/dev-docs/cmp-best-practices.md
+++ b/dev-docs/cmp-best-practices.md
@@ -14,11 +14,7 @@ of Prebid.js and Consent Management Platforms.
 
 ## NOT LEGAL ADVICE
 
-{% capture legalNotice %}
-  This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under European and/or US regulations, including the GDPR, the ePrivacy Directive and CCPA. Only a lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
-  {% endcapture %}
-
-{% include /alerts/alert_important.html content=legalNotice %}
+{% include legal-warning.html %}
 
 ## General
 

--- a/dev-docs/modules/consentManagement.md
+++ b/dev-docs/modules/consentManagement.md
@@ -11,17 +11,12 @@ sidebarType : 1
 ---
 
 # GDPR Consent Management Module
-
 {: .no_toc }
 
 - TOC
 {: toc }
 
-{% capture legalNotice %}
-  This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under European and /or US regulations, including the GDPR, the ePrivacy Directive and CCPA. Only a lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
-  {% endcapture %}
-
-{% include /alerts/alert_important.html content=legalNotice %}
+{% include legal-warning.html %}
 
 ## Overview
 

--- a/dev-docs/modules/consentManagementGpp.md
+++ b/dev-docs/modules/consentManagementGpp.md
@@ -12,17 +12,12 @@ sidebarType : 1
 ---
 
 # GPP Consent Management Module
-
 {: .no_toc }
 
 - TOC
 {: toc }
 
-{% capture legalNotice %}
-  This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company's collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under European, Canadian and /or US regulations, including the GDPR, the ePrivacy Directive and CCPA. Only a lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
-  {% endcapture %}
-
-{% include /alerts/alert_important.html content=legalNotice %}
+{% include legal-warning.html %}
 
 ## Overview
 

--- a/dev-docs/modules/consentManagementUsp.md
+++ b/dev-docs/modules/consentManagementUsp.md
@@ -11,18 +11,12 @@ sidebarType : 1
 ---
 
 # US Privacy Consent Management Module
-
 {: .no_toc }
 
 * TOC
 {: toc }
 
-{% capture legalNotice %}
-
-  This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under European and /or US regulations, including the GDPR, the ePrivacy Directive and CCPA. Only a lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
-  {% endcapture %}
-
-{% include /alerts/alert_important.html content=legalNotice %}
+{% include legal-warning.html %}
 
 ## Overview
 

--- a/dev-docs/modules/gdprEnforcement.md
+++ b/dev-docs/modules/gdprEnforcement.md
@@ -16,11 +16,7 @@ sidebarType : 1
 * TOC
 {: toc }
 
-{% capture legalNotice %}
-  This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under European and /or US regulations, including the GDPR, the ePrivacy Directive and CCPA. Only a lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
-  {% endcapture %}
-
-{% include /alerts/alert_important.html content=legalNotice %}
+{% include legal-warning.html %}
 
 {: .alert.alert-warning :}
 This module requires the [EU GDPR consent management module](/dev-docs/modules/consentManagement.html) (the base consent module), which reads consent values from the Consent Management Platform (CMP). The GDPR Enforcement Module

--- a/dev-docs/modules/gppControl_usnat.md
+++ b/dev-docs/modules/gppControl_usnat.md
@@ -17,11 +17,7 @@ sidebarType : 1
 - TOC
 {: toc }
 
-{% capture legalNotice %}
-This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under European and/or US regulations, including the GDPR, the ePrivacy Directive, CCPA, other state privacy laws, etc, and how you implement the tools outlined in this document. Only your lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
-{% endcapture %}
-
-{% include /alerts/alert_important.html content=legalNotice %}
+{% include legal-warning.html %}
 
 ## Overview
 

--- a/dev-docs/modules/gppControl_usstates.md
+++ b/dev-docs/modules/gppControl_usstates.md
@@ -17,11 +17,7 @@ sidebarType : 1
 - TOC
 {: toc }
 
-{% capture legalNotice %}
-This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under European and/or US regulations, including the GDPR, the ePrivacy Directive, CCPA, other state privacy laws, etc, and how you implement the tools outlined in this document. Only your lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
-{% endcapture %}
-
-{% include /alerts/alert_important.html content=legalNotice %}
+{% include legal-warning.html %}
 
 ## Overview
 

--- a/features/ac-quebec.md
+++ b/features/ac-quebec.md
@@ -2,7 +2,7 @@
 layout: page_v2
 title: Prebid Quebec Privacy Support
 description: Prebid Quebec Privacy Support
-sidebarType: 0
+sidebarType: 7
 ---
 
 # Prebid Quebec Privacy Support
@@ -11,26 +11,21 @@ sidebarType: 0
 - TOC
 {:toc}
 
-{: .alert.alert-warning :}
-This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under Canadian, European and/or US regulations, including the GDPR, the ePrivacy Directive, CCPA, other state privacy laws, etc, and how you implement the tools outlined in this document. Only your lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
+{% include legal-warning.html %}
 
 ## Overview
 
-Starting September 23 2023, new privacy regulations will come into effect in Quebec, a province of Canada, governing about a quarter of Canada's population.
+Starting September 2023, new privacy regulations came into effect in Quebec, a province of Canada, governing about a quarter of Canada's population.
 
-IAB Canada has offered a modified version of the Transparency and Consent Framework (TCF) as a solution to cover user consent preferences in Quebec. At the time of this writing (August 2023), guidance from regulators, TCF Canada, and major advertising entities in Canada is in flux, even though enforceability of the law is imminent. The Canadian vendor list does not have enough vendors for meaningful adoption of the framework by any publisher, as it does not include the primary publisher ad server nor any large DSP, nor have any of the top five CMPs [registered as CMPs with TCF Canada](https://iabcanada.com/tcf-canada/cmp-list/).
+IAB Canada has offered a modified version of the Transparency and Consent Framework (TCF) as a solution to cover user consent preferences in Quebec. However, at the time of this writing (Jan 2024), guidance from regulators, TCF Canada, and major advertising entities in Canada is in flux. The Canadian vendor list does not have enough vendors for meaningful adoption of the framework by any publisher, as it does not include the primary publisher ad server nor many large DSPs, nor many of the top five CMPs [registered as CMPs with TCF Canada](https://iabcanada.com/tcf-canada/cmp-list/).
 
-The full list of CMPs registered on August 11 2023 are: ATOMIOS, Consent Manager AB, Transfon Ltd, Plex GmbH, Ketch Kloud Inc. The [Canadian vendor list](https://vendor-list.consensu.org/v2/ca/vendor-list.json) has 27 vendors.
-
-Given this context, Prebid has identified publisher concern that many will not be able to transact programmatically in Quebec beginning in September. This document is intended to provide guidance on conveying user notification and consent signals as gathered by the publisher to Prebid software independent of the GPP signals in Section 5 and the lack of a working consent string framework from IAB Canada.
+Given this context, Prebid has identified publisher concern that many will not be able to transact programmatically in Quebec until broader adoption of the IAB TCF-Canada spec is achieved. This document is intended to provide guidance on conveying user notification and consent signals as gathered by the publisher to Prebid software independent of the GPP signals in Section 5 and the lack of a working consent string framework from IAB Canada.
 
 References:
 
 - [TCF Canada Infographic on Quebec Privacy Law](https://iabcanada.com/content/uploads/2022/04/IAB-Canada_Quebec-Privacy-Law-Inforgraphic.pdf)
 - [IAB Canada TCF Canada policies](https://iabcanada.com/tcf-canada/for-publishers/)
 - [IABTL's GPP Canada section spec](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/Canada/GPPExtension%3A%20IAB%20Canada%20TCF.md)
-
-Prebid.org cannot advise publishers on how to conform to privacy laws that affect their business. Instead, publishers should be aware of what privacy-related features Prebid supports so that their legal, product, and engineering teams can define a privacy implementation.
 
 ## TCF Canada and GPP Support in Prebid.js
 
@@ -102,7 +97,7 @@ bidders are in such alignment.
 An alternate solution would utilize the Prebid Server version of the [Activity Control system](/prebid-server/features/pbs-activitycontrols.html).
 
 {: .alert.alert-info :}
-Only the Java version of Prebid Server currently supports the Activity Control system.
+Only the Java version of Prebid Server currently supports targeting Activity Controls to geographic regions.
 
 Here's an example account configuration that utilizes the user's geographic region to determine
 whether to allow or deny the named activities. Publishers will need to confirm the details with

--- a/features/mspa-usnat.md
+++ b/features/mspa-usnat.md
@@ -69,7 +69,7 @@ Here's a summary of the privacy features in Prebid.js that publishers may use to
 | ----------------- | ---------------------- | ----- |
 | before 7.30 | None | If you operate in the US, you should consider upgrading. |
 | 7.30-7.51 | **GPP module** | The [GPP module](/dev-docs/modules/consentManagementGpp.html) reads the GPP string from a compliant CMP and passes to compliant bid adapters. Not many bid adapters supported GPP in earlier versions. |
-| 7.52-8.1 | GPP module <br/> **Activity&nbsp;Controls** | [Activity Controls](/dev-docs/activity-controls.html) provide the ability for publishers to allow or restrict certain privacy-sensitive activities for particular bidders and modules. See examples in that document for supporting CCPA directly.
+| 7.52-8.1 | GPP module <br/> **Activity&nbsp;Controls** | [Activity Controls](/dev-docs/activity-controls.html) provide the ability for publishers to allow or restrict certain privacy-sensitive activities for particular bidders and modules. See examples in that document for supporting CCPA directly. |
 | 8.2-8.x | GPP module<br/>Activity Controls<br/>**USNat module** | The [USNat module](/dev-docs/modules/gppControl_usnat.html) processes SID 7. |
 | After 8.x | GPP module<br/>Activity Controls<br/>USNat module<br/>**US&nbsp;State&nbsp;module** | The US State module processes SIDs 8 through 12 after normalizing protocol differences. |
 | After 8.10 | **GPP Module**  | The [GPP module](/dev-docs/modules/consentManagementGpp.html) now understands GPP 1.1 which makes it incompatible with GPP 1.0. Publishers **<u>MUST</u>** upgrade for continued GPP support. |

--- a/features/mspa-usnat.md
+++ b/features/mspa-usnat.md
@@ -2,7 +2,7 @@
 layout: page_v2
 title: Prebid MSPA Support
 description: Prebid MSPA Support
-sidebarType: 0
+sidebarType: 7
 ---
 
 # Prebid Multi-State Privacy Agreement Support
@@ -11,8 +11,7 @@ sidebarType: 0
 - TOC
 {:toc}
 
-{: .alert.alert-warning :}
-This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under European and/or US regulations, including the GDPR, the ePrivacy Directive, CCPA, other state privacy laws, etc, and how you implement the tools outlined in this document. Only your lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
+{% include legal-warning.html %}
 
 ## Overview
 
@@ -85,10 +84,10 @@ Here's a summary of the privacy features in Prebid Server that publishers may us
 | PBS-Go before 0.236<br/>PBS-Java before 1.110 | None | If you operate in the US, you should consider upgrading. |
 | PBS-Go 0.236<br/>PBS-Java 1.110 | **GPP passthrough** | PBS reads the GPP string from the ORTB request and passes to compliant bid adapters. Not many bid adapters supported GPP in earlier versions. |
 | PBS&#8209;Go&nbsp;0.248&nbsp;and&nbsp;later<br/>PBS&#8209;Java&nbsp;1.113&nbsp;and&nbsp;later | GPP passthrough<br/>**GPP US Privacy** | PBS will read SID 6 out of the GPP string and process it as if regs.us_privacy were present on the request. |
-| PBS-Go TBD<br/>PBS-Java 1.118 | GPP passthrough<br/>GPP US Privacy<br/>**Activity Controls** | [Activity Controls](/prebid-server/features/pbs-activitycontrols.html) grant the ability for publishers to allow or restrict certain privacy-sensitive activities for particular bidders and modules. |
+| PBS-Go 2.2<br/>PBS-Java 1.118 | GPP passthrough<br/>GPP US Privacy<br/>**Activity Controls** | [Activity Controls](/prebid-server/features/pbs-activitycontrols.html) grant the ability for publishers to allow or restrict certain privacy-sensitive activities for particular bidders and modules. |
 | PBS-Go TBD<br/>PBS-Java 1.122 | GPP passthrough<br/>GPP US Privacy<br/>**Enhanced Activity Controls** | Activity controls support additional conditions for defining USNat-related rules: gppSid, geo, and gpc. |
 | PBS-Go TBD<br/>PBS-Java 1.126 | GPP passthrough<br/>GPP US Privacy<br/>Enhanced Activity Controls<br/>**USGen Module** | The [USGen module](/prebid-server/features/pbs-usgen.html) processes SIDs 7 through 12 after normalizing protocol differences. |
-| TBD | GPP passthrough<br/>GPP US Privacy<br/>Enhanced Activity Controls<br/>USNat Module<br/>**US&nbsp;Custom&nbsp;Logic&nbsp;module** | Allows publishers to provide alternate interpretations of the USNat string as it applies to Activity Controls. |
+| PBS-Go TBD<br/>PBS-Java 1.130 | GPP passthrough<br/>GPP US Privacy<br/>Enhanced Activity Controls<br/>USNat Module<br/>**US&nbsp;Custom&nbsp;Logic&nbsp;module** | Allows publishers to provide alternate interpretations of the USNat string as it applies to Activity Controls. |
 
 ### Prebid SDK
 

--- a/prebid-mobile/prebid-mobile-privacy-regulation.md
+++ b/prebid-mobile/prebid-mobile-privacy-regulation.md
@@ -9,14 +9,9 @@ sidebarType: 2
 ---
 
 # Prebid Mobile Guide to Privacy Regulation
-
 {:.no_toc}
 
-{% capture legalNotice %}
-  This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under European and /or US regulations, including the GDPR, the ePrivacy Directive and CCPA. Only a lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
-  {% endcapture %}
-
-{% include /alerts/alert_important.html content=legalNotice %}
+{% include legal-warning.html %}
 
 - TOC
 {:toc}

--- a/prebid-mobile/prebid-mobile-privacy-regulation.md
+++ b/prebid-mobile/prebid-mobile-privacy-regulation.md
@@ -123,4 +123,3 @@ The job of the Prebid SDK will:
 - Not strip any user data or signaling of the request regardless of Notice and Opt out signal
 
 It is worth noting Prebid Server will be a passthrough as well and will not validate format or correctness of US Privacy signal nor strip any user data from the request either, even if the presence of an opt out.
-

--- a/prebid-server/endpoints/openrtb2/pbs-endpoint-video.md
+++ b/prebid-server/endpoints/openrtb2/pbs-endpoint-video.md
@@ -201,12 +201,7 @@ The `pricegranularity` sub-object `range` describes the maximum price point for 
 
 ### Regulations
 
-{% capture legalNotice %}
-
-  This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation.  Please note that because every company and its collection, use, and storage of personal data is different, you should also seek independent legal advice relating to obligations under European and /or US regulations, including the General Data Protection Regulations (GDPR), the existing ePrivacy Directive and California Consumer Protection Act (CCPA). Only a lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
-  {% endcapture %}
-
-{% include /alerts/alert_important.html content=legalNotice %}
+{% include legal-warning.html %}
 
 In order for publishers to meet their transparency, notice and choice/consent requirements under the GDPR and CCPA, Prebid Server supports the [IAB Europe Transparency & Consent Framework](https://www.iab.com/topics/consumer-privacy/gdpr/) and the [CCPA Compliance Framework](https://www.iab.com/guidelines/ccpa-framework/).
 

--- a/prebid-server/endpoints/openrtb2/pbs-endpoint-video.md
+++ b/prebid-server/endpoints/openrtb2/pbs-endpoint-video.md
@@ -47,7 +47,7 @@ These key-values are returned to the SSAI server as part of the video response.
 10. The stitched stream is returned to the application.
 
 <br>
-<img src="/assets/images/flowcharts/pb-lfv-serverside.png">
+<img src="/assets/images/flowcharts/pb-lfv-serverside.png" alt="architecture diagram">
 <br>
 
  **Parameters**<a name="parameters"></a>

--- a/prebid-server/features/pbs-activitycontrols.md
+++ b/prebid-server/features/pbs-activitycontrols.md
@@ -39,8 +39,7 @@ The Activity Control configuration has two components:
 
 ### Prebid Server Is a Toolkit
 
-{: .alert.alert-danger :}
-Important: This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under European and /or US regulations, including the GDPR, the ePrivacy Directive and CCPA. Only a lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
+{% include legal-warning.html %}
 
 Activity Controls and privacy features within Prebid Server are tools meant to be useful to
 publishers within their overall privacy strategy. Prebid assumes a larger context around these

--- a/prebid-server/features/pbs-privacy.md
+++ b/prebid-server/features/pbs-privacy.md
@@ -10,8 +10,7 @@ title: Prebid Server | Features | Privacy
 * TOC
 {:toc}
 
-{: .alert.alert-danger :}
-Important: This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under European and /or US regulations, including the GDPR, the ePrivacy Directive and individual state laws. Only a lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
+{% include legal-warning.html %}
 
 ## Prebid Server Activity Control Infrastructure
 

--- a/prebid-server/features/pbs-uscustomlogic.md
+++ b/prebid-server/features/pbs-uscustomlogic.md
@@ -13,8 +13,7 @@ This feature is currently only available in PBS-Java.
 - TOC
 {:toc}
 
-{: .alert.alert-danger :}
-Important: This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under European and /or US regulations, including the GDPR, individual state laws, the ePrivacy Directive and CCPA. Only a lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
+{% include legal-warning.html %}
 
 ## Overview
 

--- a/prebid-server/features/pbs-usgen.md
+++ b/prebid-server/features/pbs-usgen.md
@@ -13,8 +13,7 @@ This feature is currently only available in PBS-Java.
 * TOC
 {:toc}
 
-{: .alert.alert-danger :}
-Important: This resource should not be construed as legal advice and Prebid.org makes no guarantees about compliance with any law or regulation. Please note that because every company and its collection, use, and storage of personal data is different, you should seek independent legal advice relating to obligations under European and /or US regulations, including the GDPR, individual state laws, the ePrivacy Directive and CCPA. Only a lawyer can provide you with legal advice specifically tailored to your situation. Nothing in this guide is intended to provide you with, or should be used as a substitute for, legal advice tailored to your business.
+{% include legal-warning.html %}
 
 ## Overview
 

--- a/support/index.md
+++ b/support/index.md
@@ -17,45 +17,31 @@ There are several ways to ask for help or get involved with Prebid.  See below f
 
 ## Overview
 
-For technical and feature requests or questions, it's best to use the GitHub or Stack Overflow forums. Prebid is worked on full-time by engineering teams from Xandr and Magnite.  There are also many publishers using and contributing to the project.
+For technical and feature requests or questions, it's best to use GitHub. Prebid is worked on by engineering teams from Xandr, Magnite, Pubmatic, IndexExchange, and other companies. There are also many publishers using and contributing to the project.
 
 For questions about how an adapter works, it's best to reach out to the company directly, or raise an issue on GitHub. Each demand adapter should be maintained by the SSPs or exchange behind that adapter.
-
-For Prebid news or general questions, we recommend the Ad Ops Slack Channel, Quora, or Twitter.
 
 {: .alert.alert-success :}
 There are serveral Prebid.org members that will install and maintain Prebid on a publisher's behalf. See the list of [Managed Prebid Solutions](https://prebid.org/product-suite/managed-services/).
 
 ## GitHub
 
-Sometimes people have already gotten answers on the GitHub forums. See [issues with the 'question' tag on the Prebid.js repo](https://github.com/prebid/Prebid.js/issues?utf8=%E2%9C%93&q=is%3Aissue%20label%3Aquestion%20)
+Sometimes people have already gotten answers on the GitHub forums. Search for [issues in the Prebid.js repo](https://github.com/prebid/Prebid.js/issues)
 
 Submit a GitHub issue for [Prebid.js](https://github.com/prebid/Prebid.js/issues), [Prebid SDK iOS](https://github.com/prebid/prebid-mobile-ios/issues), [Prebid Mobile Android](https://github.com/prebid/prebid-mobile-android/issues) or [Prebid Server](https://github.com/prebid/prebid-server/issues) if:
 
 - You have a feature request to the code base.
 - You have found a bug in the code.
 
-For more information about how to contribute, see the *Contribute* section of the site.
+For more information about how to contribute, see:
+- [Prebid.js](https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md)
+- [Prebid Server GoLang](https://github.com/prebid/prebid-server/blob/master/docs/developers/contributing.md)
+- [Prebid Server Java](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/contributing.md)
 
-## Stack Overflow
+## Web Contact Form
 
-If you ask questions on [Stack Overflow](https://stackoverflow.com/), please use the following tags:
-
-- `prebid`
-- `prebid.js`
+Another option is to use our [web contact form](https://prebid.org/contact-us/).
 
 ## Ad Ops Slack Channel
 
 Join the [Ad Ops Reddit Slack](https://redditadops.slack.com/messages/C0HVALS8P/) (specifically the `#HeaderBidding` channel) to connect with other publishers and developers using Prebid.
-
-## Reddit
-
-[Post on Reddit](https://www.reddit.com/r/adops/search?q=prebid.js) (Please include the word "Prebid.js" for us to get notified) if:
-
-- You have ad ops related questions, e.g. setting up line items and creatives.
-
-## Quora
-
-[Post on Quora](https://www.quora.com/topic/Prebid-js) (Please tag the question with "Prebid.js") if:
-
-- You have high level questions, e.g. the best strategy to host unbiased header bidding auctions.

--- a/support/index.md
+++ b/support/index.md
@@ -34,6 +34,7 @@ Submit a GitHub issue for [Prebid.js](https://github.com/prebid/Prebid.js/issues
 - You have found a bug in the code.
 
 For more information about how to contribute, see:
+
 - [Prebid.js](https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md)
 - [Prebid Server GoLang](https://github.com/prebid/prebid-server/blob/master/docs/developers/contributing.md)
 - [Prebid Server Java](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/contributing.md)

--- a/support/privacy-resources.md
+++ b/support/privacy-resources.md
@@ -85,6 +85,7 @@ period, publishers can better align browser and programmatic ad behavior by only
 the relevant Chrome testing labels.
 
 If you want to gather interest group bids only when IG auctions are very likely to run, you can enable the module like this:
+
 ```javascript
 Promise.resolve(navigator.cookieDeprecationLabel?.getValue?.()).then(label => {
     pbjs.setConfig({
@@ -96,6 +97,7 @@ Promise.resolve(navigator.cookieDeprecationLabel?.getValue?.()).then(label => {
 ```
 
 If you want to gather interest group bids whenever when IG auctions _might_ run, you can enable the module like this:
+
 ```javascript
 Promise.resolve(navigator.cookieDeprecationLabel?.getValue?.()).then(label => {
     pbjs.setConfig({

--- a/support/privacy-resources.md
+++ b/support/privacy-resources.md
@@ -1,0 +1,108 @@
+---
+layout: page_v2
+title: Prebid Privacy Resources
+description: Prebid Privacy Resources
+sidebarType: 7
+---
+
+# Prebid Privacy Resources
+{:.no_toc}
+
+- TOC
+{:toc}
+
+## Overview
+
+{% include legal-warning.html %}
+
+Prebid has many tools that can be utilized to help publishers and app developers achieve the data privacy goals defined by their legal teams.
+We cannot help you decide _what_ to do, but this page will help you understand the tools that various Prebid products offer in support
+of user privacy.
+
+## Regional Privacy References
+
+### United States
+
+The IAB's original "US Privacy" standard was designed for the California rules known as CCPA or CPRA. Prebid support for the original USP
+protocol is described:
+
+- [Prebid.js US Privacy Consent Management Module](/dev-docs/modules/consentManagementUsp.html)
+- [Prebid Server and CCPA/USP](/prebid-server/features/pbs-privacy.html#ccpa--us-privacy)
+
+After more states started making their own privacy regulations, the IAB developed the "Global Privacy Protocol" (GPP) and the
+Multi-State Privacy Agreement (MSPA). GPP is just a container that can hold specific regional protocols.
+
+- [Prebid.js support for GPP](/dev-docs/modules/consentManagementGpp.html)
+- [Prebid Support for MSPA](/features/mspa-usnat.html).
+
+### Europe
+
+The privacy tools that Prebid has built in support of European rules may help address the requirements of the GDPR and the Digital Services Act.
+
+The IAB defined the Transparency and Consent Framework (TCF) to address European GDPR rules. Prebid support for TCF is described:
+
+- [Prebid.js CMP Best Practices](/dev-docs/cmp-best-practices.html)
+- [Prebid.js GDPR Consent Management Module](/dev-docs/modules/consentManagement.html)
+- [Prebid.js GDPR Enforcement Module](/dev-docs/modules/gdprEnforcement.html)
+- [Prebid Server GDPR Support](/prebid-server/features/pbs-privacy.html#gdpr)
+- [White paper: Prebid Support for Enforcing TCF 2](https://docs.google.com/document/d/1fBRaodKifv1pYsWY3ia-9K96VHUjd8kKvxZlOsozm8E/edit)
+
+### Canada
+
+Please see [Prebid's support for Quebec privacy law 25](/features/ac-quebec.html).
+
+## Global Privacy References
+
+### Chrome Privacy Sandbox
+
+Privacy Sandbox is the name the Chrome browser has given to a series of features aimed at smoothing the transition off the 3rd party cookie.
+
+#### Topics
+
+At a high level, the "Topics" feature is Chrome's way of defining a taxonomy of information that can be used for ad targeting. See 
+[Chrome Topics](https://privacysandbox.com/proposals/topics/) for details.
+
+There's actually nothing to do to enable Topics in Prebid – bidders will receive their own Topics if they've implemented that feature.
+That said, Prebid does have a [Topics FPD Module](/dev-docs/modules/topicsFpdModule.html) that allows bidders to share each other's Topics.
+
+#### Protected Audience API
+
+PAAPI is Chrome's solution for ad targeting done in a privacy-friendly way. In short, GAM will kick off an in-browser auction after
+the contextual auction. If the in-browser auction wins, it can override the ad chosen by GAM. 
+
+See [Chrome's PAAPI documentation](https://developers.google.com/privacy-sandbox/relevance/protected-audience) for the full background.
+
+To enable Interest Group bidding in Prebid, you can add the Prebid [Fledge For GPT Module](/dev-docs/modules/fledgeForGpt.html).
+
+##### Test Period
+
+During the first part of 2024, Chrome and GAM are running a test of PAAPI on a limited subset of traffic. However, the
+[Fledge For GPT Module](/dev-docs/modules/fledgeForGpt.html) enables Interest Group auctions 100% of the time. During the test
+period, publishers can better align browser and programmatic ad behavior by only enabling Interest Group auctions for
+the relevant Chrome testing labels. Here's example code:
+
+```javascript
+Promise.resolve(navigator.cookieDeprecationLabel?.getValue?.()).then(label => {
+    pbjs.setConfig({
+        fledgeForGpt: {
+            enabled: !label || label.startsWith("treatment_") || label === 'label_only_5'
+        }
+    });
+});
+```
+
+#### Prebid.js Versions Supporting Privacy Sandbox
+
+This table may be useful to publishers trying to decide which version of Prebid.js to use to support Privacy Sandbox.
+
+{: .table .table-bordered .table-striped }
+| Prebid.js Version | Notes |
+|-------------------|-------|
+| 8.22| Makes Prebid FPD available to the PAAPI generateBid, scoreAds, and reportResult functions |
+| 8.15| Added floor signal to the fledgeForGpt module |
+| 8.9| Initial release of the fledgeForGpt module, Sec-Browsing-Topics header enabled |
+| 8.8| The topicsFpd module is released, allowing bidders to share topics |
+
+## Further Reading
+
+- [Prebid Server Privacy Support](/prebid-server/features/pbs-privacy.html)

--- a/support/privacy-resources.md
+++ b/support/privacy-resources.md
@@ -74,18 +74,33 @@ See [Chrome's PAAPI documentation](https://developers.google.com/privacy-sandbox
 
 To enable Interest Group bidding in Prebid, you can add the Prebid [Fledge For GPT Module](/dev-docs/modules/fledgeForGpt.html).
 
+{: .alert.alert-info :}
+Note that 'FLEDGE' was the original name of the Protected Audience feature. The name of the Prebid.js module may change in the future.
+
 ##### Test Period
 
 During the first part of 2024, Chrome and GAM are running a test of PAAPI on a limited subset of traffic. However, the
 [Fledge For GPT Module](/dev-docs/modules/fledgeForGpt.html) enables Interest Group auctions 100% of the time. During the test
-period, publishers can better align browser and programmatic ad behavior by only enabling Interest Group auctions for
-the relevant Chrome testing labels. Here's example code:
+period, publishers can better align browser and programmatic ad behavior by only enabling Prebid interest group bids for
+the relevant Chrome testing labels.
 
+If you want to gather interest group bids only when IG auctions are very likely to run, you can enable the module like this:
 ```javascript
 Promise.resolve(navigator.cookieDeprecationLabel?.getValue?.()).then(label => {
     pbjs.setConfig({
         fledgeForGpt: {
             enabled: !label || label.startsWith("treatment_") || label === 'label_only_5'
+        }
+    });
+});
+```
+
+If you want to gather interest group bids whenever when IG auctions _might_ run, you can enable the module like this:
+```javascript
+Promise.resolve(navigator.cookieDeprecationLabel?.getValue?.()).then(label => {
+    pbjs.setConfig({
+        fledgeForGpt: {
+            enabled: !label || label.startsWith("treatment_") || label != 'label_only_1'
         }
     });
 });

--- a/support/privacy-resources.md
+++ b/support/privacy-resources.md
@@ -45,7 +45,7 @@ The IAB defined the Transparency and Consent Framework (TCF) to address European
 - [Prebid.js GDPR Consent Management Module](/dev-docs/modules/consentManagement.html)
 - [Prebid.js GDPR Enforcement Module](/dev-docs/modules/gdprEnforcement.html)
 - [Prebid Server GDPR Support](/prebid-server/features/pbs-privacy.html#gdpr)
-- [White paper: Prebid Support for Enforcing TCF 2](https://docs.google.com/document/d/1fBRaodKifv1pYsWY3ia-9K96VHUjd8kKvxZlOsozm8E/edit)
+- [White paper: Prebid Support for Enforcing TCF 2](https://docs.google.com/document/d/1fBRaodKifv1pYsWY3ia-9K96VHUjd8kKvxZlOsozm8E)
 
 ### Canada
 


### PR DESCRIPTION
Documentation for Privacy Sandbox per https://github.com/prebid/Prebid.js/issues/10932 and refactored several other privacy-related pages. Made the legal warning an include and shifted the location of privacy docs in the left nav.