### PR TITLE
ras rename

### DIFF
--- a/dev-docs/bidders/ringieraxelspringer.md
+++ b/dev-docs/bidders/ringieraxelspringer.md
@@ -5,6 +5,8 @@ description: Prebid RingierAxelSpringer Bidder Adapter
 biddercode: ringieraxelspringer
 media_types: banner, native
 pbjs: true
+pbs: false
+prebid_member: false
 gvl_id: 1021
 tcfeu_supported: true
 safeframes_ok: false
@@ -13,6 +15,14 @@ floors_supported: false
 fpd_supported: false
 sidebarType: 1
 multiformat_supported: will-bid-on-one
+dsa_supported: true
+privacy_sandbox: paapi
+ortb_blocking_supported: false
+schain_supported: false
+dchain_supported: false
+gpp_sids: None
+coppa_supported: false
+usp_supported: false
 ---
 
 

--- a/dev-docs/bidders/ringieraxelspringer.md
+++ b/dev-docs/bidders/ringieraxelspringer.md
@@ -2,7 +2,7 @@
 layout: bidder
 title: RingierAxelSpringer
 description: Prebid RingierAxelSpringer Bidder Adapter
-biddercode: ras
+biddercode: ringieraxelspringer
 media_types: banner, native
 pbjs: true
 gvl_id: 1021
@@ -13,7 +13,6 @@ floors_supported: false
 fpd_supported: false
 sidebarType: 1
 multiformat_supported: will-bid-on-one
-pbjs_version_notes: removed in 9.0
 ---
 
 


### PR DESCRIPTION
New version of https://github.com/prebid/prebid.github.io/pull/5383

Related to 9.0 PR https://github.com/prebid/Prebid.js/pull/11657

Note to @wsusrasp - there are many metadata fields missing from this file. Please see the documentation at https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter - the full list would look something like

```
tcfeu_supported: true/false
dsa_supported: true/false
gvl_id: none
usp_supported: true/false
coppa_supported: true/false
gpp_sids: tcfeu, tcfca, usnat, usstate_all, usp
schain_supported: true/false
dchain_supported: true/false
userId: (list of supported vendors)
media_types: banner, video, native
safeframes_ok: true/false
deals_supported: true/false
floors_supported: true/false
fpd_supported: true/false
pbjs: true/false
pbs: true/false
prebid_member: true/false
multiformat_supported: will-bid-on-any, will-bid-on-one, will-not-bid
ortb_blocking_supported: true/partial/false
privacy_sandbox: no or comma separated list of `paapi`, `topics`
```