### PR TITLE
Adkernel: actualizing bidder/aliases documentation

### DIFF
--- a/dev-docs/bidders/adbite.md
+++ b/dev-docs/bidders/adbite.md
@@ -3,23 +3,28 @@ layout: bidder
 title: Adbite
 description: Adbite LLC
 biddercode: adbite
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14
+aliasCode: adkernel
 tcfeu_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-gpp_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/adkernel.md
+++ b/dev-docs/bidders/adkernel.md
@@ -2,23 +2,28 @@
 layout: bidder
 title: AdKernel
 description: Prebid AdKernel Bidder Adaptor
-pbjs: true
-pbs: true
 biddercode: adkernel
-media_types: banner, native, video
 tcfeu_supported: true
+dsa_supported: false
+gvl_id: 14
 usp_supported: true
 coppa_supported: true
-gpp_supported: true
-pbs_app_supported: true
-gvl_id: 14
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
+fpd_supported: true
+pbjs: true
+pbs: true
+pbs_app_supported: true
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/adomega.md
+++ b/dev-docs/bidders/adomega.md
@@ -3,23 +3,28 @@ layout: bidder
 title: adOmega
 description: adOmega Bidder Adaptor
 biddercode: adomega
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/adpluto.md
+++ b/dev-docs/bidders/adpluto.md
@@ -3,22 +3,28 @@ layout: bidder
 title: AdPluto
 description: AdPluto Bidder Adaptor
 biddercode: adpluto
-pbjs: true
-pbs: false
-media_types: banner, native, video
-tcfeu_supported: false
-gpp_supported: true
+aliasCode: adkernel
+tcfeu_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: false
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/adsolut.md
+++ b/dev-docs/bidders/adsolut.md
@@ -3,23 +3,28 @@ layout: bidder
 title: adsolut
 description: Prebid adsolut Bidder Adaptor
 biddercode: adsolut
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-gpp_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/audiencemedia.md
+++ b/dev-docs/bidders/audiencemedia.md
@@ -3,23 +3,28 @@ layout: bidder
 title: Audience Media
 description: Prebid Audience Media Bidder Adaptor
 biddercode: audiencemedia
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-gpp_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/bcm.md
+++ b/dev-docs/bidders/bcm.md
@@ -3,23 +3,28 @@ layout: bidder
 title: BCM
 description: BCM Bid Adapter
 biddercode: bcm
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-gpp_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/bidbuddy.md
+++ b/dev-docs/bidders/bidbuddy.md
@@ -3,23 +3,28 @@ layout: bidder
 title: Bidbuddy
 description: Bidbuddy Bidder Adaptor
 biddercode: bidbuddy
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/converge.md
+++ b/dev-docs/bidders/converge.md
@@ -3,23 +3,28 @@ layout: bidder
 title: Converge-Digital
 description: Converge-Digital Bidder Adaptor
 biddercode: converge
-pbjs: true
-pbs: false
-media_types: banner, native, video
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_supported: true
+dsa_supported: false
 gvl_id: 248
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/denakop.md
+++ b/dev-docs/bidders/denakop.md
@@ -3,23 +3,28 @@ layout: bidder
 title: Denakop
 description: Denakop Bidder Adaptor
 biddercode: denakop
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/didnadisplay.md
+++ b/dev-docs/bidders/didnadisplay.md
@@ -3,23 +3,28 @@ layout: bidder
 title: diDNA Display
 description: diDNA Display Bidder Adaptor
 biddercode: didnadisplay
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: false
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/digiad.md
+++ b/dev-docs/bidders/digiad.md
@@ -3,23 +3,28 @@ layout: bidder
 title: Digiad DMCC
 description: Digiad DMCC Adaptor
 biddercode: digiad
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: false
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/displayioads.md
+++ b/dev-docs/bidders/displayioads.md
@@ -3,23 +3,28 @@ layout: bidder
 title: DisplayioAds
 description: DisplayioAds Bidder Adaptor
 biddercode: displayioads
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/engageadx.md
+++ b/dev-docs/bidders/engageadx.md
@@ -3,23 +3,28 @@ layout: bidder
 title: EngageADX
 description: EngageADX Bidder Adaptor
 biddercode: engageadx
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-gpp_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/ergadx.md
+++ b/dev-docs/bidders/ergadx.md
@@ -3,23 +3,28 @@ layout: bidder
 title: eRGADX
 description: eRGADX Bidder Adaptor
 biddercode: ergadx
