### PR TITLE
Cwire adapter: Update tcfeu_supported field (c-wire/support#117)

### DIFF
--- a/dev-docs/bidders/cwire.md
+++ b/dev-docs/bidders/cwire.md
@@ -6,6 +6,7 @@ pbjs: true
 pbs: true
 biddercode: cwire
 tcfeu_supported: true
+gvl_id: 1081
 usp_supported: false
 schain_supported: false
 userIds: none

--- a/dev-docs/bidders/cwire.md
+++ b/dev-docs/bidders/cwire.md
@@ -5,7 +5,7 @@ description: C-WIRE Prebid Bidder Adapter
 pbjs: true
 pbs: true
 biddercode: cwire
-tcfeu_supported: false
+tcfeu_supported: true
 usp_supported: false
 schain_supported: false
 userIds: none


### PR DESCRIPTION

## 🏷 Type of documentation

Updated `tcfeu_supported: true` in CWire's adapter docs.