### PR TITLE
Update Gemfile for FFI version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages', '>= 228'
-
+gem 'ffi', '1.16.3'
 gem "webrick", "~> 1.7"


### PR DESCRIPTION
We started getting build errors for this repo yesterday when ffi released 1.17.0. It requires Ruby 3.0.

Tried this tying of the Gemfile to the previous version 1.16.3 in https://github.com/prebid/prebid.github.io/pull/5381 and it seemed to work.