-pbjs: true
-pbs: true
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/global_sun.md
+++ b/dev-docs/bidders/global_sun.md
@@ -3,23 +3,28 @@ layout: bidder
 title: Global Sun
 description: Global Sun Adaptor
 biddercode: global_sun
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_sids: tcfeu, usp
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: false
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/headbidder.md
+++ b/dev-docs/bidders/headbidder.md
@@ -3,23 +3,28 @@ layout: bidder
 title: Headbidder.net
 description: Headbidder.net Bidder Adaptor
 biddercode: headbidder
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: false
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/houseofpubs.md
+++ b/dev-docs/bidders/houseofpubs.md
@@ -3,23 +3,28 @@ layout: bidder
 title: HouseOfPubs
 description: House of Pubs Bid Adapter
 biddercode: houseofpubs
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-gpp_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/hyperbrainz.md
+++ b/dev-docs/bidders/hyperbrainz.md
@@ -3,23 +3,28 @@ layout: bidder
 title: HyperBrainz
 description: HyperBrainz Adaptor
 biddercode: hyperbrainz
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_sids: tcfeu, usp
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: false
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/monetix.md
+++ b/dev-docs/bidders/monetix.md
@@ -3,23 +3,28 @@ layout: bidder
 title: Monetix
 description: Monetix Adaptor
 biddercode: monetix
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_sids: tcfeu, usp
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: false
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/motionspots.md
+++ b/dev-docs/bidders/motionspots.md
@@ -3,23 +3,28 @@ layout: bidder
 title: Motionspots
 description: Motionspots Bidder Adaptor
 biddercode: motionspots
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/oppamedia.md
+++ b/dev-docs/bidders/oppamedia.md
@@ -3,23 +3,28 @@ layout: bidder
 title: OppaMedia
 description: OppaMedia Bidder Adaptor
 biddercode: oppamedia
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-gpp_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/pixelpluses.md
+++ b/dev-docs/bidders/pixelpluses.md
@@ -3,23 +3,28 @@ layout: bidder
 title: Pixelpluses
 description: Pixelpluses Bidder Adaptor
 biddercode: pixelpluses
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 1209
+aliasCode: adkernel
 tcfeu_supported: true
+dsa_supported: false
+gvl_id: 1209
 usp_supported: true
 coppa_supported: true
-gpp_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/qortex.md
+++ b/dev-docs/bidders/qortex.md
@@ -3,23 +3,28 @@ layout: bidder
 title: Qortex
 description: Qortex Bidder Adaptor
 biddercode: qortex
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/revbid.md
+++ b/dev-docs/bidders/revbid.md
@@ -3,23 +3,28 @@ layout: bidder
 title: RevBid
 description: RevBid Adaptor
 biddercode: revbid
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_sids: tcfeu, usp
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: false
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/rtbanalytica.md
+++ b/dev-docs/bidders/rtbanalytica.md
@@ -3,23 +3,28 @@ layout: bidder
 title: RtbAnalytica
 description: RtbAnalytica Bidder Adaptor
 biddercode: rtbanalytica
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/rtbdemand_com.md
+++ b/dev-docs/bidders/rtbdemand_com.md
@@ -3,23 +3,28 @@ layout: bidder
 title: RtbDemand.com
 description: Prebid RtbDemand.com Bidder Adaptor
 biddercode: rtbdemand_com
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/rxnetwork.md
+++ b/dev-docs/bidders/rxnetwork.md
@@ -2,24 +2,28 @@
 layout: bidder
 title: RxNetwork
 description: Prebid RxNetwork Bidder Adaptor
-pbjs: true
-pbs: false
-biddercode: rxnetwork
 aliasCode: adkernel
