### PR TITLE
EClickAds: rename bidder from EClickAds to eClick

### DIFF
--- a/dev-docs/bidders/eclick.md
+++ b/dev-docs/bidders/eclick.md
@@ -1,8 +1,8 @@
 ---
 layout: bidder
-title: EClickAds
-description: EClickAds Bidder Adaptor
-biddercode: eclickads
+title: eClick
+description: eClick Bidder Adaptor
+biddercode: eclick
 media_types: native
 sidebarType: 1
 pbjs: true
@@ -19,12 +19,13 @@ prebid_member: false
 ortb_blocking_supported: false
 fpd_supported: true
 multiformat_supported: will-bid-on-one
-pbjs_version_notes: available in 9.9.0 and later, not in 10.x
+pbjs_version_notes: v10.x and later
+
 ---
 
 ### Note
-The EClickAds bidder adapter is going to be renamed to eClick in PBJS 10.x, using a bidder code of `eclick`. Please update your implementation accordingly. This bidder adapter is still available for PBJS versions 9.9.0 and later.
-The EClickAds adapter requires setup and approval from the EClick Team. Please contact us via <sales@eclick.vn> for detail.
+
+The eClick adapter requires setup and approval from the eClick Team. Please contact us via <sales@eclick.vn> for detail.
 
 ### Bid params
 

--- a/dev-docs/bidders/eclick.md
+++ b/dev-docs/bidders/eclick.md
@@ -1,8 +1,8 @@
 ---
 layout: bidder
-title: EClickAds
-description: EClickAds Bidder Adaptor
-biddercode: eclickads
+title: eClick
+description: eClick Bidder Adaptor
+biddercode: eclick
 media_types: native
 sidebarType: 1
 pbjs: true
@@ -23,7 +23,7 @@ multiformat_supported: will-bid-on-one
 
 ### Note
 
-The EClickAds adapter requires setup and approval from the EClick Team. Please contact us via <sales@eclick.vn> for detail.
+The eClick adapter requires setup and approval from the eClick Team. Please contact us via <sales@eclick.vn> for detail.
 
 ### Bid params
 

--- a/dev-docs/bidders/eclickads.md
+++ b/dev-docs/bidders/eclickads.md
@@ -1,8 +1,8 @@
 ---
 layout: bidder
-title: eClick
-description: eClick Bidder Adaptor
-biddercode: eclick
+title: EClickAds
+description: EClickAds Bidder Adaptor
+biddercode: eclickads
 media_types: native
 sidebarType: 1
 pbjs: true
@@ -23,7 +23,7 @@ multiformat_supported: will-bid-on-one
 
 ### Note
 
-The eClick adapter requires setup and approval from the eClick Team. Please contact us via <sales@eclick.vn> for detail.
+The EClickAds adapter requires setup and approval from the EClick Team. Please contact us via <sales@eclick.vn> for detail.
 
 ### Bid params
 


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.
-->

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] text edit only (wording, typos)

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked
-> https://github.com/prebid/Prebid.js/pull/12145

This commit does nothing but change the bidder name from `EClickAds` to `eClick` (also `bidderCode` from  `eclickads` to `eclick`)