### PR TITLE
Update Vidazoo bidder documentation

### DIFF
--- a/dev-docs/bidders/vidazoo.md
+++ b/dev-docs/bidders/vidazoo.md
@@ -10,6 +10,7 @@ tcfeu_supported: true
 gpp_supported: true
 usp_supported: true
 pbjs: true
+pbs: true
 sidebarType: 1
 ---
 
@@ -19,6 +20,6 @@ sidebarType: 1
 | Name       | Scope    | Description                                                                              | Example                      | Type     |
 |------------|----------|------------------------------------------------------------------------------------------|------------------------------|----------|
 | `cId`      | required | The connection ID from Vidazoo.                                                          | `'562524b21b1c1f08117fc7f9'` | `string` |
-| `pId`      | required | The publisher ID from Vidazoo.                                                           | `'59ac17c192832d0011283fe3'` | `string` |
+| `pId`      | required | The publisher ID from Vidazoo (pbjs only).                                               | `'59ac17c192832d0011283fe3'` | `string` |
 | `bidFloor` | optional | The minimum bid value desired. Vidazoo will not respond with bids lower than this value. | `0.90`                       | `float`  |
 | `subDomain`| optional | Sets the server subdomain, default: 'prebid'.                                            | `'prebid'`                     | `string` |


### PR DESCRIPTION
Added `pbs: true` to bidder functionality and updated the `pId` parameter description in the Vidazoo bidder documentation, specifying its use for pbjs only.

<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.
-->

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked -> https://github.com/prebid/prebid-server/pull/3698