### PR TITLE
Added filename for freedomadnetwork.md

### DIFF
--- a/dev-docs/bidders/freedomadnetwork.md
+++ b/dev-docs/bidders/freedomadnetwork.md
@@ -3,6 +3,7 @@ layout: bidder
 title: Freedom Ad Network
 description: Freedom Ad Network Bidder Adapter
 biddercode: freedomadnetwork
+filename: fanAdapter
 gvl_id: none
 coppa_supported: true
 media_types: banner, native


### PR DESCRIPTION
Since the filename differs, needed to be updated here following the new feature added on [this PR](https://github.com/prebid/prebid.github.io/pull/4186)

## 🏷 Type of documentation
- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [x] bugfix (code examples)
- [ ] new examples

