### PR TITLE
Update README: remove liquid template section

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,6 @@ This means an adaptor is not available to download from Prebid.org as soon as th
 
 <a name="thanks"></a>
 
-## Liquid Templating
-
-* [jekyll - check for non empty](https://michaelcurrin.github.io/dev-cheatsheets/cheatsheets/jekyll/liquid/conditionals/non-empty.html)
-
 ## Thanks
 
 Many thanks to the following people who have submitted content to Prebid.org.  We really appreciate the help!


### PR DESCRIPTION
Really just testing the netlify preview environment, but I can't understand why this liquid section of the README exists