### PR TITLE
Update docs for Vox adapter

### DIFF
--- a/dev-docs/bidders/vox.md
+++ b/dev-docs/bidders/vox.md
@@ -77,7 +77,7 @@ var adUnits = [{
     code: 'test-div',
     mediaTypes: {
         banner: {
-            sizes: [0, 0],
+            sizes: [0, 0]
         }
     },
     bids: [{

--- a/dev-docs/bidders/vox.md
+++ b/dev-docs/bidders/vox.md
@@ -6,6 +6,7 @@ schain_supported: true
 floors_supported: true
 userIds: all
 pbjs: true
+pbs: true
 media_types: banner, video
 biddercode: vox
 tcfeu_supported: true
@@ -26,6 +27,7 @@ Please reach out to your partners account team before using this plugin to get p
 | `placementId`       | required               | The place id.                                                     | '5af45ad34d506ee7acad0c26'           | `string` |
 | `placement`         | required               | Adunit placement, possible values: banner, video, inImage         | 'banner'                             | `string` |
 | `imageUrl`          | required for inImage   | URL of the image on which the banner will be displayed            | `'https://example.com/images/image.jpg'` | `string` |
+| `displaySizes`      | optional, only supported by inImage format   | An array of strings. Each string should be in `<Width>x<Height>` format (currently, this parameter is supported only by PrebidServer vox adapter) | `["123x90", "720x100"]` | `string[]` |
 
 ### Sample Banner Ad Unit
 
@@ -54,7 +56,7 @@ var adUnits = [{
     code: 'video_ad_unit',
     mediaTypes: {
         video: {
-            context: 'outstream',      // required, possible values: instream, outstream 
+            context: 'outstream',      // required, possible values: instream, outstream
             playerSize: [[640, 480]]   // required
         }
     },
@@ -75,7 +77,7 @@ var adUnits = [{
     code: 'test-div',
     mediaTypes: {
         banner: {
-            sizes: [0, 0]
+            sizes: [0, 0],
         }
     },
     bids: [{


### PR DESCRIPTION
Good day,

This PR updates docs for Vox adapter.

- add `pbs: true` flag
- add `displaySizes` parameter

### More context information

Some time ago we added a Vox adapter for PrebidServer. ([Link](https://github.com/prebid/prebid-server/pull/2928)), but, i suppose, we forgot to update documentation on this particular repository.

Moreover, we are listed in **Prebid.js** bidders list([Link](https://docs.prebid.org/dev-docs/bidders/vox.html)), but we are not listed in **PrebidServer** bidders([Link](https://docs.prebid.org/dev-docs/pbs-bidders.html)), despite the fact that we added PrebidServer adapter about a year ago. 

As far, as i understand, this happened because we forgot to add `pbs:true` flag to this repository.

## 🏷 Type of documentation
- [X] update bid adapter

## 📋 Checklist
- [X] Related pull requests in prebid.js or server are linked
Pull Request in PrebidServer repository for Vox adapter: [https://github.com/prebid/prebid-server/pull/2928](https://github.com/prebid/prebid-server/pull/2928)