### PR TITLE
added vendor exception disclaimer

### DIFF
--- a/dev-docs/modules/permutiveRtdProvider.md
+++ b/dev-docs/modules/permutiveRtdProvider.md
@@ -78,6 +78,9 @@ If you are also using the [TCF Control Module](/dev-docs/modules/tcfControl.html
 
 ### Instructions
 
+{: .alert.alert-warning :}
+Prebid.org recommends working with a privacy lawyer before making enforcement exceptions for any vendor.
+
 1. Publisher enables rules within Prebid.js configuration. 
 2. Label Permutive as an exception, as shown below.
 

--- a/dev-docs/modules/permutiveRtdProvider.md
+++ b/dev-docs/modules/permutiveRtdProvider.md
@@ -79,7 +79,7 @@ If you are also using the [TCF Control Module](/dev-docs/modules/tcfControl.html
 ### Instructions
 
 {: .alert.alert-warning :}
-Prebid.org recommends working with a privacy lawyer before making enforcement exceptions for any vendor.
+Prebid.org recommends working with a privacy lawyer before making enforcement exceptions for any vendor. Specifically for Permutive, we recommend publishers let Prebid.js make use of their registered GVL ID 361 instead of a vendor exception.
 
 1. Publisher enables rules within Prebid.js configuration. 
 2. Label Permutive as an exception, as shown below.

--- a/dev-docs/modules/tcfControl.md
+++ b/dev-docs/modules/tcfControl.md
@@ -73,8 +73,8 @@ The following fields related to anonymizing aspects of the auction are supported
 | gdpr.rules[].purpose | `String` | Supported values: "storage" (Purpose 1), "basicAds" (Purpose 2), "personalizedAds" (purpose 4), "measurement" (Purpose 7), "transmitPreciseGeo" (Special Feature 1) | "storage" |
 | gdpr.rules[].enforcePurpose | `Boolean` | Determines whether to enforce the purpose consent. The default in Prebid.js 3.x was not to enforce any purposes. Prebid.js 4.0 and later require legal basis for Purposes 1 and 2 by default. | true |
 | gdpr.rules[].enforceVendor | `Boolean` | Determines whether to check vendor signals for this purpose. The default in Prebid.js 3.x is not to check vendor signals. Prebid.js 4.0 and later require legal basis for Purposes 1 and 2 by default. | true |
-| gdpr.rules[].vendorExceptions | `Array of Strings` | Defines a list of biddercodes or module names that are exempt from determining legal basis for this Purpose. | ["bidderA", "userID-module-B"] |
-| gdpr.rules[].softVendorExceptions | `Array of Strings` | Defines a list of biddercodes or module names that are exempt from the checking vendor signals for this purpose. Unlike with `vendorExceptions`, Purpose consent is still checked. | ["bidderA", "userID-module-B"] |
+| gdpr.rules[].vendorExceptions | `Array of Strings` | Defines a list of biddercodes or module names that are exempt from determining legal basis for this Purpose. **Note:** Prebid.org recommends working with a privacy lawyer before making enforcement exceptions for any vendor. | ["bidderA", "userID-module-B"] |
+| gdpr.rules[].softVendorExceptions | `Array of Strings` | Defines a list of biddercodes or module names that are exempt from the checking vendor signals for this purpose. Unlike with `vendorExceptions`, Purpose consent is still checked. **Note:** Prebid.org recommends working with a privacy lawyer before making enforcement exceptions for any vendor. | ["bidderA", "userID-module-B"] |
 | gdpr.rules[].eidsRequireP4Consent | `Boolean` | Only relevant on the personalizedAds `purpose`. If true, user IDs and EIDs will not be shared without evidence of consent for TCF Purpose 4. If false, evidence of consent for any of Purposes 2-10 is sufficient for sharing user IDs and EIDs. Defaults to false. See [note](#note-transmitEids) | true |
 | strictStorageEnforcement | `Boolean` | If false (the default), allows some use of storage regardless of purpose 1 consent - see [note](#strictStorageEnforcement) below | true |
 
@@ -87,7 +87,7 @@ Notes:
 ```javascript
 pbjs.setConfig({
     gvlMapping: {
-    bidderA: 12345,
+        bidderA: 12345,
         bidderB: 67890
     }
 });
@@ -97,6 +97,9 @@ pbjs.setConfig({
 
 The following examples cover a range of use cases and show how Prebid.js supports
 configuration of different business rules.
+
+{: .alert.alert-warning :}
+Prebid.org recommends working with a privacy lawyer before making enforcement exceptions for any vendor.
 
 1. Restrict device access activity and basic ads. These are the default values (in Prebid.js 4.0) if the module is included in the build.
 
@@ -152,9 +155,9 @@ configuration of different business rules.
         enforcePurpose: true,
         enforceVendor: true
       },{
-    purpose: "basicAds",
-    enforcePurpose: true,
-    enforceVendor: true,
+        purpose: "basicAds",
+        enforcePurpose: true,
+        enforceVendor: true,
         vendorExceptions: ["firstPartyBidder"]
       }]
     ```
@@ -178,7 +181,7 @@ configuration of different business rules.
         purpose: "measurement",
         enforcePurpose: true,
         enforceVendor: true,
-    vendorExceptions: ["analyticsB"]
+        vendorExceptions: ["analyticsB"]
       }]
     ```
 

--- a/dev-docs/modules/userid-submodules/utiq.md
+++ b/dev-docs/modules/userid-submodules/utiq.md
@@ -42,6 +42,9 @@ If you use the Prebid.js [TCF Control Module](/dev-docs/modules/tcfControl.html)
 
 To do that, you can use below configuration:
 
+{: .alert.alert-warning :}
+Prebid.org recommends working with a privacy lawyer before making enforcement exceptions for any vendor.
+
 ```javascript
 pbjs.setConfig({
   consentManagement: {


### PR DESCRIPTION
We had a publisher who wanted to make a vendorException for Utiq with the rationale that "Prebid says it's ok because it's in the docs". That's incorrect. Vendors can ask for exceptions, but it has to be completely clear that Prebid is not condoning their exception.