### PR TITLE
1accord bid adapter - 1accord to 1Accord

### DIFF
--- a/dev-docs/bidders/1accord.md
+++ b/dev-docs/bidders/1accord.md
@@ -1,7 +1,7 @@
 ---
 layout: bidder
-title: 1accord
-description: Prebid 1accord Bidder Adapter
+title: 1Accord
+description: Prebid 1Accord Bidder Adapter
 pbjs: true
 biddercode: 1accord
 aliasCode : nexx360


### PR DESCRIPTION
Typo fix for 1Accord

## 🏷 Type of documentation
- [x] text edit only (wording, typos)

## 📋 Checklist

