### PR TITLE
Bug: Update the code for ortb2Imp for setting floorMin

### DIFF
--- a/dev-docs/modules/floors.md
+++ b/dev-docs/modules/floors.md
@@ -1281,10 +1281,10 @@ pbjs.addAdUnits({
     ortb2Imp: {
         ext: {
         prebid: {
-                data: {
-            floorMin: 0.25,
-            floorMinCur: "USD"
-        }
+                floors: {
+                    floorMin: 0.25,
+                    floorMinCur: "USD"
+                }
             }
         }
     },


### PR DESCRIPTION
Fixed the code example for configuring impression-level floor min in the floors documentation.

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] bugfix (code examples)
