### PR TITLE
AppNexus bidders page - update and clarify video params

### DIFF
--- a/dev-docs/bidders/appnexus.md
+++ b/dev-docs/bidders/appnexus.md
@@ -28,6 +28,7 @@ sidebarType: 1
   - [Video Object](#video-object)
   - [User Object](#user-object)
   - [App Object](#app-object)
+  - [Video Bid params and Video MediaTypes params](#video-bid-params-and-video-mediatypes-params)
   - [Custom Targeting keys](#custom-targeting-keys)
   - [Auction Level Keywords](#auction-level-keywords)
   - [Passing Keys Without Values](#passing-keys-without-values)
@@ -80,12 +81,14 @@ The table below will reflect both formats, though it's recommended to use the lo
 
 #### Video Object
 
+For details on how these video params work with the params set in the adUnit.mediaTypes.video object, see [Video Bid params and Video MediaTypes params](#appnexus-video-params) section below.
+
 {: .table .table-bordered .table-striped }
 | Name              | Description                                                                                                                                                                                                                                  | Type             |
 |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|
 | `minduration` | Integer that defines the minimum video ad duration in seconds. | `integer` |
 | `maxduration` | Integer that defines the maximum video ad duration in seconds. | `integer` |
-|`context` | A string that indicates the type of video ad requested.  Allowed values: `"pre_roll"`; `"mid_roll"`; `"post_roll"`; `"outstream"`. | `string` |
+|`context` | A string that indicates the type of video ad requested.  Allowed values: `"pre_roll"`; `"mid_roll"`; `"post_roll"`; `"outstream"`; `"in-banner"`, `"in-feed"`, `"interstitial"`, `"accompanying_content_pre_roll"`, `"accompanying_content_mid_roll"`, `"accompanying_content_post_roll"`. | `string` |
 | `skippable` | Boolean which, if `true`, means the user can click a button to skip the video ad.  Defaults to `false`. | `boolean` |
 |`skipoffset`| Integer that defines the number of seconds until an ad can be skipped.  Assumes `skippable` setting was set to `true`. | `integer` |
 | `playback_method` | A string that sets the playback method supported by the publisher.  Allowed values: `"auto_play_sound_on"`; `"auto_play_sound_off"`; `"click_to_play"`; `"mouse_over"`; `"auto_play_sound_unknown"`. | `string` |
@@ -149,6 +152,16 @@ pbjs.bidderSettings = {
   }
 }
 ```
+
+<a name="appnexus-video-params"></a>
+
+#### Video Bid params and Video MediaTypes params
+
+It is possible to have setup video params within the adUnit's AppNexus bid object as well as in the adUnit's `mediaTypes.video` object.  In this case, there is a set of logic that the AppNexus bid adapter follows to resolve which values should be passed along to the ad server request.  Generally speaking, the adapter prefers the values from bid param video object over the mediaTypes video object, in order to preserve historical setups.  So for instance, if the playbackmethod field was set in both locations, then the bid params `playback_method` would be chosen over the mediaTypes `playbackmethod`.  If there are different fields set between the two locations and they don't overlap, then the `mediaTypes.video` params would be included along with the bid params.
+
+To note - not all the fields between the two locations have a single direct comparison, nor are all fields from the `mediaTypes.video` object are supported by the ad server endpoint.  The fields/values set in the `mediaTypes.video` object follow the OpenRTB convention, while our bid params follow the convention for the ad server endpoint (which is **not** a straight OpenRTB endpoint).  The AppNexus bid adapter converts the matching fields from the `mediaTypes.video` object where there is a correlation to help support as much as possible.  For example, to help infer the `context` field, the adapter will look to the `mediaTypes.video.plcmt`, `mediaTypes.video.startdelay`, and `mediaTypes.video.placement` fields to help determine the appropriate `context` value.  The `startdelay` field is included here to help clarify the type of instream video that is used (ie pre/mid/post-roll).  
+
+If you want to transition from video bid params to use the `mediaTypes.video` params (to simplify the adUnit setup), please contact your AppNexus contact to help identify the proper fields/values are populated to ensure a smooth transition.
 
 <a name="appnexus-auction-keywords"></a>
 


### PR DESCRIPTION

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] update bid adapter


This PR updates some available values in the AppNexus bidders param page, as well as add a section about the interaction between `bid.params.video` and `mediaTypes.video` objects.