### PR TITLE
auctionDelay is optional

### DIFF
--- a/dev-docs/publisher-api-reference/setConfig.md
+++ b/dev-docs/publisher-api-reference/setConfig.md
@@ -1252,7 +1252,7 @@ than others.
 pbjs.setConfig({
     // ...,
     realTimeData: {
-      auctionDelay: 100,     // REQUIRED: applies to all RTD modules
+      auctionDelay: 100,     // OPTIONAL: applies to all RTD modules.
       dataProviders: [{
           name: "RTD-MODULE-1",
           waitForIt: true,   // OPTIONAL: flag this module as important


### PR DESCRIPTION
Discussed in prebid.js , the auctionDelay is optional. It's already documented in the table as optional, but not in the code example.

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] bugfix (code examples)
