### PR TITLE
Add docker container for running preview locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.0
+
+WORKDIR /usr/src/app
+
+COPY Gemfile* ./
+
+RUN bundle install
+
+COPY . .
+
+CMD JEKYLL_ENV=production bundle exec jekyll serve -H 0.0.0.0
+
+EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ Configuration file: /Users/me/git/prebid.github.io/_config.yml
 
 Open the `Server address` URL in your browser, and you should see a locally running copy of the site.
 
+### Running in a docker container
+
+```bash
+docker build . -t prebid.github.io
+docker run -i -t -p 8080:8080 prebid.github.io
+```
+
 <a name="building-assets"></a>
 
 ## Building Assets


### PR DESCRIPTION
Hi! Currently, it is not very convenient to run jekyll on a personal machine since it would require us to install ruby and related tooling. So I added a docker configuration for those who prefer containerized preview of the docs. 

Thanks!