### PR TITLE
Intent IQ Analytics Adapter: Update Module Code

### DIFF
--- a/dev-docs/analytics/intentiq.md
+++ b/dev-docs/analytics/intentiq.md
@@ -1,8 +1,8 @@
 ---
 layout: analytics
-title: IntentIQ
+title: Intent IQ
 description: IntentIQ Analytics Adapter
-modulecode: intentiq
+modulecode: intentIq
 ---
 
 ### Description


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.
-->

Currently, when the Intent IQ Analytics Adapter is selected on Prebid Download page, the build gives an error. The reason is that the module code in the documentation (intentiq) does not match the file name for the adapter in Prebid.js main repo (intent**I**qAnalyticsAdapter.js)

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] bugfix (fix typo in modulecode causing error in download page)
