### PR TITLE
Fix #5358 Normalize headings in bidder docs

### DIFF
--- a/dev-docs/bidders/admatic.md
+++ b/dev-docs/bidders/admatic.md
@@ -27,6 +27,7 @@ AdMatic header bidding adapter connects with AdMatic demand sources to fetch bid
 ### Bid params
 
 {: .table .table-bordered .table-striped }
+
 | Name         | Scope    | Description                        | Example    | Type     |
 |--------------|----------|------------------------------------|------------|----------|
 | `networkId` | required | The network ID from AdMatic | `12345` | `number` |
@@ -76,7 +77,7 @@ var adUnits = [{
 }];
 ```
 
-## UserSync example
+### UserSync example
 
 ```javascript
 pbjs.setConfig({

--- a/dev-docs/bidders/admaticde.md
+++ b/dev-docs/bidders/admaticde.md
@@ -28,6 +28,7 @@ AdMatic GMBH header bidding adapter connects with AdMatic GMBH demand sources to
 ### Bid params
 
 {: .table .table-bordered .table-striped }
+
 | Name        | Scope    | Description                         | Example  | Type     |
 |-------------|----------|-------------------------------------|----------|----------|
 | `networkId` | required | The network ID from AdMatic GMBH | `12345` | `number` |
@@ -77,7 +78,7 @@ var adUnits = [{
 }];
 ```
 
-## UserSync example
+### UserSync example
 
 ```javascript
 pbjs.setConfig({

--- a/dev-docs/bidders/aidem.md
+++ b/dev-docs/bidders/aidem.md
@@ -22,7 +22,7 @@ ortb_blocking_supported: false
 sidebarType: 1
 ---
 
-## Description
+### Description
 
 This module connects publishers to AIDEM demand.
 
@@ -31,6 +31,7 @@ This module is GDPR and CCPA compliant, and no 3rd party userIds are allowed.
 ### Global Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name          | Scope    | Description         | Example    | Type     |
 |---------------|----------|---------------------|------------|----------|
 | `siteId`      | required | Unique site ID      | `'ABCDEF'` | `String` |
@@ -41,6 +42,7 @@ This module is GDPR and CCPA compliant, and no 3rd party userIds are allowed.
 #### Banner Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name       | Scope    | Description              | Example                   | Type    |
 |------------|----------|--------------------------|---------------------------|---------|
 | `sizes`    | required | List of the sizes wanted | `[[300, 250], [300,600]]` | `Array` |
@@ -48,6 +50,7 @@ This module is GDPR and CCPA compliant, and no 3rd party userIds are allowed.
 #### Video Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name          | Scope    | Description                             | Example         | Type      |
 |---------------|----------|-----------------------------------------|-----------------|-----------|
 | `context`     | required | One of instream, outstream, adpod       | `'instream'`    | `String`  |
@@ -60,6 +63,7 @@ This module is GDPR and CCPA compliant, and no 3rd party userIds are allowed.
 #### Additional Config
 
 {: .table .table-bordered .table-striped }
+
 | Name                | Scope    | Description                                             | Example | Type      |
 |---------------------|----------|---------------------------------------------------------|---------|-----------|
 | `coppa`             | optional | Child Online Privacy Protection Act                     | `true`  | `Boolean` |
@@ -68,6 +72,7 @@ This module is GDPR and CCPA compliant, and no 3rd party userIds are allowed.
 #### Consent Management Object
 
 {: .table .table-bordered .table-striped }
+
 | Name   | Scope    | Description                                                                                      | Example | Type     |
 |--------|----------|--------------------------------------------------------------------------------------------------|---------|----------|
 | `gdpr` | optional | GDPR Object see [Prebid.js doc](https://docs.prebid.org/dev-docs/modules/consentManagementTcf.html) | `{}`    | `Object` |
@@ -182,12 +187,13 @@ pbjs.que.push(function (){
 ### Supported Media Types
 
 {: .table .table-bordered .table-striped }
+
 | Type   | Support                                                            |
 |--------|--------------------------------------------------------------------|
 | Banner | Support all [AIDEM Sizes](https://kb.aidem.com/ssp/lists/adsizes/) |
 | Video  | Support all [AIDEM Sizes](https://kb.aidem.com/ssp/lists/adsizes/) |
 
-## Setup / Dev Guide
+### Setup / Dev Guide
 
 ```shell
 nvm use
@@ -210,9 +216,9 @@ gulp test --file "test/spec/modules/aidemBidAdapter_spec.js"
 
 For video: gulp serve --modules=aidemBidAdapter,dfpAdServerVideo
 
-## FAQs
+### FAQs
 
-### How do I view AIDEM bid request?
+#### How do I view AIDEM bid request?
 
 Navigate to a page where AIDEM is setup to bid. In the network tab,
 search for requests to `zero.aidemsrv.com/bid/request`.

--- a/dev-docs/bidders/ampliffy.md
+++ b/dev-docs/bidders/ampliffy.md
@@ -12,7 +12,7 @@ multiformat_supported: will-bid-on-one
 safeframes_ok: true
 ---
 
-## Table of contents
+### Table of contents
 
 * [Table of contents](#table-of-contents)
 * [Introduction](#introduction)
@@ -23,13 +23,13 @@ safeframes_ok: true
   * [Video](#video)
 * [Examples](#examples)
 
-## Introduction
+### Introduction
 
 Publishers can use Prebid.js to call Ampliffy through our client-side adapter: Prebid.js calls ampliffy directly from the browser using our client-side adapter. For configuration instructions, see the below on this page.
 
 ### Example
 
-## Supported media types
+### Supported media types
 
 The following table lists the media types that Ampliffy supports.
 
@@ -41,7 +41,7 @@ The following table lists the media types that Ampliffy supports.
 | video  |
 | native |
 
-## Modules to include in your build process
+### Modules to include in your build process
 
 If you are building the JS binary on your own from source code, follow the instructions in [Prebid.js project README](https://github.com/prebid/Prebid.js/blob/master/README.md#build-optimization). You will need to include the `ampliffyBidAdapter`. To show video ads with Google Ad Manager, you need to include the `dfpAdServerVideo` module. We highly recommend adding the `gptPreAuction` module as well, which improves a DSP's ability to bid accurately on your supply. The following is an example build command that include these modules: <br />
 `gulp build --modules=ampliffyBidAdapter,dfpAdServerVideo,gptPreAuction`
@@ -56,7 +56,7 @@ If you are using a JSON file to specify modules, add `ampliffyBidAdapter` and `d
 ]
 ```
 
-## Bid request parameters
+### Bid request parameters
 
 ### Banner
 
@@ -82,7 +82,7 @@ You must include these parameters at the bidder level.
 | `format` | Required | String | specify 'video' for this kind of inventory`                                                                                                                                                                                                                                                                                                                                                                                    |
 | `server` | Optional | String | An Ampliffy-specific identifier that is associated with this ad unit`                                                                                                                                                                                                                                                                                                                                                          |
 
-## Examples
+### Examples
 
 **Video (instream):** <br />
 

--- a/dev-docs/bidders/browsi.md
+++ b/dev-docs/bidders/browsi.md
@@ -20,12 +20,13 @@ For more information about [Browsi](https://www.browsi.com), please contact [sup
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name             | Scope    | Description      | Example                      | Type     |
 |------------------|----------|------------------|------------------------------|----------|
 | `pubId` | required | Publisher ID  | `'117a476f-9791-4a82-80db-4c01c1683db0'` | `string` |
 | `tagId`   | required | Tag ID       | `'1'` | `string` |
 
-# Sample Ad Unit: For Publishers
+### Sample Ad Unit: For Publishers
 
 ```javascript
 let videoAdUnit = [

--- a/dev-docs/bidders/consumable-server.md
+++ b/dev-docs/bidders/consumable-server.md
@@ -33,6 +33,7 @@ The Consumable bid adapter may cycle the ad initially shown with a new one at va
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name        | Scope    | Description                    | Example | Type      |
 |-------------|----------|--------------------------------|---------|-----------|
 | `siteId`    | required | The site ID from Consumable.    | `12345` | `integer` |
@@ -41,7 +42,7 @@ The Consumable bid adapter may cycle the ad initially shown with a new one at va
 | `unitName` | required | The unit name from Consumable. | `cnsmbl-unit`  | `string` |
 | `placementId` | required | the placementid from Consumable. | `0421008445828ceb46f496700a5fa65e` | `string` |
 
-## Table of contents
+### Table of contents
 
 * [Table of contents](#table-of-contents)
 * [Introduction](#introduction)
@@ -55,7 +56,7 @@ The Consumable bid adapter may cycle the ad initially shown with a new one at va
   * [App](#app-or-ctv-banner-video-audio)
 * [Examples](#examples)
 
-## Introduction
+### Introduction
 
 Publishers can use Prebid Server in any of the following ways with Consumable. Consumable's adapter supports all of the following methods:
 
@@ -63,18 +64,19 @@ Publishers can use Prebid Server in any of the following ways with Consumable. C
 * In mobile apps, you can use the Prebid Mobile SDK to call Prebid Server and then Prebid Server uses our server-side adapter to call Consumable. For set up instructions, see [Call Consumable from Prebid Mobile SDK](#call-consumable-from-prebid-mobile-sdk) section on this page.
 * In CTV apps and other long-form video environments, you (or the SSAI vendor) can make a call to Prebid Server using OpenRTB, and then Prebid Server uses our server-side adapter to call Consumable. For set up instructions, see [Call Consumable from CTV/long-form video environment](#call-consumable-from-ctvlong-form-video-environment) section on this page.
 
-## Supported media types
+### Supported media types
 
 The following table lists the media types that Consumable supports. For information about the the Time-To-Live (TTL) for each media type, see [How Consumable counts impressions](https://kb.Consumableexchange.com/publishers/billing/how_Consumable_counts_impressions.htm) in our Knowledge Base.
 
 {: .table .table-bordered .table-striped }
+
 | Type      | Prebid Server support |
 | ----------- | ----------- |
 | banner      | Supported       |
 | video   | Supported, including ad pods for OTT    |
 | audio      | Supported       |
 
-## Setup instructions to call Consumable through Prebid Server
+### Setup instructions to call Consumable through Prebid Server
 
 **Note:** If you are hosting your own Prebid Server instance, you must contact your Consumable Exchange Representative to get an endpoint and setup instructions.
 
@@ -152,7 +154,7 @@ To add Consumable as a bidder:
 2. Define the Consumable-specific parameters at the bidder level. For information about these parameters, see the [Bid request parameters](#bid-request-parameters) section below.
 3. Include any ad unit level required or optional parameters provided in Prebid's [/openrtb2/video](/prebid-server/endpoints/openrtb2/pbs-endpoint-video.html) documentation.
 
-## Bid request parameters
+### Bid request parameters
 
 For a list of the OpenRTB fields that Consumable supports in bid requests, see [List of supported OpenRTB bid request fields for sellers](https://kb.Consumableexchange.com/publishers/openrtb_integration/list_of_supported_openrtb_bid_request_fields_for_sellers.htm#List_of_supported_OpenRTB_bid_request_fields_for_sellers). The following are the required fields for the various supported media types.
 ### Site (Banner, Video, Audio)
@@ -160,6 +162,7 @@ For a list of the OpenRTB fields that Consumable supports in bid requests, see [
 You must include these parameters at the bidder level.
 
 {: .table .table-bordered .table-striped }
+
 | Name        | Scope    | Description                    | Example | Type      |
 |-------------|----------|--------------------------------|---------|-----------|
 | `siteId`    | required | The site ID from Consumable.    | `12345` | `integer` |
@@ -172,11 +175,12 @@ You must include these parameters at the bidder level.
 You must include these parameters at the bidder level.
 
 {: .table .table-bordered .table-striped }
+
 | Key | Scope | Type | Description |
 |---|---|---|---|
 | `placementId` | Required | String | An Consumable-specific identifier that is associated with this ad unit. It will be associated with the single size, if the size is provided. This is similar to a placement ID or an ad unit ID that some other modules have. For example, `'0421008445828ceb46f496700a5fa65e'`|
 
-## Examples
+### Examples
 
 **Banner**
 

--- a/dev-docs/bidders/consumable.md
+++ b/dev-docs/bidders/consumable.md
@@ -33,6 +33,7 @@ The Consumable bid adapter may cycle the ad initially shown with a new one at va
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name        | Scope    | Description                    | Example | Type      |
 |-------------|----------|--------------------------------|---------|-----------|
 | `siteId`    | required | The site ID from Consumable.    | `12345` | `integer` |
@@ -40,7 +41,7 @@ The Consumable bid adapter may cycle the ad initially shown with a new one at va
 | `unitId` | required | The unit ID from Consumable. | `987654`  | `integer` |
 | `unitName` | required | The unit name from Consumable. | `cnsmbl-unit`  | `string` |
 
-## Table of contents
+### Table of contents
 
 * [Table of contents](#table-of-contents)
 * [Introduction](#introduction)
@@ -56,7 +57,7 @@ The Consumable bid adapter may cycle the ad initially shown with a new one at va
   * [Video](#video)
 * [Examples](#examples)
 
-## Introduction
+### Introduction
 
 Publishers can use Prebid.js to call Consumable Exchange (Consumable) in any of the following ways:
 
@@ -77,7 +78,7 @@ pbjs.bidderSettings = {
 };
 ```
 
-## Supported media types
+### Supported media types
 
 The following table lists the media types that Consumable supports. 
 
@@ -88,11 +89,11 @@ The following table lists the media types that Consumable supports.
 | banner | Supported       |
 | video  | Supported      |
 
-## Set up Prebid.js to call Consumable directly from the browser (client-side adapter)
+### Set up Prebid.js to call Consumable directly from the browser (client-side adapter)
 
 To call Consumable from a web browser environment using a Prebid Server integration, see the Consumable-specific configuration steps in [Setup instructions to call Consumable through Prebid Server](/dev-docs/bidders/consumable-server.html#setup-instructions-to-call-consumable-through-prebid-server) in our Prebid Server documentation on the Prebid site.
 
-## Set up Prebid.js to call Consumable through Prebid Server (server-side adapter)
+### Set up Prebid.js to call Consumable through Prebid Server (server-side adapter)
 
 In this configuration, Prebid.js makes a call to Prebid Server and then Prebid Server uses our server-side adapter to call Consumable. Complete the following steps to configure Consumable as a demand source:
 
@@ -127,7 +128,7 @@ In this configuration, Prebid.js makes a call to Prebid Server and then Prebid S
     });
     ```
 
-## Set up First Party Data (FPD)
+### Set up First Party Data (FPD)
 
 You can set up the Prebid.js FPD module using Global data, Consumable bidder-specific site data, or ad unit-specific data. Consumable supports deal targeting in all the three FPD types.
 
@@ -183,13 +184,14 @@ ortb2Imp: {
 }
 ```
 
-## Bid request parameters
+### Bid request parameters
 
 ### Banner
 
 You must include these parameters at the bidder level.
 
 {: .table .table-bordered .table-striped }
+
 | Name        | Scope    | Description                    | Example | Type      |
 |-------------|----------|--------------------------------|---------|-----------|
 | `siteId`    | required | The site ID from Consumable.    | `12345` | `integer` |
@@ -202,6 +204,7 @@ You must include these parameters at the bidder level.
 You must include these parameters at the bidder level.
 
 {: .table .table-bordered .table-striped }
+
 | Name        | Scope    | Description                    | Example | Type      |
 |-------------|----------|--------------------------------|---------|-----------|
 | `siteId`    | required | The site ID from Consumable.    | `12345` | `integer` |
@@ -209,7 +212,7 @@ You must include these parameters at the bidder level.
 | `unitId` | required | The unit ID from Consumable. | `987654`  | `integer` |
 | `unitName` | required | The unit name from Consumable. | `cnsmbl-unit`  | `string` |
 
-## Examples
+### Examples
 
 **Banner**
 

--- a/dev-docs/bidders/contxtful.md
+++ b/dev-docs/bidders/contxtful.md
@@ -20,11 +20,11 @@ multiformar_supported: will-bid-on-any
 ortb_blocking_supported: true
 ---
 
-# Note
+### Note
 
 The Contxtful bidder adapter requires some setup. Contact us at [contact@contxtful.com](mailto:contact@contxtful.com)
 
-## User Sync
+### User Sync
 Contxtful recommends enabling [User Syncing](https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#setConfig-Configure-User-Syncing) to optimize match rate and monetization.
 
 ```javascript

--- a/dev-docs/bidders/exco.md
+++ b/dev-docs/bidders/exco.md
@@ -27,13 +27,14 @@ sidebarType: 1
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name       | Scope    | Description                                                                               | Example                      | Type     |
 |------------|----------|-------------------------------------------------------------------------------------------|------------------------------|----------|
 | `cId`      | required | The connection ID from Exco.                                                          | `'562524b21b1c1f08117fc7f9'` | `string` |
 | `pId`      | required | The publisher ID from Exco.                                                           | `'59ac17c192832d0011283fe3'` | `string` |
 | `bidFloor` | optional | The minimum bid value desired. Exco will not respond with bids lower than this value. | `0.90`                       | `float`  |
 
-## Example
+### Example
 
   ```javascript
 var adUnits = [{

--- a/dev-docs/bidders/glimpse.md
+++ b/dev-docs/bidders/glimpse.md
@@ -15,7 +15,7 @@ sidebarType: 1
 {: .alert.alert-warning :}
 glimpse is probably a defunct bidder, as the glimpseportal.io domain is no longer active.
 
-## Overview
+### Overview
 
 ```text
 Module Name: Glimpse Protocol Bid Adapter
@@ -23,19 +23,20 @@ Module Type: Bidder Adapter
 Maintainer: support@glimpseportal.io
 ```
 
-## Description
+### Description
 
 Glimpse protects consumer privacy while allowing precise targeting. This module connects publishers
 to Glimpse Protocol's demand sources via Prebid.js.
 
-## Supported Media Types
+### Supported Media Types
 
 {: .table .table-bordered .table-striped }
+
 | Type | Sizes |
 | -------- | ----------------------------------------- |
 | `Banner` | 300x250, 300x600, 320x50, 728x90, 970x250 |
 
-## Setup
+### Setup
 
 ### Prerequisites
 
@@ -50,13 +51,14 @@ Before you start, you will need to build a `prebid.js` file with the Glimpse mod
 <script async src="https://<PUBLISHER_DOMAIN>/prebid.js"></script>
 ```
 
-## Configuration
+### Configuration
 
 ### Bid Requests
 
 Our adapter expects the following values in the `params` block of each bid request:
 
 {: .table .table-bordered .table-striped }
+
 | Name | Scope | Type | Description | Example |
 | ----- | -------- | ------ | --------------------------------------------------------------------------------------------------- | ---------------------- |
 | `pid` | Required | string | A unique identifier representing an ad unit. It is provided by Glimpse when registering an ad unit. | 'glimpse-placement-id' |
@@ -123,8 +125,8 @@ pbjs.que.push(() => {
 })
 ```
 
-## FAQs
+### FAQs
 
-### Can you provide additional support?
+#### Can you provide additional support?
 
 Of course! You can check the Glimpse Prebid Adapter documentation or reach out to us at <support@glimpseportal.io>.

--- a/dev-docs/bidders/illumin.md
+++ b/dev-docs/bidders/illumin.md
@@ -26,13 +26,14 @@ sidebarType: 1
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name       | Scope    | Description                                                                               | Example                      | Type     |
 |------------|----------|-------------------------------------------------------------------------------------------|------------------------------|----------|
 | `cId`      | required | The connection ID from Illumin.                                                          | `'562524b21b1c1f08117fc7f9'` | `string` |
 | `pId`      | required | The publisher ID from Illumin.                                                           | `'59ac17c192832d0011283fe3'` | `string` |
 | `bidFloor` | optional | The minimum bid value desired. Illumin will not respond with bids lower than this value. | `0.90`                       | `float`  |
 
-## Example
+### Example
 
   ```javascript
 var adUnits = [{

--- a/dev-docs/bidders/iqm.md
+++ b/dev-docs/bidders/iqm.md
@@ -8,9 +8,10 @@ pbjs_version_notes: removed in 9.0
 sidebarType: 1
 ---
 
-## Parameters
+### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name          | Scope    | Description               | Example              |
 | :------------ | :------- | :------------------------ | :------------------- |
 | `publisherId` | required | The Publisher ID from iQM | "df5fd732-c5f3-11e7-abc4-cec278b6b50a" |
@@ -18,11 +19,11 @@ sidebarType: 1
 | `placementId` | required | The Placement ID from iQM | 23451                |
 | `bidfloor`    | optional | Bid Floor                 | 0.50                 |
 
-## Description
+### Description
 
 Module that connects to iQM demand sources
 
-## Test Parameters
+### Test Parameters
 
 ```javascript
 var adUnits = [{
@@ -50,7 +51,7 @@ var adUnits = [{
 
 ```
 
-## adUnit Video
+### adUnit Video
 
 ```javascript
  var videoAdUnit = {

--- a/dev-docs/bidders/ix-server.md
+++ b/dev-docs/bidders/ix-server.md
@@ -24,7 +24,7 @@ sidebarType: 1
 privacy_sandbox: paapi
 ---
 
-## Table of contents
+### Table of contents
 
 * [Table of contents](#table-of-contents)
 * [Introduction](#introduction)
@@ -40,9 +40,7 @@ privacy_sandbox: paapi
   * [Video](#video)
 * [Examples](#examples)
 
-<a id="introduction"></a>
-
-## Introduction
+### Introduction
 
 Publishers can use Prebid Server in any of the following ways with Index Exchange (Index). Index's adapter supports all of the following methods:
 
@@ -55,11 +53,12 @@ Publishers can use Prebid Server in any of the following ways with Index Exchang
 
 <a id="supported-media-types"></a>
 
-## Supported media types
+### Supported media types
 
 The following table lists the media types that Index supports. For information about the the Time-To-Live (TTL) for each media type, see [How Index counts impressions](https://kb.indexexchange.com/publishers/billing/how_Index_counts_impressions.htm) in our Knowledge Base.
 
 {: .table .table-bordered .table-striped }
+
 | Type      | Prebid Server support |
 | ----------- | ----------- |
 | banner      | Supported       |
@@ -68,7 +67,7 @@ The following table lists the media types that Index supports. For information a
 
 <a id="hosting-instance"></a>
 
-## Configure the Index adapter in your Prebid Server instance 
+### Configure the Index adapter in your Prebid Server instance 
 
 **Before you begin:** Contact your Index Exchange Representative to get an endpoint and setup instructions.
 
@@ -134,7 +133,7 @@ If you are hosting your own Prebid Server instance, depending on whether you are
 
 <a id="call-index"></a>
 
-## Publisher instructions to call Index through Prebid Server
+### Publisher instructions to call Index through Prebid Server
 
 If you are using an existing Prebid Server instance that is already configured to call Index, depending on whether you want to call Index from the browser, mobile app, CTV, or long-form video, follow any of the below sections to complete the Index-specific configuration.
 
@@ -241,7 +240,7 @@ To request bids from Index:
 
 <a id="bid-request-parameters"></a>
 
-## Bid request parameters
+### Bid request parameters
 
 For a list of the OpenRTB fields that Index supports in bid requests, see [List of supported OpenRTB bid request fields for sellers](https://kb.indexexchange.com/publishers/openrtb_integration/list_of_supported_openrtb_bid_request_fields_for_sellers.htm#List_of_supported_OpenRTB_bid_request_fields_for_sellers). The following are the required fields for the various supported media types.
 
@@ -250,6 +249,7 @@ For a list of the OpenRTB fields that Index supports in bid requests, see [List 
 You must include these parameters at the bidder level.
 
 {: .table .table-bordered .table-striped }
+
 | Key | Scope | Type | Description |
 |---|---|---|---|
 | `siteId` | Required | String | An Index-specific identifier that is associated with this ad unit. This is similar to a placement ID or an ad unit ID that some other modules have. For example, `'9999990'`, `'9999991'`, `'9999992'`|
@@ -259,6 +259,7 @@ You must include these parameters at the bidder level.
 You must include these parameters at the bidder level.
 
 {: .table .table-bordered .table-striped }
+
 | Key | Scope | Type | Description |
 |---|---|---|---|
 | `siteId` | Required | String | An Index-specific identifier that is associated with this ad unit. It will be associated with the single size, if the size is provided. This is similar to a placement ID or an ad unit ID that some other modules have. For example, `'9999990'`, `'9999991'`, `'9999992'`<br /> **Note:** You can re-use the existing `siteId` within the same flex position or video size, if the video adapts to the containing `<div>` element.|
@@ -266,6 +267,7 @@ You must include these parameters at the bidder level.
 If you are using Index's outstream ad unit and have placed the video object at the bidder level, you must include the Index required parameters at the bidder level. You can include the optional parameters to specify the outstream ad unit configurations.
 
 {: .table .table-bordered .table-striped }
+
 | Key | Scope | Type | Description |
 |---|---|---|---|
 | `video.w` | Required | Integer | The width of the video player in pixels that will be passed to demand partners. You must define the size of the video player using the `video.w` and `video.h` parameters. We strongly recommend video sizes to be `256 x 256` or greater, `300 x 250`, or `320 x 180`. |
@@ -278,7 +280,7 @@ If you are using Index's outstream ad unit and have placed the video object at t
 
 <a id="examples"></a>
 
-## Examples
+### Examples
 
 **Banner**
 

--- a/dev-docs/bidders/ix.md
+++ b/dev-docs/bidders/ix.md
@@ -26,7 +26,7 @@ sidebarType: 1
 privacy_sandbox: paapi, topics
 ---
 
-## Table of contents
+### Table of contents
 
 * [Table of contents](#table-of-contents)
 * [Introduction](#introduction)
@@ -52,7 +52,7 @@ privacy_sandbox: paapi, topics
 
 <a id="introduction"></a>
 
-## Introduction
+### Introduction
 
 Publishers can use Prebid.js to call Index Exchange (Index) in any of the following ways:
 
@@ -79,9 +79,7 @@ pbjs.bidderSettings = {
 };
 ```
 
-<a id="supported-media-types"></a>
-
-## Supported media types
+### Supported media types
 
 The following table lists the media types that Index supports. For information about the the Time-To-Live (TTL) for each media type, see [How Index counts impressions](https://kb.indexexchange.com/publishers/billing/how_Index_counts_impressions.htm) in our Knowledge Base.
 
@@ -95,13 +93,13 @@ The following table lists the media types that Index supports. For information a
 
 <a id="client-side-adapter"></a>
 
-## Set up Prebid.js to call Index directly from the browser (client-side adapter)
+### Set up Prebid.js to call Index directly from the browser (client-side adapter)
 
 To call Index from a web browser environment using a Prebid Server integration, see the Index-specific configuration steps in [Setup instructions to call Index through Prebid Server](/dev-docs/bidders/ix-server.html#setup-instructions-to-call-index-through-prebid-server) in our Prebid Server documentation on the Prebid site.
 
 <a id="server-side-adapter"></a>
 
-## Set up Prebid.js to call Index through Prebid Server (server-side adapter)
+### Set up Prebid.js to call Index through Prebid Server (server-side adapter)
 
 In this configuration, Prebid.js makes a call to Prebid Server and then Prebid Server uses our server-side adapter to call Index. Complete the following steps to configure Index as a demand source:
 
@@ -134,7 +132,7 @@ In this configuration, Prebid.js makes a call to Prebid Server and then Prebid S
 
 <a id="modules-to-include-in-your-build-process"></a>
 
-## Modules to include in your build process
+### Modules to include in your build process
 
 If you are building the JS binary on your own from source code, follow the instructions in [Prebid.js project README](https://github.com/prebid/Prebid.js/blob/master/README.md#build-optimization). You will need to include the `ixBidAdapter`. If you want to show video ads with Google Ad Manager, also include the `dfpAdServerVideo` module. We highly recommend adding the `gptPreAuction` module as well, which improves a DSP's ability to bid accurately on your supply. The following is an example build command that include these modules: <br />
 `gulp build --modules=ixBidAdapter,dfpAdServerVideo,gptPreAuction,fooBidAdapter,bazBidAdapter`
@@ -153,7 +151,7 @@ If you are using a JSON file to specify modules, add `ixBidAdapter` and `dfpAdSe
 
 <a id="set-up-first-party-data-fpd"></a>
 
-## Set up First Party Data (FPD)
+### Set up First Party Data (FPD)
 
 You can set up the Prebid.js FPD module using Global data, Index bidder-specific site data, or ad unit-specific data. Index supports deal targeting in all the three FPD types.
 
@@ -215,7 +213,7 @@ ortb2Imp: {
 }
 ```
 
-## Monetize instream video 
+### Monetize instream video 
 
 Unlike Outstream Video, instream video does not use the Prebid Universal Creative. Instead, video bids provide VAST that Prebid caches to obtain a cache ID that can be retrieved with a URL. The cache ID is passed as a key value to the ad server.  
 
@@ -233,7 +231,7 @@ To monetize instream video, complete the following steps:
 
 2. Set up your line items in Google Ad manger by following the instructions in Prebid's [Setting Up Video In GAM](/adops/setting-up-prebid-video-in-dfp.html) documentation. 
 
-## Index's outstream ad unit
+### Index's outstream ad unit
 
 Publishers who are using Index as a bidding adapter in Prebid.js can show outstream video ads on their site using Index's outstream ad unit. This allows a video ad to be placed anywhere on a publisher’s site, such as in-article, in-feed, and more. To use Index's outstream ad unit, you must be on Prebid.js version 5.13 or higher. However, if you are using your own outstream video player, Index's adapter can accept video signals from version 2.41.0 or higher. <br />
 **Note:** When you use the Index ad unit for outstream video, all impressions are considered viewable, which is similar to how Google's ActiveView counts impressions for outstream. This is because Index plays the outstream video as soon as it is in view and concurrently fires any impression pixels in the VAST.
@@ -309,7 +307,7 @@ pbjs.addAdUnit({
 
 <a id="prebid-native-configuration"></a>
 
-## Prebid Native configuration
+### Prebid Native configuration
 
 Prebid Native is available from Prebid.js version 7.4.0 or higher. We support the three native template rendering options that are provided in [Setting up Prebid Native in Google Ad Manager](/adops/gam-native.html). The following code is an example of a Prebid native setup using Google Ad Manager, but the concept and implementation should be similar for other ad servers.<br />
 
@@ -372,7 +370,7 @@ pbjs.addAdUnits({
 
 <a id="protected-audience-api-support"></a>
 
-## Protected Audience API support
+### Protected Audience API support
 
 **Before you begin:**
 
@@ -484,7 +482,7 @@ Depending on the Prebid.js version that you are using, the steps to configure Pr
 
 <a id="signal-inventory-using-external-ids"></a>
 
-## Signal inventory using  external IDs
+### Signal inventory using  external IDs
 
 1. In the `pbjs.setBidderConfig` object at the `ix` bidder level, you must configure an `exchangeId` that applies to all your placements as follows. Note that the `exchangeId` is provided by Index.
 
@@ -525,7 +523,7 @@ Depending on the Prebid.js version that you are using, the steps to configure Pr
 
 <a id="bid-request-parameters"></a>
 
-## Bid request parameters
+### Bid request parameters
 
 For a list of the OpenRTB fields that Index supports in bid requests, see [List of supported OpenRTB bid request fields for sellers](https://kb.indexexchange.com/publishers/openrtb_integration/list_of_supported_openrtb_bid_request_fields_for_sellers.htm#List_of_supported_OpenRTB_bid_request_fields_for_sellers). The following are the required fields for the various supported media types.
 
@@ -569,7 +567,7 @@ Index supports the same set of native assets that Prebid.js recognizes. For the 
 
 <a id="multi-format-ad-units"></a>
 
-## Multi-format ad units
+### Multi-format ad units
 
 Index supports multi-format ad units, see [Show Multi-Format Ads with Prebid.js](https://docs.prebid.org/dev-docs/show-multi-format-ads.html). For multi-format ad units, you can optionally specify a different siteId for each multi-format type at the bidder  level. This is useful  if you have deals set up with Index at the siteId level. See multi-format examples [here](#examples).
 
@@ -586,7 +584,7 @@ The following are the parameters that you can specify for each multi-format type
 
 <a id="examples"></a>
 
-## Examples
+### Examples
 
 **Banner**
 

--- a/dev-docs/bidders/jwplayer.md
+++ b/dev-docs/bidders/jwplayer.md
@@ -23,7 +23,7 @@ sidebarType: 1
 
 <a id="table-of-contents"></a>
 
-## Table of contents
+### Table of contents
 
 * [Table of contents](#table-of-contents)
 * [Introduction](#introduction)
@@ -36,7 +36,7 @@ sidebarType: 1
 
 <a id="introduction"></a>
 
-## Introduction
+### Introduction
 
 The JW Player Bid Adapter allows publishers to tap into JW Player's Video Advertising Demand.
 Publishers are not required to use JW Player as a video player.
@@ -44,7 +44,7 @@ Instream and outstream video ads are supported.
 
 <a id="modules-to-include-in-your-build-process"></a>
 
-## Modules to include in your build process
+### Modules to include in your build process
 
 You will need to include the `jwplayerBidAdapter` in your build. If you are building the JS binary on your own from source code, follow the instructions in [Prebid.js project README](https://github.com/prebid/Prebid.js/blob/master/README.md#build-optimization). 
 We recommend including the [jwplayerVideoProvider](/dev-docs/modules/jwplayerVideoProvider.html) to connect Prebid.js to your JW Player instance via the [Prebid Video Module](/dev-docs/modules/video.html). 
@@ -75,7 +75,7 @@ or
 
 <a id="bid-request-parameters"></a>
 
-## Bid Params
+### Bid Params
 
 We support all oRTB params and encourage populating as many as possible.
 
@@ -86,6 +86,7 @@ We support all oRTB params and encourage populating as many as possible.
 You must include the following parameters at the bidder level, in `adUnit.bids[index].params`.
 
 {: .table .table-bordered .table-striped }
+
 | Name | Scope | Type | Description                                          |
 |---|---|---|------------------------------------------------------|
 | `siteId` | Required | String | Site-specific id that is provided by JW Player.      |
@@ -99,6 +100,7 @@ You must include the following parameters at the bidder level, in `adUnit.bids[i
 We recommend populating as many params as possible in `adUnit.mediaTypes.video`. When using the [jwplayerVideoProvider](/dev-docs/modules/jwplayerVideoProvider.html), these fields are populated automatically. 
 
 {: .table .table-bordered .table-striped }
+
 | Name               | Scope       | Type    | Description                                                                                                                                                                                                                                                                                                             |
 |--------------------|-------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `video.w`          | Recommended | Integer | Populated automatically when using the `jwplayerVideoProvider`. The width of the video player in pixels that will be passed to demand partners. You must define the size of the video player using the `video.w` and `video.h` parameters.                                                                              |
@@ -113,6 +115,7 @@ In release 4.30 and later, publishers who are not using the [jwplayerVideoProvid
 The following fields are required:
 
 {: .table .table-bordered .table-striped }
+
 | Name               | Scope       | Type    | Description                                                                                                                                                                                                                                                                                                             |
 |--------------------|-------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `site.content.url` | Required    | string  | Populated automatically when the `jwplayerVideoProvider` or `jwplayerRtdProvider` are included. This is the URL of the media being rendered in the video player, for buy-side contextualization or review. This needs to be accessible (w/o DRM, Geo-blocking etc.) and without parameters (Such as size, quality etc.) |
@@ -135,7 +138,7 @@ pbjs.setConfig({
 
 <a id="examples"></a>
 
-## Examples
+### Examples
 
 ### With the JW Player Video Provider
 

--- a/dev-docs/bidders/kueezrtb.md
+++ b/dev-docs/bidders/kueezrtb.md
@@ -27,13 +27,14 @@ sidebarType: 1
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name       | Scope    | Description                                                                               | Example                      | Type     |
 |------------|----------|-------------------------------------------------------------------------------------------|------------------------------|----------|
 | `cId`      | required | The connection ID from KueezRTB.                                                          | `'562524b21b1c1f08117fc7f9'` | `string` |
 | `pId`      | required | The publisher ID from KueezRTB.                                                           | `'59ac17c192832d0011283fe3'` | `string` |
 | `bidFloor` | optional | The minimum bid value desired. KueezRTB will not respond with bids lower than this value. | `0.90`                       | `float`  |
 
-## Example
+### Example
 
   ```javascript
 var adUnits = [{

--- a/dev-docs/bidders/medianet.md
+++ b/dev-docs/bidders/medianet.md
@@ -21,6 +21,7 @@ sidebarType: 1
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name       | Scope    | Description                            | Example       | Type     |
 |------------|----------|----------------------------------------|---------------|----------|
 | `cid`      | required | The customer id provided by Media.net. | `'8CUX0H51C'` | `string` |
@@ -33,6 +34,7 @@ sidebarType: 1
 #### Video Object
 
 {: .table .table-bordered .table-striped }
+
 | Name       | Type    | Description   | Example|
 |------------|----------|--------------|--------|
 |mimes|array of strings|(Recommended) Specifies the video content MIME types supported; for example, video/x-ms-wmv and video/x-flv.|["video/x-ms-wmv","video/x-flv"]|
@@ -144,7 +146,7 @@ var adUnits = [{
 }];
 ```
 
-# Protected Audience API (FLEDGE)
+### Protected Audience API (FLEDGE)
 
 To enable PAAPI auctions follow the instructions below:
 

--- a/dev-docs/bidders/minutemedia.md
+++ b/dev-docs/bidders/minutemedia.md
@@ -28,6 +28,7 @@ The MinuteMedia adapter requires setup and approval. Please reach out to <hb@min
 #### Banner ,Video
 
 {: .table .table-bordered .table-striped }
+
 | Name | Scope | Type | Description | Example
 | ---- | ----- | ---- | ----------- | -------
 | `org` | required | String |  MinuteMedia publisher Id provided by your MinuteMedia representative  | "1234567890abcdef12345678"
@@ -35,7 +36,7 @@ The MinuteMedia adapter requires setup and approval. Please reach out to <hb@min
 | `placementId` | optional | String |  A unique placement identifier  | "12345678"
 | `testMode` | optional | Boolean |  This activates the test mode  | false
 
-## Example
+### Example
 
 ```javascript
 var adUnits = [{

--- a/dev-docs/bidders/monetixads.md
+++ b/dev-docs/bidders/monetixads.md
@@ -28,6 +28,7 @@ Monetix Ads header bidding adapter connects with Monetix Ads demand sources to f
 ### Bid params
 
 {: .table .table-bordered .table-striped }
+
 | Name        | Scope    | Description                         | Example  | Type     |
 |-------------|----------|-------------------------------------|----------|----------|
 | `networkId` | required | The network ID from Monetix Ads | `12345` | `number` |
@@ -77,7 +78,7 @@ var adUnits = [{
 }];
 ```
 
-## UserSync example
+### UserSync example
 
 ```javascript
 pbjs.setConfig({

--- a/dev-docs/bidders/netaddiction.md
+++ b/dev-docs/bidders/netaddiction.md
@@ -28,6 +28,7 @@ NetAddiction header bidding adapter connects with NetAddiction demand sources to
 ### Bid params
 
 {: .table .table-bordered .table-striped }
+
 | Name        | Scope    | Description                         | Example  | Type     |
 |-------------|----------|-------------------------------------|----------|----------|
 | `networkId` | required | The network ID from NetAddiction | `12345` | `number` |
@@ -77,7 +78,7 @@ var adUnits = [{
 }];
 ```
 
-## UserSync example
+### UserSync example
 
 ```javascript
 pbjs.setConfig({

--- a/dev-docs/bidders/ogury.md
+++ b/dev-docs/bidders/ogury.md
@@ -32,6 +32,7 @@ A detailed overview about the integration process can be found in [this document
 The minimal list of bid params is:
 
 {: .table .table-bordered .table-striped }
+
 | Name          | Scope    | Description           | Example   | Type      |
 |---------------|----------|-----------------------|-----------|-----------|
 | `assetKey`    | required | The asset key provided by Ogury   | `'OGY-CA41D116484F'` | `string`  |
@@ -41,6 +42,6 @@ The minimal list of bid params is:
 
 Depending on your advertising format needs, other optional parameters can be used. Supported parameters are detailed [here](https://ogury-ltd.gitbook.io/mobile-web/header-bidding/ogury-prebid.js-adapter-integration#optional-configuration).
 
-## How to contact us
+### How to contact us
 
 If you have any technical concerns or questions about the adapter, please contact <web.inventory@ogury.co>.

--- a/dev-docs/bidders/openweb.md
+++ b/dev-docs/bidders/openweb.md
@@ -30,6 +30,7 @@ The OpenWeb adapter requires setup and approval. Please reach out to <monetizati
 #### Banner, Video
 
 {: .table .table-bordered .table-striped }
+
 | Name | Scope | Type | Description | Example
 | ---- | ----- | ---- | ----------- | -------
 | `org` | required | String |  OpenWeb publisher Id provided by your OpenWeb representative  | "1234567890abcdef12345678"
@@ -37,7 +38,7 @@ The OpenWeb adapter requires setup and approval. Please reach out to <monetizati
 | `floorPrice` | optional | Number |  Minimum price in USD. <br/><br/> **WARNING:**<br/> Misuse of this parameter can impact revenue | 2.00
 | `testMode` | optional | Boolean |  This activates the test mode  | false
 
-## Example
+### Example
 
 ```javascript
 var adUnits = [{

--- a/dev-docs/bidders/openwebxchange.md
+++ b/dev-docs/bidders/openwebxchange.md
@@ -26,6 +26,7 @@ The OpenWebXChange adapter requires setup and approval.
 #### Banner, Video
 
 {: .table .table-bordered .table-striped }
+
 | Name | Scope | Type | Description | Example
 | ---- | ----- | ---- | ----------- | -------
 | `org` | required | String |  OpenWebXChange publisher Id  | "1234567890abcdef12345678"
@@ -36,7 +37,7 @@ The OpenWebXChange adapter requires setup and approval.
 | `is_wrapper` | private | Boolean |  Please don't use unless your account manager asked you to    | false
 | `currency` | optional | String | 3 letters currency | "EUR"
 
-## Example
+### Example
 
 ```javascript
 var adUnits = [{

--- a/dev-docs/bidders/openx.md
+++ b/dev-docs/bidders/openx.md
@@ -38,6 +38,7 @@ IMPORTANT: only include either openxBidAdapter or openxOrtbBidAdapter in your bu
 #### Banner
 
 {: .table .table-bordered .table-striped }
+
 | Name | Scope | Description | Example | Type |
 | ---- | ----- | ----------- | ------- | ---- |
 | `delDomain` ~~or `platform`~~** | required | OpenX delivery domain provided by your OpenX representative. | "PUBLISHER-d.openx.net" | String |
@@ -87,6 +88,7 @@ var adUnits = [
 #### Video
 
 {: .table .table-bordered .table-striped }
+
 | Name | Scope | Description | Example | Type |
 | ---- | ----- | ----------- | ------- | ---- |
 | `unit` | required | OpenX ad unit ID provided by your OpenX representative. | "1611023122" | String |
@@ -99,6 +101,7 @@ var adUnits = [
 The following video parameters are supported here so publishers may fully declare their video inventory:
 
 {: .table .table-bordered .table-striped }
+
 | Name           | Scope              | Description                                                                                                                                                                                              | Example | Type      |
 |----------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|-----------|
 | context | required | instream or outstream |"outstream" | string |
@@ -151,7 +154,7 @@ var videoAdUnits = [
 }]
 ```
 
-## Example
+### Example
 
 ```javascript
 var adUnits = [
@@ -254,7 +257,7 @@ pbjs.setConfig({
 });
 ```
 
-## Additional Details
+### Additional Details
 
 * [Banner Ads](https://docs.openx.com/publishers/prebid-adapter-web/) (Customer login required.)
 * [Video Ads](https://docs.openx.com/publishers/prebid-adapter-video/) (Customer login required.)

--- a/dev-docs/bidders/pixad.md
+++ b/dev-docs/bidders/pixad.md
@@ -28,6 +28,7 @@ Pixad header bidding adapter connects with Pixad demand sources to fetch bids fo
 ### Bid params
 
 {: .table .table-bordered .table-striped }
+
 | Name        | Scope    | Description                         | Example  | Type     |
 |-------------|----------|-------------------------------------|----------|----------|
 | `networkId` | required | The network ID from Pixad | `12345` | `number` |
@@ -77,7 +78,7 @@ var adUnits = [{
 }];
 ```
 
-## UserSync example
+### UserSync example
 
 ```javascript
 pbjs.setConfig({

--- a/dev-docs/bidders/publir.md
+++ b/dev-docs/bidders/publir.md
@@ -26,11 +26,12 @@ The Publir adapter requires setup and approval. Please reach out to [info@publir
 #### Banner, Video
 
 {: .table .table-bordered .table-striped }
+
 | Name | Scope | Type | Description | Example
 | ---- | ----- | ---- | ----------- | -------
 | `pubId` | required | String |  Publir publisher Id provided by your Publir representative  | "1234567890abcdef12345678"
 
-## Example
+### Example
 
 ```javascript
 var adUnits = [{

--- a/dev-docs/bidders/quantumdex.md
+++ b/dev-docs/bidders/quantumdex.md
@@ -16,6 +16,6 @@ pbs_app_supported: true
 sidebarType: 1
 ---
 
-## Description
+### Description
 
 Quantumdex is an aliased bidder of Apacdex bid adapter. Please refer to [Apacdex documentation](https://docs.prebid.org/dev-docs/bidders/apacdex) for bid parameters and implementation guide.

--- a/dev-docs/bidders/relevantdigital.md
+++ b/dev-docs/bidders/relevantdigital.md
@@ -26,6 +26,7 @@ sidebarType: 1
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name          | Scope    | Description                                             | Example                    | Type         |
 |---------------|----------|---------------------------------------------------------|----------------------------|--------------|
 | `placementId`       | required | The placement id.  | `'6204e83a077_620f9e8e4fe'`      | `String`     |
@@ -36,6 +37,7 @@ sidebarType: 1
 ### Config Parameters
 
 {: .table .table-bordered .table-striped }
+
 | Name          | Scope    | Description                                             | Example                    | Type         |
 |---------------|----------|---------------------------------------------------------|----------------------------|--------------|
 | `pbsHost` | required if not set in bid parameters | Host name of the server. | `'pbs-example.relevant-digital.com'`                | `String`     |
@@ -71,7 +73,7 @@ var adUnits = [
 ];
 ```
 
-## Example setup using only bid params
+### Example setup using only bid params
 
 This method to set the global configuration parameters (like **pbsHost**) in **params** could simplify integration of a provider for some publishers. Setting different global config-parameters on different bids is not supported in general*, as the first settings found will be used and any subsequent global settings will be ignored.
 

--- a/dev-docs/bidders/rise.md
+++ b/dev-docs/bidders/rise.md
@@ -29,6 +29,7 @@ The Rise adapter requires setup and approval. Please reach out to [prebid-rise-e
 #### Banner, Video
 
 {: .table .table-bordered .table-striped }
+
 | Name | Scope | Type | Description | Example
 | ---- | ----- | ---- | ----------- | -------
 | `org` | required | String |  Rise publisher Id provided by your Rise representative  | "1234567890abcdef12345678"
@@ -38,7 +39,7 @@ The Rise adapter requires setup and approval. Please reach out to [prebid-rise-e
 | `rtbDomain` | optional | String |  Sets the seller end point    | "www.test.com"
 | `is_wrapper` | private | Boolean |  Please don't use unless your account manager asked you to    | false
 
-## Example
+### Example
 
 ```javascript
 var adUnits = [{

--- a/dev-docs/bidders/risexchange.md
+++ b/dev-docs/bidders/risexchange.md
@@ -28,6 +28,7 @@ The RiseXChange adapter requires setup and approval. Please reach out to [prebid
 #### Banner, Video
 
 {: .table .table-bordered .table-striped }
+
 | Name | Scope | Type | Description | Example
 | ---- | ----- | ---- | ----------- | -------
 | `org` | required | String |  RiseXChange publisher Id  | "1234567890abcdef12345678"
@@ -37,7 +38,7 @@ The RiseXChange adapter requires setup and approval. Please reach out to [prebid
 | `rtbDomain` | optional | String |  Sets the seller end point    | "www.test.com"
 | `is_wrapper` | private | Boolean |  Please don't use unless your account manager asked you to    | false
 
-## Example
+### Example
 
 ```javascript
 var adUnits = [{

--- a/dev-docs/bidders/roundel.md
+++ b/dev-docs/bidders/roundel.md
@@ -18,10 +18,10 @@ prebid_member: yes
 sidebarType: 1
 ---
 
-## Overview
+### Overview
 
 Roundel is an aliased bidder for Index Exchange and must be configured alongside the [IdentityLink](/dev-docs/modules/userId.html#identitylink) user ID module.
 
-## Bid Params
+### Bid Params
 
 Bidder params for roundel follow the same structure as the Index Exchange bidder. Please reference configuration examples [here](/dev-docs/bidders/ix).

--- a/dev-docs/bidders/seedtag.md
+++ b/dev-docs/bidders/seedtag.md
@@ -24,6 +24,7 @@ The publisher id 0000-0000-01 returns demo responses.
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name              | Scope               | Description                                                                    | Example               | Type     |
 |-------------------|---------------------|--------------------------------------------------------------------------------|-----------------------|----------|
 | `publisherId`     | required            | The publisher id.                                                              | 0000-0000-01          | `string` |
@@ -84,7 +85,7 @@ const adUnits = [
 ]
 ```
 
-## InBanner example
+### InBanner example
 
 ```js
 const adUnits = [
@@ -109,7 +110,7 @@ const adUnits = [
 ]
 ```
 
-## inStream example
+### inStream example
 
 ```js
 var adUnits = [{

--- a/dev-docs/bidders/shinez.md
+++ b/dev-docs/bidders/shinez.md
@@ -24,6 +24,7 @@ The Shinez adapter requires setup and approval. Please reach out to <tech-team@s
 #### Banner, Video
 
 {: .table .table-bordered .table-striped }
+
 | Name | Scope | Type | Description | Example
 | ---- | ----- | ---- | ----------- | -------
 | `org` | required | String |  Shinez publisher Id provided by your Shinez representative  | "56f91cd4d3e3660002000033"
@@ -31,7 +32,7 @@ The Shinez adapter requires setup and approval. Please reach out to <tech-team@s
 | `placementId` | optional | String |  A unique placement identifier  | "12345678"
 | `testMode` | optional | Boolean |  This activates the test mode  | false
 
-## Example
+### Example
 
 ```javascript
 var adUnits = [{

--- a/dev-docs/bidders/shinezRtb.md
+++ b/dev-docs/bidders/shinezRtb.md
@@ -26,13 +26,14 @@ sidebarType: 1
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name       | Scope    | Description                                                                               | Example                      | Type     |
 |------------|----------|-------------------------------------------------------------------------------------------|------------------------------|----------|
 | `cId`      | required | The connection ID from shinezRtb.                                                          | `'562524b21b1c1f08117fc7f9'` | `string` |
 | `pId`      | required | The publisher ID from shinezRtb.                                                           | `'59ac17c192832d0011283fe3'` | `string` |
 | `bidFloor` | optional | The minimum bid value desired. shinezRtb will not respond with bids lower than this value. | `0.90`                       | `float`  |
 
-## Example
+### Example
 
   ```javascript
 var adUnits = [{

--- a/dev-docs/bidders/silverpush.md
+++ b/dev-docs/bidders/silverpush.md
@@ -27,6 +27,7 @@ The Silverpush Bidding adapter requires setup before beginning. Please contact u
 #### Banner
 
 {: .table .table-bordered .table-striped }
+
 |       Name     |    Scope    |                 Description                |    Example    |     Type     |
 | -------------- | ----------- | ------------------------------------------ | ------------- | ------------ |
 | `publisherId` | required | Publisher id provided by silverpush | "123456" | String |
@@ -37,6 +38,7 @@ The Silverpush Bidding adapter requires setup before beginning. Please contact u
 The following banner parameters are supported here so publishers may fully declare their banner inventory:
 
 {: .table .table-bordered .table-striped }
+
 |    Name   |    Scope    |                      Description                                  |  Example  |    Type   |
 | --------- | ------------| ----------------------------------------------------------------- | --------- | --------- |
 | sizes | required | Avalaible sizes supported for banner ad unit | [ [300, 250], [300, 600] ] | [[Integer, Integer], [Integer, Integer]] |
@@ -64,6 +66,7 @@ const adUnits = [{
 #### Video
 
 {: .table .table-bordered .table-striped }
+
 | Name | Scope | Description | Example | Type |
 | ---- | ----- | ----------- | ------- | ---- |
 | `publisherId` | required | Publisher id provided by silverpush | "123456" | String |
@@ -74,6 +77,7 @@ const adUnits = [{
 The following video parameters are supported here so publishers may fully declare their video inventory:
 
 {: .table .table-bordered .table-striped }
+
 |    Name   |    Scope    |                      Description                                  |  Example  |    Type   |
 | --------- | ------------| ----------------------------------------------------------------- | --------- | --------- |
 | context | required | instream or outstream |"outstream" | string |
@@ -128,7 +132,7 @@ Publishers should use the `ortb2` method of setting First Party Data. The follow
 
 - ortb2.user.ext.data
 
-## Prebid Server
+### Prebid Server
 
 ```javascript
 pbjs.setConfig({
@@ -157,5 +161,5 @@ pbjs.setConfig({
 });
 ```
 
-## Additional Details
+### Additional Details
 For any queries, reach us at <prebid@silverpush.co>.

--- a/dev-docs/bidders/stn.md
+++ b/dev-docs/bidders/stn.md
@@ -27,6 +27,7 @@ The STN adapter requires setup and approval. Please reach out to <hb@stnvideo.co
 #### Banner ,Video
 
 {: .table .table-bordered .table-striped }
+
 | Name | Scope | Type | Description | Example
 | ---- | ----- | ---- | ----------- | -------
 | `org` | required | String |  STN publisher Id provided by your STN representative  | "0987654321abcdef87654321"
@@ -34,7 +35,7 @@ The STN adapter requires setup and approval. Please reach out to <hb@stnvideo.co
 | `placementId` | optional | String |  A unique placement identifier  | "12345678"
 | `testMode` | optional | Boolean |  This activates the test mode  | false
 
-## Example
+### Example
 
 ```javascript
 var adUnits = [{

--- a/dev-docs/bidders/synacormedia.md
+++ b/dev-docs/bidders/synacormedia.md
@@ -25,6 +25,6 @@ sidebarType: 1
 pbjs_version_notes: use imds after 8.0
 ---
 
-# Note
+### Note
 
 The Synacor Media bidder adapter has been renamed to the [iMedia Digital Services (iMDS)](/dev-docs/bidders/imds.html) adapter, using an bidder code of `imds`. Please update your implementation accordingly.

--- a/dev-docs/bidders/tagoras.md
+++ b/dev-docs/bidders/tagoras.md
@@ -26,13 +26,14 @@ sidebarType: 1
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name       | Scope    | Description                                                                               | Example                      | Type     |
 |------------|----------|-------------------------------------------------------------------------------------------|------------------------------|----------|
 | `cId`      | required | The connection ID from Tagoras.                                                          | `'562524b21b1c1f08117fc7f9'` | `string` |
 | `pId`      | required | The publisher ID from Tagoras.                                                           | `'59ac17c192832d0011283fe3'` | `string` |
 | `bidFloor` | optional | The minimum bid value desired. Tagoras will not respond with bids lower than this value. | `0.90`                       | `float`  |
 
-## Example
+### Example
 
   ```javascript
 var adUnits = [{

--- a/dev-docs/bidders/valueimpression.md
+++ b/dev-docs/bidders/valueimpression.md
@@ -16,6 +16,6 @@ pbs_app_supported: true
 sidebarType: 1
 ---
 
-## Description
+### Description
 
 Valueimpression is an aliased bidder of Apacdex bid adapter. Please refer to [Apacdex documentation](https://docs.prebid.org/dev-docs/bidders/apacdex) for bid parameters and implementation guide.


### PR DESCRIPTION
Fixes #5358 - all headings start with `###` minimum in bidder docs

## 🏷 Type of documentation

- [x] text edit only (wording, typos)
