### PR TITLE
Prebid 9: split dfpAdpod from dfpAdserverVideo

### DIFF
--- a/dev-docs/modules/dfpAdpod.md
+++ b/dev-docs/modules/dfpAdpod.md
@@ -1,0 +1,21 @@
+---
+layout: page_v2
+page_type: module
+title: Module - Google Ad Manager Adpod Support
+description: Required for serving adpod video through Google Ad Manager.
+module_code : dfpAdpod
+display_name : Google Ad Manager Adpod Support
+enable_download : true
+vendor_specific: true
+sidebarType : 1
+---
+
+# Google Ad Manager Adpod Support
+
+{:.no_toc}
+
+This module exposes the [`pbjs.adServers.dfp.buildAdpodVideoUrl](/dev-docs/publisher-api-reference/adServers.dfp.buildAdpodVideoUrl.html) method, required to use [adpod](/dev-docs/modules/adpod.md) with Google Ad Manager.
+
+## Further Reading
+
+- [Show long form video ads with GAM](/dev-docs/show-long-form-video-with-gam.html)

--- a/dev-docs/show-long-form-video-with-gam.md
+++ b/dev-docs/show-long-form-video-with-gam.md
@@ -175,7 +175,7 @@ For instructions on setting custom price buckets, view the [Custom Price Granula
 
 ### 5. Send request for bids and build video URL
 
-The `dfpAdServerVideo` module provides a method, `buildAdpodVideoUrl`, that combines publisher-provided parameters with Prebid.js targeting key values to build a GAM video ad tag URL that can be used by a video player.
+The `dfpAdpod` module provides a method, `buildAdpodVideoUrl`, that combines publisher-provided parameters with Prebid.js targeting key values to build a GAM video ad tag URL that can be used by a video player.
 
 In the example below the callback in the `bidsBackHandler` returns the video ad tag needed by the video player.
 
@@ -196,7 +196,7 @@ pbjs.que.push(function(){
 
     pbjs.requestBids({
         bidsBackHandler: function(bids) {
-            pbjs.adServers.dfp. buildAdpodVideoUrl({
+            pbjs.adServers.dfp.buildAdpodVideoUrl({
                 codes: ['sample-code'],
                 params: {
                     iu: '/123456/testing/prebid.org/adunit1',


### PR DESCRIPTION
https://github.com/prebid/Prebid.js/issues/10552

In prebid 9, the adpod portion of `dfpAdServerVideo` is being split out to a separate module, `dfpAdpod`.

I am not sure how adpod works or how to flesh this out more - there's only one reference to it that I can't get to work.

