### PR TITLE
[JW Player RTD Module] Updates docs for new content fields and deprecated config param

### DIFF
--- a/dev-docs/modules/jwplayerRtdProvider.md
+++ b/dev-docs/modules/jwplayerRtdProvider.md
@@ -65,8 +65,12 @@ To use this module, you'll need to work with [JW Player](https://www.jwplayer.co
     | waitForIt | Boolean | Required to ensure that the auction is delayed until prefetch is complete | Optional. Defaults to false |
     | params | Object | | |
     | params.mediaIDs | Array of Strings | Media Ids for prefetching | Optional |
+    | params.overrideContentId | String enum: 'always', 'whenEmpty' or 'never' | Determines when the module should update the oRTB site.content.id  | Defaults to 'always' |
+    | params.overrideContentUrl | String enum: 'always', 'whenEmpty' or 'never' | Determines when the module should update the oRTB site.content.url | Defaults to 'whenEmpty' |
+    | params.overrideContentTitle | String enum: 'always', 'whenEmpty' or 'never' | Determines when the module should update the oRTB site.content.title | Defaults to 'whenEmpty' |
+    | params.overrideContentDescription | String enum: 'always', 'whenEmpty' or 'never' | Determines when the module should update the oRTB site.content.ext.description | Defaults to 'whenEmpty' |
 
-4. Include the content's media ID and/or the player's ID in the matching AdUnit's `fpd.context.data.jwTargeting` before calling `addAdUnits`:
+5. Include the content's media ID and/or the player's ID in the matching AdUnit's `fpd.context.data.jwTargeting` before calling `addAdUnits`:
 
     ```javascript
     const adUnit = {

--- a/dev-docs/modules/jwplayerRtdProvider.md
+++ b/dev-docs/modules/jwplayerRtdProvider.md
@@ -70,7 +70,7 @@ To use this module, you'll need to work with [JW Player](https://www.jwplayer.co
     | params.overrideContentTitle | String enum: 'always', 'whenEmpty' or 'never' | Determines when the module should update the oRTB site.content.title | Defaults to 'whenEmpty' |
     | params.overrideContentDescription | String enum: 'always', 'whenEmpty' or 'never' | Determines when the module should update the oRTB site.content.ext.description | Defaults to 'whenEmpty' |
 
-5. Include the content's media ID and/or the player's ID in the matching AdUnit's `fpd.context.data.jwTargeting` before calling `addAdUnits`:
+4. Include the content's media ID and/or the player's ID in the matching AdUnit's `fpd.context.data.jwTargeting` before calling `addAdUnits`:
 
     ```javascript
     const adUnit = {

--- a/dev-docs/modules/jwplayerRtdProvider.md
+++ b/dev-docs/modules/jwplayerRtdProvider.md
@@ -69,7 +69,7 @@ To use this module, you'll need to work with [JW Player](https://www.jwplayer.co
 4. Include the content's media ID and/or the player's ID in the matching AdUnit's `fpd.context.data.jwTargeting` before calling `addAdUnits`:
 
     ```javascript
-    const adUnit = {1
+    const adUnit = {
       code: '/19968336/prebid_native_example_1',
       ...,
       ortb2Imp: {
@@ -101,6 +101,7 @@ To use this module, you'll need to work with [JW Player](https://www.jwplayer.co
 | ortb2Imp.ext.data.jwTargeting | Object | | |
 | ortb2Imp.ext.data.jwTargeting.mediaID | String | Media Id of the content associated to the Ad Unit | Optional but highly recommended |
 | ortb2Imp.ext.data.jwTargeting.playerDivId | String | the ID of the HTML div element used when instantiating the JW Player instance that will render the content associated with the Ad Unit | Optional but recommended. You can retrieve this ID by calling `player.id`, where player is the JW Player instance variable. |
+| ortb2Imp.ext.data.jwTargeting.playerID | String | Deprecated as of 8.40.0 - use playerDivId instead | |
 
 ## Implementation for Bid Adapters
 

--- a/dev-docs/modules/jwplayerRtdProvider.md
+++ b/dev-docs/modules/jwplayerRtdProvider.md
@@ -77,7 +77,7 @@ To use this module, you'll need to work with [JW Player](https://www.jwplayer.co
           data: {
             jwTargeting: {
               // Note: the following Ids are placeholders and should be replaced with your Ids.
-              playerID: 'abcd',
+              playerDivId: 'abcd',
               mediaID: '1234'
             }
           }
@@ -100,7 +100,7 @@ To use this module, you'll need to work with [JW Player](https://www.jwplayer.co
 | :------------ | :------------ | :------------ |:------------ |
 | ortb2Imp.ext.data.jwTargeting | Object | | |
 | ortb2Imp.ext.data.jwTargeting.mediaID | String | Media Id of the content associated to the Ad Unit | Optional but highly recommended |
-| ortb2Imp.ext.data.jwTargeting.playerID | String | the ID of the HTML div element used when instantiating the JW Player instance that will render the content associated with the Ad Unit | Optional but recommended. You can retrieve this ID by calling `player.id`, where player is the JW Player instance variable. |
+| ortb2Imp.ext.data.jwTargeting.playerDivId | String | the ID of the HTML div element used when instantiating the JW Player instance that will render the content associated with the Ad Unit | Optional but recommended. You can retrieve this ID by calling `player.id`, where player is the JW Player instance variable. |
 
 ## Implementation for Bid Adapters
 
@@ -118,6 +118,8 @@ Each bidRequest for which targeting information was found will conform to the fo
     site: {
       content: {
         id: 'jw_abc123',
+        title: 'media title',
+        url: 'https:www.cdn.com/media.mp4',
         data: [
           {
             name: 'jwplayer.com',
@@ -134,7 +136,10 @@ Each bidRequest for which targeting information was found will conform to the fo
               }
             ]
           }
-        ]
+        ],
+        ext: {
+          description: 'media description'
+        }
       }
     }
   }
@@ -152,6 +157,9 @@ The content's ID can be obtained in the `bid.ortb2.site.content.id` property pat
 | :------------ | :------------ | :------------ |:------------ |
 | ortb2.site.content | Object | | |
 | ortb2.site.content.id | String | Unique identifier for the specific media asset | |
+| ortb2.site.content.url | String | URL for the specific media asset | |
+| ortb2.site.content.title | String | The title of the media content | |
+| ortb2.site.content.ext.description | String | The description of the media content | |
 | ortb2.site.content.data | Array | Contains segment taxonomy objects | |
 | ortb2.site.content.data[index].name | String | the `jwplayer.com` string indicating the provider name | |
 | ortb2.site.content.data[index].ext.segtax | Integer | the `502` value is the unique identifier for JW Player's proprietary taxonomy | |


### PR DESCRIPTION
This PR updates the JW Player RTD Module docs to include:
- new content fields populated in the ORTB request
- replaces the deprecate `playerID` param with `playerDivId`

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] new feature

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
https://github.com/prebid/Prebid.js/pull/11179
https://github.com/prebid/Prebid.js/pull/11178

