### PR TITLE
Kargo: adds ORTB blocking to docs

### DIFF
--- a/dev-docs/bidders/kargo.md
+++ b/dev-docs/bidders/kargo.md
@@ -52,3 +52,37 @@ pbjs.bidderSettings = {
 | Name          | Scope    | Description | Example | Type     |
 |---------------|----------|-------------|---------|----------|
 | `placementId`       | required | The placementId of the ad slot. |`'_jWuc8Hks'`| `string` |
+
+### ORTB Blocking
+
+Kargo supports blocking advertisers in `badv` and categories in `bcat` parameters.
+The blocked advertisers/categories list has no length limitation, but response timeout is more likely to occur as the number of entries grow.
+Blocked advertisers list (`badv`) is an array of domains as strings.
+Blocked categories list (`bcat`) is an array of IAB categories as strings.
+
+For example:
+
+#### Globally defined ORTB Blocking
+
+```javascript
+pbjs.setConfig({
+  ortb2: {
+    badv: ["domain1.com", "domain2.com"],
+    bcat: ["IAB23-1", "IAB23-5", "IAB25-3", "IAB25-2"]
+  }
+)};
+```
+
+#### ORTB Blocking specific only to rtbhouse bidder
+
+```javascript
+pbjs.setBidderConfig({
+  bidders: ['kargo'],
+  config:{
+    ortb2: {
+      badv: ["domain1.com", "domain2.com"],
+      bcat: ["IAB23-1", "IAB23-5", "IAB25-3", "IAB25-2"]
+    }
+  }
+});
+```


### PR DESCRIPTION
## 🏷 Type of documentation
- [x] new feature
- [x] new examples

Documentation update to reflect Kargo adapter ingesting `ortb2` as of [8.42.0](https://github.com/prebid/Prebid.js/releases/tag/8.42.0)

<img width="862" alt="image" src="https://github.com/KargoGlobal/prebid.github.io/assets/12804307/01a9d232-9901-45af-9bf0-e627bd4fb6ae">

