### PR TITLE
JS: remove references to defunct timeoutBuffer config

### DIFF
--- a/dev-docs/publisher-api-reference/setConfig.md
+++ b/dev-docs/publisher-api-reference/setConfig.md
@@ -19,7 +19,6 @@ Core config:
 * [Enable sharing of transaction IDs](#setConfig-enableTIDs)
 * [Max Requests Per Origin](#setConfig-Max-Requests-Per-Origin)
 * [Disable Ajax Timeout](#setConfig-Disable-Ajax-Timeout)
-* [Set Timeout Buffer](#setConfig-timeoutBuffer)
 * [Set TTL Buffer](#setConfig-ttlBuffer)
 * [Turn on send all bids mode](#setConfig-Send-All-Bids)
 * [Configure send bids control](#setConfig-Send-Bids-Control)
@@ -138,16 +137,6 @@ Prebid core adds a timeout on XMLHttpRequest request to terminate the request on
 
 ```javascript
 pbjs.setConfig({ disableAjaxTimeout: true });
-```
-
-#### Set Timeout Buffer
-
-<a name="setConfig-timeoutBuffer"></a>
-
-Prebid core adds a timeout buffer to extend the time that bidders have to return a bid after the auction closes. This buffer is used to offset the "time slippage" of the setTimeout behavior in browsers. Prebid.js sets the default value to 400ms. You can change this value by setting `timeoutBuffer` to the amount of time you want to use. The following example sets the buffer to 300ms.
-
-```javascript
-pbjs.setConfig({ timeoutBuffer: 300 });
 ```
 
 #### Set TTL Buffer

--- a/features/timeouts.md
+++ b/features/timeouts.md
@@ -26,14 +26,10 @@ header bidding activities. Determining this value is a delicate balance: too sho
 may go down due to delaying the ad server call to the point where users have left
 the page. Publishers must determine the value that works for them, considering
 a balance of factors: average user time on page, direct sellthrough, value of different ad channels, and average user network delay.
-3. **Timeout Buffer** - The JavaScript timer environment is not perfectly accurate
-because competing JavaScript on the page can delay the header bidding auction
-or the recognition that auction results have returned. By default, Prebid.js adds a 400ms buffer to the Auction Timeout to account for the noisy environment. Publishers can
-change this default value with the [`timeoutBuffer`](/dev-docs/publisher-api-reference/setConfig.html#setConfig-timeoutBuffer) configuration.
-4. **Prebid Server s2sConfig Timeout** - In order to make sure that Prebid Server
+3. **Prebid Server s2sConfig Timeout** - In order to make sure that Prebid Server
 bids can get back to the client in time for the ad server call, publishers
 should consider setting [s2sConfig.timeout](/dev-docs/publisher-api-reference/setConfig.html#setConfig-Server-to-Server) to a value lower than the Auction Timeout. How much lower depends on average user network delay, but should probably be within the range of 50%-75% of the Auction Timeout. This value is sent in the Prebid Server OpenRTB as `tmax`.
-5. **Timeout Adjustment** - In order to minimize the chance of missing the client-side
+4. **Timeout Adjustment** - In order to minimize the chance of missing the client-side
 ad server call, Prebid Server shaves off a safety buffer and responds to the client a little before the `tmax` value time is up. The Prebid Server host company sets two
 configurable values (`auction.timeout-adjustment-ms` and `auction.cache.expected-request-time-ms`), which can be expected to shave 30-100ms off of `tmax`. For example, if tmax=1000 and the Prebid Server host company has 40ms of safety margin configured,
 bidders will actually timeout at 960ms.
@@ -56,6 +52,5 @@ off the Timeout Adjustment.
 
 # Related Resources
 
-- [Prebid.js timeoutBuffer](/dev-docs/publisher-api-reference/setConfig.html#setConfig-timeoutBuffer)
 - [FAQ: What should I set my timeouts to?](/dev-docs/faq.html#what-should-my-timeouts-be)
 - [Prebid.js s2sConfig](/dev-docs/publisher-api-reference/setConfig.html#setConfig-Server-to-Server)


### PR DESCRIPTION
Remove references to the  `timeoutBuffer` config option, which was never respected and now completely unused.

https://github.com/prebid/Prebid.js/issues/11959

