### PR TITLE
re-labeling tcf control module

### DIFF
--- a/dev-docs/modules/tcfControl.md
+++ b/dev-docs/modules/tcfControl.md
@@ -10,8 +10,11 @@ recommended: true
 sidebarType : 1
 ---
 
-# GDPR Enforcement Module
+# TCF Control Module
 {: .no_toc }
+
+{: .alert.alert-info :}
+Until Prebid.js 9.0 this was known as the "GDPR Enforcement" module.
 
 * TOC
 {: toc }
@@ -31,8 +34,8 @@ The [base consent module](/dev-docs/modules/consentManagementTcf.html) performs 
 
 The TCF Control Module adds the following:
 
-1. Allows the page to define which activities should be enforced at the Prebid.js level.
-2. Actively enforces those activities based on user consent data.
+1. Allows the page to define which activities should be restricted at the Prebid.js level.
+2. Actively restricts those activities based on user consent data.
 
 The following table details the Prebid.js activities that fall under the [Transparency and Consent Framework (TCF)](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/) scope:
 
@@ -50,34 +53,34 @@ The following table details the Prebid.js activities that fall under the [Transp
 
 ## Page Integration
 
-A page needs to define configuration rules about how Prebid.js should enforce each in-scope activity.
+A page needs to define configuration rules about how Prebid.js should restricts each in-scope activity.
 
 {: .alert.alert-warning :}
 **Important Legal Note:** Prebid.org cannot provide legal advice about GDPR or any other governmental regulation. Our aim is to provide a toolkit of functionality that will let publishers configure header bidding as defined by their legal counsel. We will consider feature suggestions, and review any code offered by the community.
 
 {: .alert.alert-info :}
-To turn on Prebid.js enforcement you must:
+To turn on Prebid.js restrictions you must:
 
 (1) Include the tcfControl module in the Prebid.js build
 and (2) setConfig `consentManagement.gdpr.cmpApi` to either 'iab' or 'static'
 
-The following fields related to GDPR enforcement are supported in the [`consentManagement`](/dev-docs/modules/consentManagementTcf.html) object:
+The following fields related to anonymizing aspects of the auction are supported in the [`consentManagement`](/dev-docs/modules/consentManagementTcf.html) object:
 
 {: .table .table-bordered .table-striped }
 | Param | Type | Description | Example |
 | --- | --- | --- | --- |
 | gdpr.rules | `Array of Objects` | Lets the publisher override the default behavior. | |
 | gdpr.rules[].purpose | `String` | Supported values: "storage" (Purpose 1), "basicAds" (Purpose 2), "personalizedAds" (purpose 4), "measurement" (Purpose 7), "transmitPreciseGeo" (Special Feature 1) | "storage" |
-| gdpr.rules[].enforcePurpose | `Boolean` | Determines whether to enforce the purpose consent. The default in Prebid.js 3.x is not to enforce purposes. Prebid.js 4.0 enforces legal basis for Purposes 1 and 2 by default. | true |
-| gdpr.rules[].enforceVendor | `Boolean` | Determines whether to enforce vendor signals for this purpose. The default in Prebid.js 3.x is not to enforce vendor signals. Prebid.js 4.0 enforces legal basis for Purposes 1 and 2 by default. | true |
-| gdpr.rules[].vendorExceptions | `Array of Strings` | Defines a list of biddercodes or module names that are exempt from the enforcement of this Purpose. | ["bidderA", "userID-module-B"] |
-| gdpr.rules[].softVendorExceptions | `Array of Strings` | Defines a list of biddercodes or module names that are exempt from the enforcement of vendor signals for this purpose. Unlike with `vendorExceptions`, Purpose consent is still enforced . | ["bidderA", "userID-module-B"] |
+| gdpr.rules[].enforcePurpose | `Boolean` | Determines whether to enforce the purpose consent. The default in Prebid.js 3.x was not to enforce any purposes. Prebid.js 4.0 and later require legal basis for Purposes 1 and 2 by default. | true |
+| gdpr.rules[].enforceVendor | `Boolean` | Determines whether to check vendor signals for this purpose. The default in Prebid.js 3.x is not to check vendor signals. Prebid.js 4.0 and later require legal basis for Purposes 1 and 2 by default. | true |
+| gdpr.rules[].vendorExceptions | `Array of Strings` | Defines a list of biddercodes or module names that are exempt from determining legal basis for this Purpose. | ["bidderA", "userID-module-B"] |
+| gdpr.rules[].softVendorExceptions | `Array of Strings` | Defines a list of biddercodes or module names that are exempt from the checking vendor signals for this purpose. Unlike with `vendorExceptions`, Purpose consent is still checked. | ["bidderA", "userID-module-B"] |
 | gdpr.rules[].eidsRequireP4Consent | `Boolean` | Only relevant on the personalizedAds `purpose`. If true, user IDs and EIDs will not be shared without evidence of consent for TCF Purpose 4. If false, evidence of consent for any of Purposes 2-10 is sufficient for sharing user IDs and EIDs. Defaults to false. See [note](#note-transmitEids) | true |
 | strictStorageEnforcement | `Boolean` | If false (the default), allows some use of storage regardless of purpose 1 consent - see [note](#strictStorageEnforcement) below | true |
 
 Notes:
 
-* <a id="strictStorageEnforcement"></a> By default, Prebid allows some limited use of storage even when purpose 1 consent was not given: this is limited to non-PII, such as [category translation mappings](/dev-docs/modules/categoryTranslation.html), or temporary test data used to probe the browser's storage features. If `strictStorageEnforcement` is true, purpose 1 consent will always be enforced for any access to storage.
+* <a id="strictStorageEnforcement"></a> By default, Prebid allows some limited use of storage even when purpose 1 consent was not given: this is limited to non-PII, such as [category translation mappings](/dev-docs/modules/categoryTranslation.html), or temporary test data used to probe the browser's storage features. If `strictStorageEnforcement` is true, Purpose 1 consent will always be enforced for any access to storage.
 * To accomodate Prebid.js modules and adapters that don't have GVL IDs, the vendorExceptions list is based on Prebid.js biddercodes instead of Global Vendor List (GVL) IDs (i.e. "bidderA" instead of "12345").
 * An alternate way of establishing a GVL mapping is to define a 'gvlMapping' object:
 
@@ -101,7 +104,7 @@ configuration of different business rules.
     pbjs.setConfig({
       consentManagement: {
         gdpr: {
-          cmpApi: 'iab',   // activates the enforcement module
+          cmpApi: 'iab',   // activates the control module
           defaultGdprScope: true,
           rules: [{        // these are the default values
             purpose: "storage",
@@ -112,9 +115,16 @@ configuration of different business rules.
             enforcePurpose: true,
             enforceVendor: true
           },{
+            purpose: "personalizedAds",
+            enforcePurpose: true,
+            enforceVendor: true
+          },{
             purpose: "measurement",
             enforcePurpose: true,
             enforceVendor: true
+          },{
+            purpose: "transmitPreciseGeo",
+            enforcePurpose: true
           }]
         }
       }
@@ -172,12 +182,12 @@ configuration of different business rules.
       }]
     ```
 
-## Basic Enforcement
+## Basic Legal Basis
 
 Prebid.js does not have access to the Global Vendor List (GVL), so it implements
 a "basic" form of TCF 'legal basis' validation using the supplied consent string.
 
-A goal of 'basic enforcement' is to confirm that there's enough evidence of consent to pass data on to vendors who do have access to the GVL and can fully parse and enforce.
+A goal of 'basic legal basis' is to confirm that there's enough evidence of consent to pass data on to vendors who do have access to the GVL and can fully parse and take any necessary action.
 
 Evidence of consent for a particular purpose or vendor means that:
 
@@ -186,17 +196,17 @@ Evidence of consent for a particular purpose or vendor means that:
 
 Before allowing an activity tied to a TCF-protected Purpose for a given vendor, one of these scenarios must be true:
 
-* Configuration rules enforce both consent and vendor signals and:
+* Configuration rules check both consent and vendor signals and:
   * we have evidence of consent for both, or
   * we have evidence of consent for the purpose, and the vendor is excepted through `softVendorException`, or
   * the vendor is excepted through `vendorExceptions`;
-* Configuration rules enforce only purpose consent and either:
+* Configuration rules check only purpose consent and either:
   * we have evidence of consent for the purpose, or
   * the vendor is excepted through `vendorExceptions`;
-* Configuration rules enforce only vendor signals and either:
+* Configuration rules check only vendor signals and either:
   * we have evidence of consent for the vendor, or
   * the vendor is excepted through either `softVendorExceptions` or `vendorExceptions`;
-* Configuration rules enforce neither purpose consent nor vendor signal.
+* Configuration rules check neither purpose consent nor vendor signal.
 
 See the [IAB TCF Consent String Format](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md) for details.
 
@@ -213,7 +223,7 @@ By default, sending user IDs and EIDs to bid adapters or RTD modules (the `trans
 * We have evidence of consent for any purpose between 2 and 10, and the vendor is excepted through `softVendorException` in at least one of: `basicAds`, `personalizedAds`, or `measurement`;
 * The vendor is excepted through `vendorExceptions` in at least one of `basicAds`, `personalizedAds`, or `measurement`.
 
-This behavior can be changed to the same "basic enforcement" algorithm described above, tied to TCF Purpose 4, by setting `eidsRequireP4Consent: true` on a `personalizedAds` rule:
+This behavior can be changed to the same "basic legal basis" algorithm described above, tied to TCF Purpose 4, by setting `eidsRequireP4Consent: true` on a `personalizedAds` rule:
 
 ```javascript
   ...
@@ -225,7 +235,7 @@ This behavior can be changed to the same "basic enforcement" algorithm described
 
 ## Build the Package
 
-Follow the basic build instructions in the GitHub Prebid.js repo's main [README](https://github.com/prebid/Prebid.js/blob/master/README.md). Include the base consent management module and this enforcement module as additional options on the **gulp build** command:
+Follow the basic build instructions in the GitHub Prebid.js repo's main [README](https://github.com/prebid/Prebid.js/blob/master/README.md). Include the base consent management module and this control module as additional options on the **gulp build** command:
 
 ```bash
 gulp build --modules=consentManagement,tcfControl,bidAdapter1,bidAdapter2

--- a/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.md
+++ b/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.md
@@ -660,7 +660,7 @@ It will become impossible to fetch bids from AppNexus within that Request.
 
 ##### Bidder Alias GVL IDs
 
-For environments that have turned on [GDPR enforcement](/prebid-server/features/pbs-privacy.html#gdpr), it can be important to define the Global Vendor List (GVL) ID with an alias.
+For publishers that use Prebid Server as part of their [GDPR/TCF](/prebid-server/features/pbs-privacy.html#gdpr) strategy, it can be important to define the Global Vendor List (GVL) ID with an alias.
 
 To do this, just set `ext.prebid.aliasgvlids` alongside ext.prebid.aliases:
 

--- a/prebid-server/features/pbs-privacy.md
+++ b/prebid-server/features/pbs-privacy.md
@@ -36,8 +36,8 @@ The enforcement strategy changed significantly between TCF 1.1 and TCF 2.0. [TCF
 more nuanced and stricter policy.
 
 {: .alert.alert-info :}
-If a Prebid Server host company wants to support GDPR, they must currently [register for the IAB Global Vendor List](https://register.consensu.org/).
-The user must provide legal basis for the host company to read/write cookies or `/cookie_sync` will return an empty response with no syncs and `/setuid` will fail.
+If a Prebid Server host company wants to support GDPR, they should [register for the IAB Global Vendor List](https://register.consensu.org/). This is because
+end users must provide legal basis for the host company to read/write cookies or `/cookie_sync` will return an empty response with no syncs and `/setuid` will fail.
 
 ### TCF 2.0 and 2.2
 

--- a/prebid/prebidjsReleases.md
+++ b/prebid/prebidjsReleases.md
@@ -56,7 +56,7 @@ The table below is a summary of feature changes and important bug fixes in core 
 | 4.4 | DFP Video Module supports VAST 4 |
 | 4.3 | DFP Video Module bug fixed |
 | 4.1.1 | Release of the [GPT Pre-Auction Module](https://docs.prebid.org/dev-docs/modules/gpt-pre-auction.html). Price Floors: new signals (location: noData + floorProvider) |
-| 4.0 | TCF Purpose 1 and Purpose 2 enforced by default when GDPR enforcement module turned on. Removed Digitrust userId module. Removed audienceNetworkBidAdapter. |
+| 4.0 | TCF Purpose 1 and Purpose 2 enforced by default when GDPR enforcement (now TCF Control) module turned on. Removed Digitrust userId module. Removed audienceNetworkBidAdapter. |
 | 3.27.1 | DFP Video Module bug fixed |
 | 3.27 | An important bug in the DFP Video Module was introduced with this release and fixed in 4.3 and 3.27.1. The dfpVideoModule only looked in adunit.sizes but adunit.sizes was stripped. Unfortunately there's not a workaround - if you use that video module, you shouldn't use Prebid.js 3.27 through 4.2 inclusive. |
 | 3.24 | PBS Bid Adapter allows setting site params |
@@ -66,7 +66,7 @@ The table below is a summary of feature changes and important bug fixes in core 
 | 3.17 | UserID module also exports IDs as eids |
 | 3.16 | isSafariBrowser fixed for Chrome and Firefox on iOS |
 | 3.15 | Advanced Size Mapping module support adunits of the same name |
-| 3.14 | New [GDPR enforcement module](/dev-docs/modules/tcfControl.html) supports enforcing Purpose 1 - DeviceAccess |
+| 3.14 | New [GDPR enforcement module](/dev-docs/modules/tcfControl.html) (now TCF Control) supports enforcing Purpose 1 - DeviceAccess |
 | 3.13 | GDPR module supports defaultGdprScope option |
 | 3.12 | Initial support for TCF2 - reading and passing consent strings, added [DeviceAccess](/dev-docs/publisher-api-reference/setConfig.html#setConfig-deviceAccess) configuration setting |
 | 3.11 | [Advanced Size Mapping module](/dev-docs/modules/sizeMappingV2.html) |


### PR DESCRIPTION
wordsmithing to complete the relabeling of "GDPR Enforcement" to  "TCF Control" and generally soften "enforce" with "restrict". We haven't changed the actual config attributes, so that can't go all the way.

https://deploy-preview-5529--prebid-docs-preview.netlify.app/dev-docs/modules/tcfcontrol