### PR TITLE
Add Lucead Adapter

### DIFF
--- a/dev-docs/bidders/lucead.md
+++ b/dev-docs/bidders/lucead.md
@@ -1,0 +1,33 @@
+---
+layout: bidder
+title: Lucead adapter
+description: Prebid Lucead Bidder Adapter
+biddercode: lucead
+tcfeu_supported: false
+gvl_id: none
+usp_supported: false
+coppa_supported: false
+schain_supported: false
+dchain_supported: false
+media_types: banner
+safeframes_ok: true
+deals_supported: true
+floors_supported: true
+fpd_supported: true
+pbjs: true/false
+pbs: true/false
+prebid_member: true/false
+ortb_blocking_supported: false
+privacy_sandbox: paapi
+sidebarType: 1
+---
+### Note
+
+The Lucead Bidding adapter requires setup before beginning. Please contact us at [aymeric@lucead.com](mailto:aymeric@lucead.com).
+
+
+### Bid Params
+
+| Name          | Scope    | Description           | Example   | Type      |
+|---------------|----------|-----------------------|-----------|-----------|
+| `placementId` | required | Placement id          | `'11111'` | `string`  |

--- a/dev-docs/bidders/lucead.md
+++ b/dev-docs/bidders/lucead.md
@@ -23,7 +23,7 @@ sidebarType: 1
 ---
 ### Note
 
-The Lucead Bidding adapter requires setup before beginning. Please contact us at [aymeric@lucead.com](mailto:aymeric@lucead.com).
+The Lucead Bidding adapter requires setup before beginning. Please contact us at [prebid@lucead.com](mailto:prebid@lucead.com).
 
 ### Bid Params
 

--- a/dev-docs/bidders/lucead.md
+++ b/dev-docs/bidders/lucead.md
@@ -25,7 +25,6 @@ sidebarType: 1
 
 The Lucead Bidding adapter requires setup before beginning. Please contact us at [aymeric@lucead.com](mailto:aymeric@lucead.com).
 
-
 ### Bid Params
 
 | Name          | Scope    | Description           | Example   | Type      |

--- a/dev-docs/bidders/lucead.md
+++ b/dev-docs/bidders/lucead.md
@@ -14,8 +14,8 @@ safeframes_ok: true
 deals_supported: true
 floors_supported: true
 fpd_supported: true
-pbjs: true/false
-pbs: true/false
+pbjs: true
+pbs: false
 prebid_member: true/false
 ortb_blocking_supported: false
 privacy_sandbox: paapi


### PR DESCRIPTION
This PR adds the documentation of the Lucead Bid Adapter.

## 🏷 Type of documentation
New Bid Adapter


## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked -> https://github.com/prebid/Prebid.js/pull/11068
- [x] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
