### PR TITLE
[Criteo] Documentation pubid on Criteo Prebid Docs

### DIFF
--- a/dev-docs/bidders/criteo.md
+++ b/dev-docs/bidders/criteo.md
@@ -35,9 +35,9 @@ Prebid-Server support is on alpha test and is currently a non-finished product. 
 |-------------------|----------|----------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|------------|
 | `zoneId`          | required | (deprecated) The zone ID from Criteo. Should be replaced by `networkId` when using zone matching.                                    | `234234`                                      | `integer`  |
 | `networkId`       | required | The network ID from Criteo. Please reach out your Criteo representative for more details.                             | `456456`                                      | `integer`  |
+| `pubid`           | required | publisher id | `'ABC123'` |  `string` |
 | `nativeCallback`  | optional | (Prebid.js only) Callback to perform render in native integrations. Please reach out your Criteo representative for more details.     | `function(payload) { console.log(payload); }` | `function` |
 | `integrationMode` | optional | (Prebid.js only) Integration mode to use for ad render (none or 'AMP'). Please reach out your Criteo representative for more details. | `'AMP'`                                       | `string`   |
-| `pubid`           | required | publisher id | `'ABC123'` |  `string` |
 | `publisherSubId`  | optional | Custom identifier for reporting. Please reach out your Criteo representative for more details. | `'adunit-1'` |  `string` |
 
 ### First Party Data

--- a/dev-docs/bidders/criteo.md
+++ b/dev-docs/bidders/criteo.md
@@ -37,6 +37,7 @@ Prebid-Server support is on alpha test and is currently a non-finished product. 
 | `networkId`       | required | The network ID from Criteo. Please reach out your Criteo representative for more details.                             | `456456`                                      | `integer`  |
 | `nativeCallback`  | optional | (Prebid.js only) Callback to perform render in native integrations. Please reach out your Criteo representative for more details.     | `function(payload) { console.log(payload); }` | `function` |
 | `integrationMode` | optional | (Prebid.js only) Integration mode to use for ad render (none or 'AMP'). Please reach out your Criteo representative for more details. | `'AMP'`                                       | `string`   |
+| `pubid`           | required | publisher id | `'ABC123'` |  `string` |
 | `publisherSubId`  | optional | Custom identifier for reporting. Please reach out your Criteo representative for more details. | `'adunit-1'` |  `string` |
 
 ### First Party Data


### PR DESCRIPTION
## 🏷 Type of documentation
- [ ] new bid adapter
- [ ] update bid adapter
- [X] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Summary
The Criteo Prebid adapter supports the pubid field.
This field is required, so we need to add it to our documentation. 