### PR TITLE
gothamads doc to turn off tcfeu_supported flag

### DIFF
--- a/dev-docs/bidders/gothamads.md
+++ b/dev-docs/bidders/gothamads.md
@@ -3,7 +3,7 @@ layout: bidder
 title: gothamads
 description: Prebid gothamads Bidder Adaptor
 biddercode: gothamads
-tcfeu_supported: true
+tcfeu_supported: false
 usp_supported: true
 coppa_supported: true
 ccpa_supported: true


### PR DESCRIPTION
Bidders cannot claim tcfeu support without a GVLID

Can't find a reference to a GVLID for them in the adapters.