-media_types: banner, native, video
 tcfeu_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-gpp_supported: true
-pbs_app_supported: false
-gvl_id: 14 (adkernel)
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
+fpd_supported: true
+pbjs: true
+pbs: true
+pbs_app_supported: true
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/sonic_twist.md
+++ b/dev-docs/bidders/sonic_twist.md
@@ -3,23 +3,28 @@ layout: bidder
 title: Sonic Twist Media
 description: Sonic Twist Media
 biddercode: sonic_twist
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/spinx.md
+++ b/dev-docs/bidders/spinx.md
@@ -3,23 +3,28 @@ layout: bidder
 title: SpinX
 description: SpinX Adaptor
 biddercode: spinx
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 1308
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_sids: tcfeu, usp
+dsa_supported: false
+gvl_id: 1308
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: false
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/turktelekom.md
+++ b/dev-docs/bidders/turktelekom.md
@@ -3,24 +3,28 @@ layout: bidder
 title: Türk Telekom
 description: Türk Telekom Bidder Adaptor
 biddercode: turktelekom
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 673
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_supported: true
+dsa_supported: false
+gvl_id: 673
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
-floors_supported: true
-aliasCode: adkernel
+dchain_supported: false
+userId: all
+media_types: banner, video, native
 safeframes_ok: true
+deals_supported: false
+floors_supported: true
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/unibots.md
+++ b/dev-docs/bidders/unibots.md
@@ -3,23 +3,28 @@ layout: bidder
 title: Unibots
 description: Unibots Bidder Adaptor
 biddercode: unibots
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/urekamedia.md
+++ b/dev-docs/bidders/urekamedia.md
@@ -3,23 +3,28 @@ layout: bidder
 title: UrekaMedia
 description: UrekaMedia Bidder Adaptor
 biddercode: urekamedia
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-gpp_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/voisetech.md
+++ b/dev-docs/bidders/voisetech.md
@@ -3,23 +3,28 @@ layout: bidder
 title: Voise Tech
 description: Voise Tech Adaptor
 biddercode: voisetech
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
-gpp_sids: tcfeu, usp
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-pbs_app_supported: false
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 

--- a/dev-docs/bidders/waardex_ak.md
+++ b/dev-docs/bidders/waardex_ak.md
@@ -3,23 +3,28 @@ layout: bidder
 title: WaardeX
 description: Prebid WaardeX Bidder Adaptor
 biddercode: waardex_ak
-pbjs: true
-pbs: false
-media_types: banner, native, video
-gvl_id: 14 (adkernel)
+aliasCode: adkernel
 tcfeu_supported: true
+dsa_supported: false
+gvl_id: 14 (adkernel)
 usp_supported: true
 coppa_supported: true
-gpp_supported: true
-pbs_app_supported: true
+gpp_sids: tcfeu, usp
 schain_supported: true
-userIds: all
-fpd_supported: true
-prebid_member: false
-ortb_blocking_supported: true
-multiformat_supported: will-bid-on-one
+dchain_supported: false
+userId: all
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: false
 floors_supported: true
-aliasCode: adkernel
+fpd_supported: true
+pbjs: true
+pbs: false
+pbs_app_supported: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+ortb_blocking_supported: true
+privacy_sandbox: no
 sidebarType: 1
 ---
 


### PR DESCRIPTION
## 🏷 Type of documentation
- [x] update bid adapter


Updated bidder and related aliases docs. 

Alias docs are now in sync with adkernel adaptor doc and share same block:

```
tcfeu_supported: true
dsa_supported: false
gvl_id: 14 (adkernel)
usp_supported: true
coppa_supported: true
gpp_sids: tcfeu, usp
schain_supported: true
dchain_supported: false
userId: all
media_types: banner, video, native
safeframes_ok: true
deals_supported: false
floors_supported: true
fpd_supported: true
pbjs: true
pbs: false
pbs_app_supported: false
prebid_member: false
multiformat_supported: will-bid-on-any
ortb_blocking_supported: true
privacy_sandbox: no
```

however, the documentation for certain aliases with their own gvl_id or prebid server alias have differences in their respective fields.