### PR TITLE
Add additional instructions to line item creation steps in step-by-step section

### DIFF
--- a/adops/step-by-step.md
+++ b/adops/step-by-step.md
@@ -84,7 +84,7 @@ From the **Settings** tab, do the following:
 ![Line item delivery settings](/assets/images/ad-ops/gam-sbs/delivery-settings.png)
 
 {:start="7"}
-7. Under **Adjust delivery**, set **Rotate creatives** to **Evenly**. You can leave the defaults for everything else.
+7. Under **Adjust delivery**, set **Display creatives** to **One or more** and **Rotate creatives** to **Evenly**. You can leave the defaults for everything else.
 
 ### Targeting
 


### PR DESCRIPTION
While running through the step by step creation of a vanilla Prebid set up, I found a potentially setup-breaking instruction (as it did indeed break my test up).

The instruction states to only change **Rotate creatives** to **Evenly** on line items, then the default settings are okay to use.

The default setting in the **Adjust delivery** for **Display creatives** is **All**, which broke my setup; by having 2 creatives attached to the line item with only one ad slot to serve into.  As per the **All** rule, the line item can only be selected if all creatives have an open ad slot to serve into.  

I believe the **All** setting would break most Prebid set ups, so I am just proposing adding **One or more** as a default step in these instructions to avoid that mistake.

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X ] text edit only (wording, typos)

