### PR TITLE
seddingAlliance: update docs because of prebid server adapter changes

### DIFF
--- a/dev-docs/bidders/seedingAlliance.md
+++ b/dev-docs/bidders/seedingAlliance.md
@@ -28,4 +28,5 @@ sidebarType: 1
 | Name        | Scope    | Description          | Example            | Type      |
 |-------------|----------|----------------------|--------------------|-----------|
 | `adUnitId`  | required | ID of the Ad Unit    | `8ao`              | `string`  |
+| `accountId` | optional | Your identifier for the account (Prebid Server only) | `12345` | `string`  |
 | `url`       | optional | URL from the Page    | `example.tld`      | `string`  |


### PR DESCRIPTION
Seeding Alliance Prebid Server Adapter introduced a new parameter, this updates the documentation 

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked (https://github.com/prebid/prebid-server/pull/3486)
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
