### PR TITLE
List bidders with gpp_sids support

### DIFF
--- a/dev-docs/modules/consentManagementGpp.md
+++ b/dev-docs/modules/consentManagementGpp.md
@@ -186,9 +186,9 @@ var adaptersSupportingGpp=[];
 var idx_gdpr=0;
 {% assign bidder_pages = site.pages | where: "layout", "bidder" %}
 {% for item in bidder_pages %}
-    {% if item.gpp_supported == true %}
+    {% if item.gpp_supported == true or item.gpp_sids %}
     adaptersSupportingGpp[idx_gdpr]={};
-    adaptersSupportingGpp[idx_gdpr].href="/dev-docs/bidders.html#{{item.biddercode}}";
+    adaptersSupportingGpp[idx_gdpr].href="/dev-docs/bidders/{{item.biddercode}}";
     adaptersSupportingGpp[idx_gdpr].text="{{item.title}}";
     idx_gdpr++;
     {% endif %}


### PR DESCRIPTION
Adds bidders with `gpp_sids` to the https://docs.prebid.org/dev-docs/modules/consentManagementGpp.html list

## 🏷 Type of documentation

- [x] bugfix 

