### PR TITLE
New Bidder Adapter: Adlive Plus

### DIFF
--- a/dev-docs/bidders/adliveplus.md
+++ b/dev-docs/bidders/adliveplus.md
@@ -1,8 +1,9 @@
 ---
 layout: bidder
-title: Lucead
-description: Prebid Lucead Bidder Adapter
-biddercode: lucead
+title: Adlive Plus
+description: Adlive Plus adapter
+biddercode: adliveplus
+aliasCode: lucead
 tcfeu_supported: false
 gvl_id: none
 usp_supported: false
@@ -23,7 +24,7 @@ sidebarType: 1
 ---
 ### Note
 
-The Lucead Bidding adapter requires setup before beginning. Please contact us at [prebid@lucead.com](mailto:prebid@lucead.com).
+The Adlive Plus adapter requires setup before beginning. Please contact us at [support@adlive.io](mailto:support@adlive.io).
 
 ### Bid Params
 
@@ -41,7 +42,7 @@ const adUnits = [
            sizes: [[300, 250]],
            bids: [
                {
-                   bidder: 'lucead',
+                   bidder: 'adliveplus',
                    params: {
                        placementId: '1',
                    }

--- a/dev-docs/bidders/adliveplus.md
+++ b/dev-docs/bidders/adliveplus.md
@@ -33,9 +33,9 @@ The Adlive Plus adapter requires setup before beginning. Please contact us at [s
 |---------------|----------|-----------------------|-----------|-----------|
 | `placementId` | required | Placement id          | `'11111'` | `string`  |
 
-
 ### Test Parameters
-```
+
+```javascript
 const adUnits = [
        {
            code: 'test-div',

--- a/dev-docs/bidders/lucead.md
+++ b/dev-docs/bidders/lucead.md
@@ -32,9 +32,9 @@ The Lucead Bidding adapter requires setup before beginning. Please contact us at
 |---------------|----------|-----------------------|-----------|-----------|
 | `placementId` | required | Placement id          | `'11111'` | `string`  |
 
-
 ### Test Parameters
-```
+
+```javascript
 const adUnits = [
        {
            code: 'test-div',


### PR DESCRIPTION
This PR adds the documentation of the Adlive Plus Bid Adapter.
This is an alias of the Lucead Bid Adapter.

## 🏷 Type of documentation
New Bid Adapter


## 📋 Checklist
- [x] Related pull requests in prebid.js -> https://github.com/prebid/Prebid.js/pull/11176
- [x] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
