### PR TITLE
JS: update documentation for markWinningBidAsUsed/renderer

### DIFF
--- a/dev-docs/publisher-api-reference/markWinningBidAsUsed.md
+++ b/dev-docs/publisher-api-reference/markWinningBidAsUsed.md
@@ -6,7 +6,8 @@ sidebarType: 1
 ---
 
 
-This function can be used to mark the winning bid as used. This is useful when running multiple video advertisements on the page, since these are not automatically marked as “rendered”.
+This function can be used to mark the winning bid as used, removing it from the bid cache. This is useful when running multiple video advertisements on the page, since these are not automatically marked as “rendered”.
+
 If you know the adId, then be specific, otherwise Prebid will retrieve the winning bid for the adUnitCode and mark it accordingly.
 
 #### Argument Reference
@@ -18,3 +19,4 @@ If you know the adId, then be specific, otherwise Prebid will retrieve the winni
 | --- | --- | --- |
 | adUnitCode | `string` | (Optional) The ad unit code |
 | adId | `string` | (Optional) The id representing the ad we want to mark |
+| analytics | `boolean` | (Optional) if true, triggers the 'bidWon' event for the marked bid |

--- a/dev-docs/show-outstream-video-ads.md
+++ b/dev-docs/show-outstream-video-ads.md
@@ -80,9 +80,9 @@ Renderers can be attached to adUnits in three ways; Prebid will pick the first t
 
 A renderer is an object containing these properties:
 
-1. `url` -- Points to a file containing the renderer script.
-2. `render` -- A function that tells Prebid.js how to invoke the renderer script.
-3. `backupOnly` -- Optional field, if set to true, buyer or adapter renderer will be preferred
+1. `render` -- A function that tells Prebid.js how to render a given bid. 
+2. `url` -- Optional, URL to a javascript file. If provided, Prebid.js will load it before invoking `render`.
+3. `backupOnly` -- Optional, if set to true, buyer or adapter renderer will be preferred
 
 In a multiFormat adUnit, you might want the renderer to only apply to only one of the mediaTypes.  You can do this by defining the renderer on the media type itself.
 


### PR DESCRIPTION
## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] new feature


Update documentation for two related features:

 - publisher-defined renderers can now omit `url` - https://github.com/prebid/Prebid.js/pull/12426
 - `markWinningBidAsUsed` can now trigger `bidWon` - https://github.com/prebid/Prebid.js/pull/12437

