### PR TITLE
Prebid 9: rename TCF modules

### DIFF
--- a/dev-docs/activity-controls.md
+++ b/dev-docs/activity-controls.md
@@ -152,7 +152,7 @@ For example, this rule would allow bidderX to perform the activity if no higher 
 Activity control rules in Prebid.js can be created by two main sources:
 
 * Publisher `setConfig({allowActivities})` as in the examples shown here. When set this way, rules are considered the highest priority value of 1.
-* Modules can set activity control rules, e.g. [usersync](/dev-docs/publisher-api-reference/setConfig.html#setConfig-Configure-User-Syncing), [bidderSettings](/dev-docs/publisher-api-reference/bidderSettings.html), the [GPP](/dev-docs/modules/consentManagementGpp.html) or [GDPR](/dev-docs/modules/gdprEnforcement.html) modules. Rules set by modules have a less urgent priority of 10.
+* Modules can set activity control rules, e.g. [usersync](/dev-docs/publisher-api-reference/setConfig.html#setConfig-Configure-User-Syncing), [bidderSettings](/dev-docs/publisher-api-reference/bidderSettings.html), the [GPP](/dev-docs/modules/consentManagementGpp.html) or [GDPR](/dev-docs/modules/tcfControl.html) modules. Rules set by modules have a less urgent priority of 10.
 
 When rules are processed, they are sorted by priority, and all rules of the same priority are considered to happen at the same time. The details:
 
@@ -234,7 +234,7 @@ If `allow` is not defined, the rule is assumed to assert **true** (i.e. allow th
 
 #### Always include a particular bidder in auctions
 
-This is similiar to the 'vendor exception' feature of the [GDPR Enforcement Module](/dev-docs/modules/gdprEnforcement.html). This would always allow bidderA to participate in the auction, even without explicit consent in GDPR scenarios. It might indicate, for instance, that this is a 'first party bidder'.
+This is similiar to the 'vendor exception' feature of the [TCF Control Module](/dev-docs/modules/tcfControl.html). This would always allow bidderA to participate in the auction, even without explicit consent in GDPR scenarios. It might indicate, for instance, that this is a 'first party bidder'.
 
 ```javascript
 pbjs.setConfig({

--- a/dev-docs/add-rtd-submodule.md
+++ b/dev-docs/add-rtd-submodule.md
@@ -123,7 +123,7 @@ submodule('realTimeData', subModuleObject);
 
 Several of the interfaces get a `userConsent` object. It's an object that carries these attributes:
 
-* [gdpr](/dev-docs/modules/consentManagement.html#bidder-adapter-gdpr-integration) - GDPR
+* [gdpr](/dev-docs/modules/consentManagementTcf.html#bidder-adapter-gdpr-integration) - GDPR
 * [usp](/dev-docs/modules/consentManagementUsp.html#bidder-adapter-us-privacy-integration) - US Privacy (aka CCPA)
 * [coppa](/dev-docs/publisher-api-reference/setConfig.html#setConfig-coppa) - the Child Online Privacy Protection Act
 

--- a/dev-docs/analytics/sharethrough.md
+++ b/dev-docs/analytics/sharethrough.md
@@ -36,7 +36,7 @@ gulp bundle --modules=gptPreAuction,sharethroughBidAdapter,sharethroughAnalytics
 Please note that the above snippet is a "bare bones" example - you will likely want to include other modules as well. A more realistic example might look something like the example below (with other bid adapters also included in the list as needed):
 
 ```sh
-gulp bundle --modules=gptPreAuction,consentManagement,consentManagementGpp,consentManagementUsp,enrichmentFpdModule,gdprEnforcement,sharethroughBidAdapter,sharethroughAnalyticsAdapter
+gulp bundle --modules=gptPreAuction,consentManagementTcf,consentManagementGpp,consentManagementUsp,enrichmentFpdModule,gdprEnforcement,sharethroughBidAdapter,sharethroughAnalyticsAdapter
 ```
 
 Enable the Sharethrough Analytics Adapter in Prebid.js using the analytics provider `sharethrough` as seen in the **Example Configuration** section.

--- a/dev-docs/analytics/sharethrough.md
+++ b/dev-docs/analytics/sharethrough.md
@@ -36,7 +36,7 @@ gulp bundle --modules=gptPreAuction,sharethroughBidAdapter,sharethroughAnalytics
 Please note that the above snippet is a "bare bones" example - you will likely want to include other modules as well. A more realistic example might look something like the example below (with other bid adapters also included in the list as needed):
 
 ```sh
-gulp bundle --modules=gptPreAuction,consentManagementTcf,consentManagementGpp,consentManagementUsp,enrichmentFpdModule,gdprEnforcement,sharethroughBidAdapter,sharethroughAnalyticsAdapter
+gulp bundle --modules=gptPreAuction,consentManagementTcf,consentManagementGpp,consentManagementUsp,enrichmentFpdModule,tcfControl,sharethroughBidAdapter,sharethroughAnalyticsAdapter
 ```
 
 Enable the Sharethrough Analytics Adapter in Prebid.js using the analytics provider `sharethrough` as seen in the **Example Configuration** section.

--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -352,7 +352,7 @@ Notes on parameters in the bidderRequest object:
 Some of the data in `ortb2` is also made available through other `bidderRequest` fields:
 
 * **refererInfo** is provided so you don't have to call any utils functions. See below for more information.
-* **gdprConsent** is the object containing data from the [GDPR ConsentManagement](/dev-docs/modules/consentManagement.html) module. For TCF2+, it will contain both the tcfString and the addtlConsent string if the CMP sets the latter as part of the TCData object.
+* **gdprConsent** is the object containing data from the [TCF ConsentManagement](/dev-docs/modules/consentManagementTcf.html) module. For TCF2+, it will contain both the tcfString and the addtlConsent string if the CMP sets the latter as part of the TCData object.
 * **uspConsent** is the object containing data from the [US Privacy ConsentManagement](/dev-docs/modules/consentManagementUsp.html) module.
 
 <a id="tid-warning"></a>

--- a/dev-docs/bidders/aidem.md
+++ b/dev-docs/bidders/aidem.md
@@ -70,7 +70,7 @@ This module is GDPR and CCPA compliant, and no 3rd party userIds are allowed.
 {: .table .table-bordered .table-striped }
 | Name   | Scope    | Description                                                                                      | Example | Type     |
 |--------|----------|--------------------------------------------------------------------------------------------------|---------|----------|
-| `gdpr` | optional | GDPR Object see [Prebid.js doc](https://docs.prebid.org/dev-docs/modules/consentManagement.html) | `{}`    | `Object` |
+| `gdpr` | optional | GDPR Object see [Prebid.js doc](https://docs.prebid.org/dev-docs/modules/consentManagementTcf.html) | `{}`    | `Object` |
 | `usp`  | optional | USP Object see [Prebid.js doc](https://docs.prebid.org/dev-docs/modules/consentManagementUsp.html)                                                                     | `{}`    | `Object` |
 
 #### Example Banner ad unit

--- a/dev-docs/bidders/aidem.md
+++ b/dev-docs/bidders/aidem.md
@@ -212,7 +212,7 @@ For video: gulp serve --modules=aidemBidAdapter,dfpAdServerVideo
 
 ## FAQs
 
-#### How do I view AIDEM bid request?
+### How do I view AIDEM bid request?
 
 Navigate to a page where AIDEM is setup to bid. In the network tab,
 search for requests to `zero.aidemsrv.com/bid/request`.

--- a/dev-docs/bidders/mediakeys.md
+++ b/dev-docs/bidders/mediakeys.md
@@ -166,7 +166,7 @@ Mediakeys fully supports the following [Prebid.js Modules](https://docs.prebid.o
 {: .table .table-bordered .table-striped }
 | Module                                                                                                | Scope                       |
 |-------------------------------------------------------------------------------------------------------|-----------------------------|
-| [Consent Management - GDPR](https://docs.prebid.org/dev-docs/modules/consentManagement.html)          | Required in Europe          |
+| [Consent Management - GDPR](https://docs.prebid.org/dev-docs/modules/consentManagementTcf.html)          | Required in Europe          |
 | [Consent Management - US Privacy](https://docs.prebid.org/dev-docs/modules/consentManagementUsp.html) | Required in US - California |
 | [Supply Chain Object](https://docs.prebid.org/dev-docs/modules/schain.html)                           | Required for all traffic    |
 | [Instream Tracking](https://docs.prebid.org/dev-docs/modules/instreamTracking.html)                   | Required for Instream Video |

--- a/dev-docs/cmp-best-practices.md
+++ b/dev-docs/cmp-best-practices.md
@@ -23,7 +23,7 @@ flavored CMPs for that.
 
 Instead, here are some general guidelines:
 
-- You can't just automatically turn on the GDPR Enforcement Module when not in GDPR scope.
+- You can't just automatically turn on the TCF Control Module when not in GDPR scope.
 - You need to understand how your CMP works, how you want to handle the "first page" scenario where the user hasn't yet had time to answer CMP questions, and how your site is laid out geographically.
 - We recommend that the page first load a CMP stub synchronously, then asynchronously load the CMP code and the Prebid code
 
@@ -52,7 +52,7 @@ Here are some approaches where PBJS config can be the same across all geos:
 
 In these approaches, the publisher has to be aware of the geo and tell Prebid.js what to do:
 
-- When in the EEA, the page sets `consentManagement` config, but when not in the EEA, the page avoids setting the `consentManagement` config, turning off GDPR enforcement.
+- When in the EEA, the page sets `consentManagement` config, but when not in the EEA, the page avoids setting the `consentManagement` config, turning off TCF controls.
 - When not in the EEA, the page sets `consentManagement` config with defaultGdprScope=false so that if the CMP is slow to respond then enforcement is off.
 
 ## CMP Best Practices
@@ -76,4 +76,4 @@ Please follow the guidelines in the [Sirdata documentation](https://cmp.docs.sir
 ## Further Reading
 
 - [IAB TCF Implementation Guidelines](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/TCF-Implementation-Guidelines.md)
-- [GDPR Enforcement Module](/dev-docs/modules/gdprEnforcement.html)
+- [TCF Control Module](/dev-docs/modules/tcfControl.html)

--- a/dev-docs/cmp-best-practices.md
+++ b/dev-docs/cmp-best-practices.md
@@ -31,7 +31,7 @@ Instead, here are some general guidelines:
 
 ### CMP/TCF gdprApplies
 
-The indicates the determination of whether GDPR applies in this context. The CMP, in most cases, is responsible for this. The publisher provides this value when supplying [static](/dev-docs/modules/consentManagement.html) consent data.
+The indicates the determination of whether GDPR applies in this context. The CMP, in most cases, is responsible for this. The publisher provides this value when supplying [static](/dev-docs/modules/consentManagementTcf.html) consent data.
 
 ### Prebid gdpr.defaultGdprScope
 

--- a/dev-docs/faq.md
+++ b/dev-docs/faq.md
@@ -62,7 +62,7 @@ After you’ve determined your legal obligations, consider the tools Prebid make
 * [Disable User ID modules](/dev-docs/modules/userId.html) - there are controls for different ID modules and which bidders can get which IDs.
 * [Disable device access](/dev-docs/publisher-api-reference/setConfig.html#setConfig-deviceAccess) - no adapter or module will be able to create a cookie or HTML5 localstorage object.
 * For GDPR:
-  * Consider the [GDPR](/dev-docs/modules/consentManagement.html) and [GDPR Enforcement](/dev-docs/modules/gdprEnforcement.html) modules, which flexibly support various actions like cancelling usersyncs, auctions, and analytics. Using these modules, bid adapters can receive the IAB TCF string from the CMP.
+  * Consider the [GDPR](/dev-docs/modules/consentManagementTcf.html) and [GDPR Enforcement](/dev-docs/modules/gdprEnforcement.html) modules, which flexibly support various actions like cancelling usersyncs, auctions, and analytics. Using these modules, bid adapters can receive the IAB TCF string from the CMP.
   * Note that TCF 2.2 is functionally the same as TCF 2.0 from the Prebid.js perspective. The code has always relied on event listeners to get the TCF string, so when `getTCData` was deprecated in 2.2 the modules were unaffected. There are still references in the code only because it is still accepted as a place for statically-supplied data.
   * Alternatively, the page can just avoid turning on certain bidders or modules.
 * For CCPA / CPRA / US-Privacy:

--- a/dev-docs/faq.md
+++ b/dev-docs/faq.md
@@ -62,7 +62,7 @@ After you’ve determined your legal obligations, consider the tools Prebid make
 * [Disable User ID modules](/dev-docs/modules/userId.html) - there are controls for different ID modules and which bidders can get which IDs.
 * [Disable device access](/dev-docs/publisher-api-reference/setConfig.html#setConfig-deviceAccess) - no adapter or module will be able to create a cookie or HTML5 localstorage object.
 * For GDPR:
-  * Consider the [GDPR](/dev-docs/modules/consentManagementTcf.html) and [GDPR Enforcement](/dev-docs/modules/gdprEnforcement.html) modules, which flexibly support various actions like cancelling usersyncs, auctions, and analytics. Using these modules, bid adapters can receive the IAB TCF string from the CMP.
+  * Consider the [TCF](/dev-docs/modules/consentManagementTcf.html) and [TCF Control](/dev-docs/modules/tcfControl.html) modules, which flexibly support various actions like cancelling usersyncs, auctions, and analytics. Using these modules, bid adapters can receive the IAB TCF string from the CMP.
   * Note that TCF 2.2 is functionally the same as TCF 2.0 from the Prebid.js perspective. The code has always relied on event listeners to get the TCF string, so when `getTCData` was deprecated in 2.2 the modules were unaffected. There are still references in the code only because it is still accepted as a place for statically-supplied data.
   * Alternatively, the page can just avoid turning on certain bidders or modules.
 * For CCPA / CPRA / US-Privacy:
@@ -84,7 +84,7 @@ This option to the ConsentManagement module was removed a long time ago in PBJS 
 * It was a poorly named flag. What it did was let the auction happen on the first page before the user had responded to the CMP.
 * It was replaced by a combination of the "defaultGdprScope" flag and the ability for a publisher to disable enforcement of the `basicAds` TCF purpose.
 
-See the [GDPR Enforcement Module](/dev-docs/modules/gdprEnforcement.html) documentation for more details.
+See the [TCF Control Module](/dev-docs/modules/tcfControl.html) documentation for more details.
 
 ## Implementation
 

--- a/dev-docs/integrate-with-the-prebid-analytics-api.md
+++ b/dev-docs/integrate-with-the-prebid-analytics-api.md
@@ -86,7 +86,7 @@ Analytics adapter for Example.com. Contact prebid@example.com for information.
 adapter needs to specify an enableAnalytics() function, but it should also call
 the base class function to set up the events.
 
-5. Doing analytics may require user permissions under [GDPR](/dev-docs/modules/consentManagement.html), which means your adapter will need to be linked to your [IAB Global Vendor List](https://iabeurope.eu/vendor-list-tcf/) ID. If no GVL ID is found, and Purpose 7 (Measurement) is enforced, your analytics adapter will be blocked unless it is specifically listed under vendorExceptions. Your GVL ID can be added to the `registerAnalyticsAdapter()` call.
+5. Doing analytics may require user permissions under [GDPR](/dev-docs/modules/consentManagementTcf.html), which means your adapter will need to be linked to your [IAB Global Vendor List](https://iabeurope.eu/vendor-list-tcf/) ID. If no GVL ID is found, and Purpose 7 (Measurement) is enforced, your analytics adapter will be blocked unless it is specifically listed under vendorExceptions. Your GVL ID can be added to the `registerAnalyticsAdapter()` call.
 
 #### Basic prototype analytics adapter
 

--- a/dev-docs/modules/azerionedgeRtdProvider.md
+++ b/dev-docs/modules/azerionedgeRtdProvider.md
@@ -74,7 +74,7 @@ received from the user, this module does not require a TCF vendor configuration.
 provided to the module when the user gives the relevant permissions on the publisher website.
 
 As Prebid.js utilizes TCF vendor consent for the RTD module to load, the module needs to be labeled
-within the Vendor Exceptions. If the Prebid GDPR enforcement is enabled, the module should be configured
+within the Vendor Exceptions. If the Prebid TCF Controls are enabled, the module should be configured
 as exception, as shown below:
 
 ```js

--- a/dev-docs/modules/consentManagementGpp.md
+++ b/dev-docs/modules/consentManagementGpp.md
@@ -200,7 +200,7 @@ var idx_gdpr=0;
 
 - [IAB Global Privacy Platform Full Specification Repository](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform)
 - [IAB Global Privacy Platform CMP API Specification](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md)
-- [Prebid Consent Management - GDPR Module](/dev-docs/modules/consentManagement.html)
+- [Prebid Consent Management - GDPR Module](/dev-docs/modules/consentManagementTcf.html)
 - [Prebid Consent Management - US Privacy Module](/dev-docs/modules/consentManagementUsp.html)
 - [Prebid Activity Controls](/dev-docs/activity-controls.html)
 - [Prebid Activity Controls -- GPP control module - usnat](/dev-docs/modules/gppControl_usnat.html)

--- a/dev-docs/modules/consentManagementTcf.md
+++ b/dev-docs/modules/consentManagementTcf.md
@@ -1,16 +1,16 @@
 ---
 layout: page_v2
 page_type: module
-title: Consent Management - GDPR
-description: If you have users in Europe, this module works with your Consent Management Platform to pass consent info to bidders and help align with EU regulations. See also the GDPR Enforcement module.
-module_code : consentManagement
-display_name : Consent Management - GDPR
+title: Consent Management - TCF
+description: If you have users in Europe, this module works with your Consent Management Platform to pass consent info to bidders and help align with EU regulations. See also the TCF Control module.
+display_name : Consent Management - TCF
+module_code : consentManagementTcf
 enable_download : true
 recommended: true
 sidebarType : 1
 ---
 
-# GDPR Consent Management Module
+# TCF Consent Management Module
 {: .no_toc }
 
 - TOC
@@ -28,12 +28,12 @@ This module works with supported [Consent Management Platforms](https://www.cmsw
 Prebid functionality created to address regulatory requirements does not replace each party's responsibility to determine its own legal obligations and comply with all applicable laws.
 **We recommend consulting with your legal counsel before determining how to utilize these features in support of your overall privacy approach.**
 
-This base EU GDPR consent management module performs these actions:
+This base EU TCF consent management module performs these actions:
 
 1. Fetch the user's GDPR & Google additional consent data from the CMP.
 2. Incorporate this data into the auction objects for adapters to collect.
 
-The optional [GDPR enforcement module](/dev-docs/modules/gdprEnforcement.html) adds on these actions:
+The optional [TCF control module](/dev-docs/modules/tcfControl.html) adds on these actions:
 
 1. Allows the page to define which activities should be enforced at the Prebid.js level.
 2. Actively enforces those activities based on user consent data (in the TCF string, not the AC string).
@@ -71,16 +71,16 @@ but we recommend migrating to the new config structure as soon as possible.
 | gdpr.actionTimeout | `integer` | Length of time (in milliseconds) to allow the user to take action to consent if they have not already done so. The actionTimer first waits for the CMP to load, then the actionTimeout begins for the specified duration. Default is `undefined`. | `10000` |
 | gdpr.defaultGdprScope | `boolean` | Defines what the `gdprApplies` flag should be when the CMP doesn't respond in time or the static data doesn't supply. Defaults to `false`. | `true` |
 | gdpr.consentData | `Object` | An object representing the GDPR consent data being passed directly; only used when cmpApi is 'static'. Default is `undefined`. | |
-| gdpr.consentData.getTCData.tcString | `string` | Base64url-encoded TCF v2.x string with segments. | |
-| gdpr.consentData.getTCData.addtlConsent | `string` | Additional consent string if available from the cmp TCData object | |
-| gdpr.consentData.getTCData.gdprApplies | `boolean` | Defines whether or not this pageview is in GDPR scope. | |
-| gdpr.consentData.getTCData.purpose.consents | `Object` | An object representing the user's consent status for specific purpose IDs. | |
-| gdpr.consentData.getTCData.purpose.legitimateInterests | `Object` | An object representing the user's legitimate interest status for specific purpose IDs. | |
-| gdpr.consentData.getTCData.vendor.consents | `Object` | An object representing the user's consent status for specific vendor IDs. | |
-| gdpr.consentData.getTCData.vendor.legitimateInterests | `Object` | An object representing the user's legitimate interest status for specific vendors IDs. | |
+| gdpr.consentData.tcString | `string` | Base64url-encoded TCF v2.x string with segments. | |
+| gdpr.consentData.addtlConsent | `string` | Additional consent string if available from the cmp TCData object | |
+| gdpr.consentData.gdprApplies | `boolean` | Defines whether or not this pageview is in GDPR scope. | |
+| gdpr.consentData.purpose.consents | `Object` | An object representing the user's consent status for specific purpose IDs. | |
+| gdpr.consentData.purpose.legitimateInterests | `Object` | An object representing the user's legitimate interest status for specific purpose IDs. | |
+| gdpr.consentData.vendor.consents | `Object` | An object representing the user's consent status for specific vendor IDs. | |
+| gdpr.consentData.vendor.legitimateInterests | `Object` | An object representing the user's legitimate interest status for specific vendors IDs. | |
 
 {: .alert.alert-info :}
-NOTE: The `purpose` and `vendor` objects are required if you are using the `gdprEnforcement` module.  If the data is not included, your bid adapters, analytics adapters, and/or userId systems will likely be excluded from the auction as Prebid will assume the user has not given consent for these entities.
+NOTE: The `purpose` and `vendor` objects are required if you are using the `tcfControl` module.  If the data is not included, your bid adapters, analytics adapters, and/or userId systems will likely be excluded from the auction as Prebid will assume the user has not given consent for these entities.
 
 A related parameter is `deviceAccess`, which is at the global level of Prebid.js configuration because it can be used GDPR, CCPA, or custom privacy implementations:
 
@@ -369,7 +369,7 @@ This should be false if there was some error in the consent data; otherwise set 
 
 ## Further Reading
 
-- [GDPR Enforcement Module](/dev-docs/modules/gdprEnforcement.html)
+- [TCF Control Module](/dev-docs/modules/tcfControl.html)
 - [IAB TCF Implementation Guide](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/TCF-Implementation-Guidelines.md)
 - [IAB Transparancy and Consent Framework Policies](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/)
 - [Prebid Consent Management - US Privacy Module](/dev-docs/modules/consentManagementUsp.html)

--- a/dev-docs/modules/consentManagementTcf.md
+++ b/dev-docs/modules/consentManagementTcf.md
@@ -210,7 +210,7 @@ Here is a sample of how the data is structured in the `bidderRequest` object:
 
 **_consentString_**
 
-This field contains the user's choices on consent, represented as an encoded string value.  In certain scenarios, this field might come to you with an `undefined` value; normally this happens when there was an error (or timeout) during the CMP interaction and the publisher turned off GDPR enforcement.  If you don't want to pass `undefined` to your system, you can check for this value and replace it with a valid consent string.  See the _consent_required_ code in the example below (under "gdprApplies") for a possible approach to checking and replacing values.
+This field contains the user's choices on consent, represented as an encoded string value.  In certain scenarios, this field might come to you with an `undefined` value; normally this happens when there was an error (or timeout) during the CMP interaction and the publisher turned off TCF controls.  If you don't want to pass `undefined` to your system, you can check for this value and replace it with a valid consent string.  See the _consent_required_ code in the example below (under "gdprApplies") for a possible approach to checking and replacing values.
 
 **_addtlConsent_**
 

--- a/dev-docs/modules/consentManagementUsp.md
+++ b/dev-docs/modules/consentManagementUsp.md
@@ -25,7 +25,7 @@ This consent management module is designed to support the California Consumer Pr
 This module works with an IAB-compatible US Privacy API (USP-API) to fetch an encoded string representing the user's notice and opt-out choices and make it available for adapters to consume and process. In Prebid 7+; the module defaults to working with an IAB-compatible US Privacy API; in prior versions, the module had to be configured to be in effect.
 
 {: .alert.alert-info :}
-See also the [Prebid Consent Management - GDPR Module](/dev-docs/modules/consentManagement.html) for supporting the EU General Data Protection Regulation (GDPR)
+See also the [Prebid Consent Management - GDPR Module](/dev-docs/modules/consentManagementTcf.html) for supporting the EU General Data Protection Regulation (GDPR)
 
 Here's a summary of the interaction process:
 

--- a/dev-docs/modules/gdprEnforcement.md
+++ b/dev-docs/modules/gdprEnforcement.md
@@ -19,12 +19,12 @@ sidebarType : 1
 {% include legal-warning.html %}
 
 {: .alert.alert-warning :}
-This module requires the [EU GDPR consent management module](/dev-docs/modules/consentManagement.html) (the base consent module), which reads consent values from the Consent Management Platform (CMP). The GDPR Enforcement Module
-will then take action based on the results. See the [base module page](/dev-docs/modules/consentManagement.html) for general background, usage, and legal disclaimers.
+This module requires the [EU GDPR consent management module](/dev-docs/modules/consentManagementTcf.html) (the base consent module), which reads consent values from the Consent Management Platform (CMP). The GDPR Enforcement Module
+will then take action based on the results. See the [base module page](/dev-docs/modules/consentManagementTcf.html) for general background, usage, and legal disclaimers.
 
 ## Overview
 
-The [base consent module](/dev-docs/modules/consentManagement.html) performs the following actions:
+The [base consent module](/dev-docs/modules/consentManagementTcf.html) performs the following actions:
 
 1. Fetches the user's GDPR consent data from the CMP.
 2. Incorporates this data into the auction objects for adapters to collect.
@@ -61,7 +61,7 @@ To turn on Prebid.js enforcement you must:
 (1) Include the gdprEnforcement module in the Prebid.js build
 and (2) setConfig `consentManagement.gdpr.cmpApi` to either 'iab' or 'static'
 
-The following fields related to GDPR enforcement are supported in the [`consentManagement`](/dev-docs/modules/consentManagement.html) object:
+The following fields related to GDPR enforcement are supported in the [`consentManagement`](/dev-docs/modules/consentManagementTcf.html) object:
 
 {: .table .table-bordered .table-striped }
 | Param | Type | Description | Example |
@@ -235,7 +235,7 @@ You can also use the [Prebid.js Download](/download.html) page.
 
 ## Further Reading
 
-* [EU GDPR Consent Management Module](/dev-docs/modules/consentManagement.html)
+* [EU GDPR Consent Management Module](/dev-docs/modules/consentManagementTcf.html)
 * [IAB TCF Implementation Guidelines](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/TCF-Implementation-Guidelines.md)
 * [IAB TCF2 Consent String Format](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md)
 * [Prebid TCF2 Support](https://docs.google.com/document/d/1fBRaodKifv1pYsWY3ia-9K96VHUjd8kKvxZlOsozm8E/edit#)

--- a/dev-docs/modules/genericAnalyticsAdapter.md
+++ b/dev-docs/modules/genericAnalyticsAdapter.md
@@ -28,9 +28,9 @@ This is an analytics adapter that can interface with any backend, meant for publ
 
 <a id="gdpr"></a>
 
-### Note on GDPR enforcement
+### Note on TCF controls
 
-If you are using the [GDPR enforcement module](/dev-docs/modules/gdprEnforcement.html) to enforce purpose 7, by default this module will be blocked when GDPR is in scope.
+If you are using the [TCF control module](/dev-docs/modules/tcfControl.html) to enforce purpose 7, by default this module will be blocked when GDPR is in scope.
 To enable it, you may either specify the `gvlid` option (if you are interfacing with a partner) or declare a `softVendorException` if you deem that vendor consent is not required for compliance:
 
 ```javascript

--- a/dev-docs/modules/permutiveRtdProvider.md
+++ b/dev-docs/modules/permutiveRtdProvider.md
@@ -73,7 +73,7 @@ as well as enabling settings for specific use cases mentioned above (e.g. acbidd
 
 Permutive is not listed as a TCF vendor as all data collection is on behalf of the publisher and based on consent the publisher has received from the user.
 Rather than through the TCF framework, this consent is provided to Permutive when the user gives the relevant permissions on the publisher website which allow the Permutive SDK to run.
-This means that if GDPR enforcement is configured _and_ the user consent isn’t given for Permutive to fire, no cohorts will populate.
+This means that if TCF controls are enabled _and_ the user consent isn’t given for Permutive to fire, no cohorts will populate.
 As Prebid utilizes TCF vendor consent, for the Permutive RTD module to load, Permutive needs to be labeled within the Vendor Exceptions
 
 ### Instructions

--- a/dev-docs/modules/tcfControl.md
+++ b/dev-docs/modules/tcfControl.md
@@ -1,10 +1,10 @@
 ---
 layout: page_v2
 page_type: module
-title: GDPR Enforcement Module
+title: TCF Control Module
 description: If you have users in Europe, you can use this module to enable actions for processing under the GDPR and ePrivacy
-module_code : gdprEnforcement
-display_name : GDPR Enforcement
+module_code : tcfControl
+display_name : TCF Control
 enable_download : true
 recommended: true
 sidebarType : 1
@@ -19,7 +19,7 @@ sidebarType : 1
 {% include legal-warning.html %}
 
 {: .alert.alert-warning :}
-This module requires the [EU GDPR consent management module](/dev-docs/modules/consentManagementTcf.html) (the base consent module), which reads consent values from the Consent Management Platform (CMP). The GDPR Enforcement Module
+This module requires the [TCF consent management module](/dev-docs/modules/consentManagementTcf.html) (the base consent module), which reads consent values from the Consent Management Platform (CMP). The TCF Control Module
 will then take action based on the results. See the [base module page](/dev-docs/modules/consentManagementTcf.html) for general background, usage, and legal disclaimers.
 
 ## Overview
@@ -29,7 +29,7 @@ The [base consent module](/dev-docs/modules/consentManagementTcf.html) performs 
 1. Fetches the user's GDPR consent data from the CMP.
 2. Incorporates this data into the auction objects for adapters to collect.
 
-The GDPR Enforcement Module adds the following:
+The TCF Control Module adds the following:
 
 1. Allows the page to define which activities should be enforced at the Prebid.js level.
 2. Actively enforces those activities based on user consent data.
@@ -58,7 +58,7 @@ A page needs to define configuration rules about how Prebid.js should enforce ea
 {: .alert.alert-info :}
 To turn on Prebid.js enforcement you must:
 
-(1) Include the gdprEnforcement module in the Prebid.js build
+(1) Include the tcfControl module in the Prebid.js build
 and (2) setConfig `consentManagement.gdpr.cmpApi` to either 'iab' or 'static'
 
 The following fields related to GDPR enforcement are supported in the [`consentManagement`](/dev-docs/modules/consentManagementTcf.html) object:
@@ -228,7 +228,7 @@ This behavior can be changed to the same "basic enforcement" algorithm described
 Follow the basic build instructions in the GitHub Prebid.js repo's main [README](https://github.com/prebid/Prebid.js/blob/master/README.md). Include the base consent management module and this enforcement module as additional options on the **gulp build** command:
 
 ```bash
-gulp build --modules=consentManagement,gdprEnforcement,bidAdapter1,bidAdapter2
+gulp build --modules=consentManagement,tcfControl,bidAdapter1,bidAdapter2
 ```
 
 You can also use the [Prebid.js Download](/download.html) page.

--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -39,7 +39,7 @@ Not all bidder adapters support all forms of user ID. See the tables below for a
 
 ## User ID, GDPR, Permissions, and Opt-Out
 
-When paired with the [Consent Management](/dev-docs/modules/consentManagement.html) module, privacy rules are enforced:
+When paired with the [Consent Management](/dev-docs/modules/consentManagementTcf.html) module, privacy rules are enforced:
 
 * The module checks the GDPR consent string
 * If no consent string is available OR if the user has not consented to Purpose 1 (local storage):
@@ -411,4 +411,4 @@ This will have no effect until you call the `registerSignalSources` API. This me
 ## Further Reading
 
 * [Prebid.js Usersync](/dev-docs/publisher-api-reference/setConfig.html#setConfig-Configure-User-Syncing)
-* [GDPR ConsentManagement Module](/dev-docs/modules/consentManagement.html)
+* [TCF ConsentManagement Module](/dev-docs/modules/consentManagementTcf.html)

--- a/dev-docs/publisher-api-reference/aliasBidder.md
+++ b/dev-docs/publisher-api-reference/aliasBidder.md
@@ -27,7 +27,7 @@ The options object supports these parameters:
 {: .table .table-bordered .table-striped }
 | Option Parameter    | Type    | Description             |
 |------------|---------|---------------------------------|
-| gvlid | integer | IAB Global Vendor List ID for this alias for use with the [GDPR Enforcement module](/dev-docs/modules/gdprEnforcement.html). |
+| gvlid | integer | IAB Global Vendor List ID for this alias for use with the [TCF control module](/dev-docs/modules/tcfControl.html). |
 
 {: .alert.alert-info :}
 Creating an alias for a Prebid Server adapter is done differently. See 'extPrebid'

--- a/dev-docs/publisher-api-reference/setConfig.md
+++ b/dev-docs/publisher-api-reference/setConfig.md
@@ -48,7 +48,7 @@ Core config:
 Module config: other options to `setConfig()` are available if the relevant module is included in the Prebid.js build.
 
 * [Currency module](/dev-docs/modules/currency.html)
-* [Consent Management](/dev-docs/modules/consentManagement.html#page-integration)
+* [Consent Management](/dev-docs/modules/consentManagementTcf.html#page-integration)
 * [User ID module](/dev-docs/modules/userId.html#configuration)
 * [Adpod](/dev-docs/modules/adpod.html)
 * [IAB Category Translation](/dev-docs/modules/categoryTranslation.html)

--- a/features/firstPartyData.md
+++ b/features/firstPartyData.md
@@ -188,7 +188,7 @@ pbjs.setConfig({
 
 {: .alert.alert-warning :}
 Note that supplying first party **user** data may require special
-consent in certain regions. By default, Prebid's [gdprEnforcement](/dev-docs/modules/gdprEnforcement.html) module does **not** police the passing
+consent in certain regions. By default, Prebid's [tcfControl](/dev-docs/modules/tcfControl.html) module does **not** police the passing
 of user data, but can optionally do so if the `personalizedAds` rule is enabled.
 
 {: .alert.alert-warning :}

--- a/identity/sharedid.md
+++ b/identity/sharedid.md
@@ -217,7 +217,7 @@ Below are the available configuration options for the PubCID script.
 | create | boolean | If true, then an id is created automatically by the script if it's missing. Default is true. If your server has a component that generates the id instead, then this should be set to false | | `true` |
 | expInterval | decimal | Expiration interval in minutes. Default is 525600, or 1 year | | `525600` |
 | extend | boolean | If true, the the expiration time is automatically extended whenever the script is executed even if the id exists already. Default is true. If false, then the id expires from the time it was initially created. | For publisher server support only. If true, the publisher's server will create the (pubcid) cookie. Default is true. | `true` |
-| pixelUrl | string (optional) | For publisher server support only. Where to call out to for a server cookie. | | `/wp-json/pubcid/v1/extend/`
+| pixelUrl | string (optional) | For publisher server support only. Where to call out to for a server cookie. | | `/wp-json/pubcid/v1/extend/` |
 | type | string | Type of storage. It's possible to specify one of the following: 'html5', 'cookie'. Default is 'html5' priority, aka local storage, and fall back to cookie if local storage is unavailable. | If true, the expiration time of the stored IDs will be refreshed during each page load. Default is false. | `cookie` |
 
 #### Example Configurations

--- a/identity/sharedid.md
+++ b/identity/sharedid.md
@@ -157,7 +157,7 @@ You can find available configuration options for the SharedID module [here](http
 There are several privacy scenarios in which a user ID is not created or read:
 
 1. The User ID module suppresses all cookie reading and setting activity
-   when the [GDPR Enforcement Module](/dev-docs/modules/gdprEnforcement.html) is in place and there's no consent for Purpose 1.
+   when the [TCF Control Module](/dev-docs/modules/tcfControl.html) is in place and there's no consent for Purpose 1.
 2. The User ID module infrastructure supports a first-party opt-out, by setting the `_pbjs_id_optout` cookie or local storage to any value. No other cookies will be set if this one is set.
 3. The SharedId module will suppress the ID when the COPPA flag is set.
 

--- a/prebid/prebidjs.md
+++ b/prebid/prebidjs.md
@@ -66,7 +66,7 @@ Analytics adapters offer the ability to learn more about latency, revenues, bid 
 Prebid.js Modules also plug into the Prebid.js Core. They add functionality not present
 in the Core that not every publisher needs. Example modules:
 
-- GDPR support (the [consentManagement]({{site.baseurl}}/dev-docs/modules/consentManagement.html) module)
+- GDPR support (the [consentManagementTcf]({{site.baseurl}}/dev-docs/modules/consentManagementTcf.html) module)
 - Currency conversion (the [currency]({{site.baseurl}}/dev-docs/modules/currency.html) module)
 - Server-to-server testing (the [s2sTest]({{site.baseurl}}/dev-docs/modules/s2sTesting.html) module)
 - and [many others](/dev-docs/modules/index.html)

--- a/prebid/prebidjsReleases.md
+++ b/prebid/prebidjsReleases.md
@@ -66,7 +66,7 @@ The table below is a summary of feature changes and important bug fixes in core 
 | 3.17 | UserID module also exports IDs as eids |
 | 3.16 | isSafariBrowser fixed for Chrome and Firefox on iOS |
 | 3.15 | Advanced Size Mapping module support adunits of the same name |
-| 3.14 | New [GDPR enforcement module](/dev-docs/modules/gdprEnforcement.html) supports enforcing Purpose 1 - DeviceAccess |
+| 3.14 | New [GDPR enforcement module](/dev-docs/modules/tcfControl.html) supports enforcing Purpose 1 - DeviceAccess |
 | 3.13 | GDPR module supports defaultGdprScope option |
 | 3.12 | Initial support for TCF2 - reading and passing consent strings, added [DeviceAccess](/dev-docs/publisher-api-reference/setConfig.html#setConfig-deviceAccess) configuration setting |
 | 3.11 | [Advanced Size Mapping module](/dev-docs/modules/sizeMappingV2.html) |

--- a/prebid/prebidjsReleases.md
+++ b/prebid/prebidjsReleases.md
@@ -95,7 +95,7 @@ The table below is a summary of feature changes and important bug fixes in core 
 | 2.10 | [User ID module](/dev-docs/modules/userId.html) released with support for PubCommon ID and Unified ID |
 | 2.10 | A bidder which responded in time is now considered a timely bidder, even if it responded with no bids. See [PR 3696](https://github.com/prebid/Prebid.js/pull/3696) |
 | 2.9 | Add 'hb_cache_host' targeting for video bids when cache is set to support upcoming video cache redirector |
-| 2.9 | remove removeRequestId logic. See [PR 3698](https://github.com/prebid/Prebid.js/pull/3698)
+| 2.9 | remove removeRequestId logic. See [PR 3698](https://github.com/prebid/Prebid.js/pull/3698) |
 | 2.8 | Added [s2sConfig](/dev-docs/publisher-api-reference/setConfig.html#setConfig-Server-to-Server) `syncUrlModifier` option to modify userSync URLs |
 | 2.8 | Add hb_uuid and hb_cache_id back to dfp module after having been removed in 2.7 |
 | 2.6 | Update auction algorithm logic for long-form. See [PR 3625](https://github.com/prebid/Prebid.js/pull/3625) |

--- a/support/privacy-resources.md
+++ b/support/privacy-resources.md
@@ -42,7 +42,7 @@ The privacy tools that Prebid has built in support of European rules may help ad
 The IAB defined the Transparency and Consent Framework (TCF) to address European GDPR rules. Prebid support for TCF is described:
 
 - [Prebid.js CMP Best Practices](/dev-docs/cmp-best-practices.html)
-- [Prebid.js GDPR Consent Management Module](/dev-docs/modules/consentManagement.html)
+- [Prebid.js GDPR Consent Management Module](/dev-docs/modules/consentManagementTcf.html)
 - [Prebid.js GDPR Enforcement Module](/dev-docs/modules/gdprEnforcement.html)
 - [Prebid Server GDPR Support](/prebid-server/features/pbs-privacy.html#gdpr)
 - [White paper: Prebid Support for Enforcing TCF 2](https://docs.google.com/document/d/1fBRaodKifv1pYsWY3ia-9K96VHUjd8kKvxZlOsozm8E)

--- a/support/privacy-resources.md
+++ b/support/privacy-resources.md
@@ -43,7 +43,7 @@ The IAB defined the Transparency and Consent Framework (TCF) to address European
 
 - [Prebid.js CMP Best Practices](/dev-docs/cmp-best-practices.html)
 - [Prebid.js GDPR Consent Management Module](/dev-docs/modules/consentManagementTcf.html)
-- [Prebid.js GDPR Enforcement Module](/dev-docs/modules/gdprEnforcement.html)
+- [Prebid.js GDPR Enforcement Module](/dev-docs/modules/tcfControl.html)
 - [Prebid Server GDPR Support](/prebid-server/features/pbs-privacy.html#gdpr)
 - [White paper: Prebid Support for Enforcing TCF 2](https://docs.google.com/document/d/1fBRaodKifv1pYsWY3ia-9K96VHUjd8kKvxZlOsozm8E)
 


### PR DESCRIPTION
https://github.com/prebid/Prebid.js/issues/10251:

- rename consentManagement to consentManagementTcf
- rename gdprEnforcement to TCF control
