### PR TITLE
Corrected link address in the idWardRtdProvider.md

### DIFF
--- a/dev-docs/modules/idWardRtdProvider.md
+++ b/dev-docs/modules/idWardRtdProvider.md
@@ -13,7 +13,7 @@ sidebarType : 1
 
 > **Warning!**
 >
-> The **idWardRtdProvider** module has been renamed to [anonymisedRtdProvider](anonymisedrtdprovider) in light of the company's rebranding.
+> The **idWardRtdProvider** module has been renamed to [anonymisedRtdProvider](/dev-docs/modules/anonymisedRtdProvider.html) in light of the company's rebranding.
 > **idWardRtdProvider** module is maintained for backward compatibility until the next major Prebid release.
 >
 > Please use anonymisedRtdProvider instead of idWardRtdProvider in your Prebid integration.


### PR DESCRIPTION
Corrected link address in the idWardRtdProvider.md(deprecated module) to the anonymisedRtdProvider.md (updated module, that replaces the old one)

## 🏷 Type of documentation
- [x] text edit only (wording, typos)
