### PR TITLE
Fix "customHeaders" in prebidServer module typo

### DIFF
--- a/dev-docs/modules/prebidServer.md
+++ b/dev-docs/modules/prebidServer.md
@@ -96,7 +96,7 @@ There are many configuration options for s2sConfig:
 | `defaultTtl` | Optional | Integer | Configures the default TTL in the Prebid Server adapter to use when Prebid Server does not return a bid TTL - 60 if not set |
 | `adapterOptions` | Optional | Object | Arguments will be added to resulting OpenRTB payload to Prebid Server in every impression object at request.imp[].ext.BIDDER. See the example above. |
 | `extPrebid` | Optional | Object | Arguments will be added to resulting OpenRTB payload to Prebid Server in request.ext.prebid. See the examples below. |
-| `customHeader` | Optional | Object | These custom headers will be included in the XHR call to the bidder's endpoint. This will allow you to send data specific to your use case. The format consists of an object where the keys represent the header names and the values correspond to the respective header values. Here is an example how a customHeader object might look like - `{"Header1": "Value1", "Header2": "Value2"}`|
+| `customHeaders` | Optional | Object | These custom headers will be included in the XHR call to the bidder's endpoint. This will allow you to send data specific to your use case. The format consists of an object where the keys represent the header names and the values correspond to the respective header values. Here is an example how a customHeader object might look like - `{"Header1": "Value1", "Header2": "Value2"}`|
 
 If `endpoint` and `syncEndpoint` are objects, these are the supported properties:
 


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.
-->

Adds missing `s` to the `customHeaders` option.

https://github.com/sanved77/Prebid.js/blob/cb7a174b989ff30749da278517d3c197654e8c0c/modules/prebidServerBidAdapter/index.js#L553

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [x] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
