### PR TITLE
ID5 Analytics - enable download

### DIFF
--- a/dev-docs/analytics/id5.md
+++ b/dev-docs/analytics/id5.md
@@ -7,7 +7,7 @@ tcfeu_supported: true
 usp_supported: true
 prebid_member: true
 gvl_id: 131
-enable_download: false
+enable_download: true
 ---
 
 #### Registration


### PR DESCRIPTION
## 🏷 Type of documentation

- [x] new feature

Enabled ID5 analytics module to be downloaded on prebid download page
