### PR TITLE
Change params.apiKey to set it as string instead of boolean

### DIFF
--- a/dev-docs/modules/airgridRtdProvider.md
+++ b/dev-docs/modules/airgridRtdProvider.md
@@ -62,7 +62,7 @@ pbjs.setConfig(
 | :------------ | :------------ | :------------ |:------------ |
 | name | `String` | RTD sub module name | Always 'airgrid' |
 | waitForIt | `Boolean` | Wether to delay auction for module response | Optional. Defaults to false |
-| params.apiKey | `Boolean` | Publisher partner specific API key | Required |
+| params.apiKey | `String` | Publisher partner specific API key | Required |
 | params.accountId | `String` | Publisher partner specific account ID | Required |
 | params.publisherId | `String` | Publisher partner specific publisher ID | Required |
 | params.bidders | `Array` | Bidders with which to share segment information | Optional |


### PR DESCRIPTION
Update RTDModule_AirGrid documentation :params.apiKey should be a String and not a Boolean
@ydennisy as an FYI

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [X] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
