### PR TITLE
Sparteo Bid Adapter: Update Docs

### DIFF
--- a/dev-docs/bidders/sparteo.md
+++ b/dev-docs/bidders/sparteo.md
@@ -10,10 +10,10 @@ tcfeu_supported: true
 gvl_id: 1028
 usp_supported: true
 prebid_member: false
-schain_supported: false
+schain_supported: true
 safeframes_ok: true
 deals_supported: false
-floors_supported: false
+floors_supported: true
 fpd_supported: false
 ortb_blocking_supported: false
 multiformat_supported: will-bid-on-any
@@ -27,12 +27,14 @@ Sparteo Header Bidding adapter requires setup and approval. Please reach out to 
 ### Bid params
 
 {: .table .table-bordered .table-striped }
-| Name          | Scope    | Description                                                                             | Example    | Type      |
-|---------------|----------|-----------------------------------------------------------------------------------------|------------|-----------|
-| `publisherId` | required | Your publisher ID. This information will be given to you by the Sparteo team.           | `1234`     | `integer` |
-| `networkId`   | required | Your network ID. This information will be given to you by the Sparteo team.             | `1234`     | `integer` |
-
-Only the `publisherId` OR `networkId` is required.
+| Name          | Scope    | Description                                                                                                                         | Example                                  | Type      |
+|---------------|----------|-------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------|-----------|
+| `networkId`   | required | Your network ID. This information will be given to you by the Sparteo team.                                                         | `'9061ab7e-f01e-43a5-b801-c1a56156f105'` | `String`  |
+| `custom1`     | optional | To be used in reporting. Alphanumeric strings ; case sensitive ; max 40 characters ; only allowed symbols are hyphen and underscore.| `'Test-datapoint_42'`                    | `String`  |
+| `custom2`     | optional | To be used in reporting. Alphanumeric strings ; case sensitive ; max 40 characters ; only allowed symbols are hyphen and underscore.| `'Test-datapoint_42'`                    | `String`  |
+| `custom3`     | optional  | To be used in reporting. Alphanumeric strings ; case sensitive ; max 40 characters ; only allowed symbols are hyphen and underscore.| `'Test-datapoint_42'`                    | `String`  |
+| `custom4`     | optional    | To be used in reporting. Alphanumeric strings ; case sensitive ; max 40 characters ; only allowed symbols are hyphen and underscore.| `'Test-datapoint_42'`                    | `String`  |
+| `custom5`     | optional    | To be used in reporting. Alphanumeric strings ; case sensitive ; max 40 characters ; only allowed symbols are hyphen and underscore.| `'Test-datapoint_42'`                    | `String`  |
 
 ### Banner Object
 
@@ -47,12 +49,12 @@ Only the `publisherId` OR `networkId` is required.
 {: .table .table-bordered .table-striped }
 | Name             | Scope    | Description                                                              | Example        | Type             |
 |------------------|----------|--------------------------------------------------------------------------|----------------|------------------|
-| `context`        | required | The video context, either 'instream', 'outstream'.                       | `'instream'`     | `String`         |
+| `context`        | required | The video context, either 'instream', 'outstream'.                       | `'instream'`   | `String`         |
 | `playerSize`     | required | The size (width, height) of the video player on the page, in pixels.     | `[640, 480]`   | `Array<integer>` |
 | `playbackmethod` | optional | Defines how the video inventory is initiated following the OpenRTB spec. | `[4, 5]`       | `Array<integer>` |
 | `protocols`      | optional | Defines the video protocols allowed.                                     | `[1, 2]`       | `Array<integer>` |
 | `api`            | optional | Defines the video api allowed.                                           | `[1, 2]`       | `Array<integer>` |
-| `mimes`          | optional | Defines the video mimes allowed.                                         | `['video/mp4']` | `Array<String>`  |
+| `mimes`          | optional | Defines the video mimes allowed.                                         | `['video/mp4']`| `Array<String>`  |
 | `skip`           | optional | Defines if skip is allowed.                                              | `1`            | `integer`        |
 | `startdelay`     | optional | Defines the startDelay.                                                  | `0`            | `integer`        |
 | `placement`      | optional | Defines the placement.                                                   | `1`            | `integer`        |


### PR DESCRIPTION
Hi!

This doc update fixes the docs of the Sparteo Bid Adapter & add existing parameters which are already available.
This is the PR in Prebid.js: https://github.com/prebid/Prebid.js/pull/12321

This is the bid adapter if needed: https://github.com/prebid/Prebid.js/blob/master/modules/sparteoBidAdapter.js

## 🏷 Type of documentation
- [ ] new bid adapter
- [X] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
- [X] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself

Thank you :-)