### PR TITLE
New RTD submodule: optableRtdProvider

### DIFF
--- a/dev-docs/modules/optableRtdProvider.md
+++ b/dev-docs/modules/optableRtdProvider.md
@@ -121,7 +121,21 @@ async function sha256(input) {
 | params                   | Object   |                                                                                                                                                                                                        |                  |          |
 | params.bundleUrl         | String   | Optable bundle URL                                                                                                                                                                                     | `null`           | Optional |
 | params.adserverTargeting | Boolean  | If set to `true`, targeting keywords will be passed to the ad server upon auction completion                                                                                                           | `true`           | Optional |
-| params.handleRtd         | Function | A function to handle RTD data. If not provided, the module will use the default handler. The function signature is `[async] (optableBundle, reqBidsConfigObj, userConsent, mergeFn, optableLog) => {}` | `null`           | Optional |
+| params.handleRtd         | Function | An optional function that uses Optable data to enrich `reqBidsConfigObj` with the real-time data. If not provided, the module will do a default call to Optable bundle. The function signature is `[async] (reqBidsConfigObj, mergeFn) => {}` | `null`           | Optional |
+
+## Publisher Customized RTD Handler Function
+
+When there is more pre-processing or post-processing needed prior/post calling Optable bundle - a custom `handleRtd` function can be supplied to do that. This function will also be responsible for the `reqBidsConfigObj` enrichment.  `mergeFn` parameter taken by `handleRtd` is a standard Prebid.js utility function that take an object to be enriched and an object to enrich with: the second object's fields will be merged into the first one (also see the code of an example mentioned below):
+
+```
+mergeFn(
+  reqBidsConfigObj.ortb2Fragments.global, // or other nested object as needed
+  rtdData,
+);
+
+```
+
+A `handleRtd` function implementation has access to its surrounding context including capturing a `pbjs` object, calling `pbjs.getConfig()` and f.e. reading off the `consentManagement` config to make the appropriate decision based on it.
 
 ## Example
 

--- a/dev-docs/modules/optableRtdProvider.md
+++ b/dev-docs/modules/optableRtdProvider.md
@@ -74,9 +74,9 @@ pbjs.setConfig({
 Optable bundle may use PPIDs (publisher provided IDs) from the `user.ext.eids` as input.
 In addition other arbitrary keys can be used as input, f.e. the following:
 
-- `user.ext.optable.email` - a SHA256-hashed user email
-- `user.ext.optable.phone` - a SHA256-hashed [E.164 normalized phone](https://unifiedid.com/docs/getting-started/gs-normalization-encoding#phone-number-normalization) (meaning a phone number consisting of digits and leading plus sign without spaces or any additional characters, f.e. a US number would be: `+12345678999`)
-- `user.ext.optable.postal_code` - a ZIP postal code string
+* `user.ext.optable.email` - a SHA256-hashed user email
+* `user.ext.optable.phone` - a SHA256-hashed [E.164 normalized phone](https://unifiedid.com/docs/getting-started/gs-normalization-encoding#phone-number-normalization) (meaning a phone number consisting of digits and leading plus sign without spaces or any additional characters, f.e. a US number would be: `+12345678999`)
+* `user.ext.optable.postal_code` - a ZIP postal code string
 
 Each of these identifiers is completely optional and can be provided through `pbjs.mergeConfig` like so:
 
@@ -112,25 +112,24 @@ To handle PPIDs and the above input - a custom `handleRtd` function may need to 
 
 {: .table .table-bordered .table-striped }
 
-| Name                     | Type     | Description                                                                                                                                                                                            | Default          | Notes    |
-|--------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|----------|
-| name                     | String   | Real time data module name                                                                                                                                                                             | Always `optable` |          |
-| waitForIt                | Boolean  | Should be set `true` together with `auctionDelay: 1000`                                                                                                                                                | `false`          |          |
-| params                   | Object   |                                                                                                                                                                                                        |                  |          |
-| params.bundleUrl         | String   | Optable bundle URL                                                                                                                                                                                     | `null`           | Optional |
-| params.adserverTargeting | Boolean  | If set to `true`, targeting keywords will be passed to the ad server upon auction completion                                                                                                           | `true`           | Optional |
+| Name                     | Type     | Description                                                                                                                                                                                                                                   | Default          | Notes    |
+|--------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|----------|
+| name                     | String   | Real time data module name                                                                                                                                                                                                                    | Always `optable` |          |
+| waitForIt                | Boolean  | Should be set `true` together with `auctionDelay: 1000`                                                                                                                                                                                       | `false`          |          |
+| params                   | Object   |                                                                                                                                                                                                                                               |                  |          |
+| params.bundleUrl         | String   | Optable bundle URL                                                                                                                                                                                                                            | `null`           | Optional |
+| params.adserverTargeting | Boolean  | If set to `true`, targeting keywords will be passed to the ad server upon auction completion                                                                                                                                                  | `true`           | Optional |
 | params.handleRtd         | Function | An optional function that uses Optable data to enrich `reqBidsConfigObj` with the real-time data. If not provided, the module will do a default call to Optable bundle. The function signature is `[async] (reqBidsConfigObj, mergeFn) => {}` | `null`           | Optional |
 
 ## Publisher Customized RTD Handler Function
 
 When there is more pre-processing or post-processing needed prior/post calling Optable bundle - a custom `handleRtd` function can be supplied to do that. This function will also be responsible for the `reqBidsConfigObj` enrichment.  `mergeFn` parameter taken by `handleRtd` is a standard Prebid.js utility function that take an object to be enriched and an object to enrich with: the second object's fields will be merged into the first one (also see the code of an example mentioned below):
 
-```
+```javascript
 mergeFn(
   reqBidsConfigObj.ortb2Fragments.global, // or other nested object as needed
   rtdData,
 );
-
 ```
 
 A `handleRtd` function implementation has access to its surrounding context including capturing a `pbjs` object, calling `pbjs.getConfig()` and f.e. reading off the `consentManagement` config to make the appropriate decision based on it.

--- a/dev-docs/modules/optableRtdProvider.md
+++ b/dev-docs/modules/optableRtdProvider.md
@@ -75,7 +75,7 @@ Optable bundle may use PPIDs (publisher provided IDs) from the `user.ext.eids` a
 In addition other arbitrary keys can be used as input, f.e. the following:
 
 - `user.ext.optable.email` - a SHA256-hashed user email
-- `user.ext.optable.phone` - a SHA256-hashed [E.164 normalized phone]() (meaning a phone number consisting of digits only without spaces or any additional characters, f.e. a US number would be: `12345678999`)
+- `user.ext.optable.phone` - a SHA256-hashed [E.164 normalized phone](https://unifiedid.com/docs/getting-started/gs-normalization-encoding#phone-number-normalization) (meaning a phone number consisting of digits and leading plus sign without spaces or any additional characters, f.e. a US number would be: `+12345678999`)
 - `user.ext.optable.postal_code` - a ZIP postal code string
 
 Each of these identifiers is completely optional and can be provided through `pbjs.mergeConfig` like so:

--- a/dev-docs/modules/optableRtdProvider.md
+++ b/dev-docs/modules/optableRtdProvider.md
@@ -114,13 +114,14 @@ async function sha256(input) {
 
 {: .table .table-bordered .table-striped }
 
-| Name                     | Type    | Description                                                                                  | Default          |
-|--------------------------|---------|----------------------------------------------------------------------------------------------|------------------|
-| name                     | String  | Real time data module name                                                                   | Always `optable` |
-| waitForIt                | Boolean | Should be set `true` together with auctionDelay: 1000                                        | `false`          |
-| params                   | Object  |                                                                                              |                  |
-| params.bundleUrl         | String  | Optable bundle URL                                                                           | `null`           |
-| params.adserverTargeting | Boolean | If set to `true`, targeting keywords will be passed to the ad server upon auction completion | `true`           |
+| Name                     | Type     | Description                                                                                                                                                                                            | Default          | Notes    |
+|--------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|----------|
+| name                     | String   | Real time data module name                                                                                                                                                                             | Always `optable` |          |
+| waitForIt                | Boolean  | Should be set `true` together with `auctionDelay: 1000`                                                                                                                                                | `false`          |          |
+| params                   | Object   |                                                                                                                                                                                                        |                  |          |
+| params.bundleUrl         | String   | Optable bundle URL                                                                                                                                                                                     | `null`           | Optional |
+| params.adserverTargeting | Boolean  | If set to `true`, targeting keywords will be passed to the ad server upon auction completion                                                                                                           | `true`           | Optional |
+| params.handleRtd         | Function | A function to handle RTD data. If not provided, the module will use the default handler. The function signature is `[async] (optableBundle, reqBidsConfigObj, userConsent, mergeFn, optableLog) => {}` | `null`           | Optional |
 
 ## Example
 

--- a/dev-docs/modules/optableRtdProvider.md
+++ b/dev-docs/modules/optableRtdProvider.md
@@ -22,7 +22,7 @@ This module may load a publisher-specific JavaScript bundle. The external resour
 
 ## Description
 
-Optable RTD submodule enriches the OpenRTB request by populating `user.ext.eids` and `user.ext.data` using an identity graph and audience segmentation service hosted by Optable on behalf of the publisher. This RTD submodule primarily relies on the Optable bundle loaded on the page, which leverages the Optable-specific Visitor ID and other PPIDs to interact with the identity graph, enriching the bid request with additional user IDs and audience data.
+Optable RTD submodule enriches the OpenRTB request by populating `user.ext.eids` and `user.data` using an identity graph and audience segmentation service hosted by Optable on behalf of the publisher. This RTD submodule primarily relies on the Optable bundle loaded on the page, which leverages the Optable-specific Visitor ID and other PPIDs to interact with the identity graph, enriching the bid request with additional user IDs and audience data.
 
 ## Usage
 

--- a/dev-docs/modules/optableRtdProvider.md
+++ b/dev-docs/modules/optableRtdProvider.md
@@ -106,7 +106,7 @@ async function sha256(input) {
 }
 ```
 
-To handle PPIDs and the above input - a custom `handleRtd` function may need to be provided.
+To handle PPIDs and the above input - a custom `handleRtd` function may need to be provided. In the custom `handleRtd` implementation make sure to erase any `user.ext.optable` fields not meant to be propagated to the bidders.
 
 ### Parameters
 

--- a/dev-docs/modules/optableRtdProvider.md
+++ b/dev-docs/modules/optableRtdProvider.md
@@ -12,7 +12,7 @@ sidebarType : 1
 ---
 
 {: .alert.alert-warning :}
-This module may load a publisher-specific JavaScript bundle.  The external resource provides flexibility in ID handling without the need to modify the RTD submodule source code.
+This module may load a publisher-specific JavaScript bundle. The external resource provides flexibility in ID handling without the need to modify the RTD submodule source code.
 
 # Optable RTD Submodule
 {:.no_toc}
@@ -31,77 +31,78 @@ Optable module enriches an OpenRTB request by setting `user.ext.eids` and `user.
 Compile the Optable RTD Module with other modules and adapters into your Prebid.js build:
 
 ```bash
-gulp build --modules="rtdModule,optableRtdProvider,appnexusBidAdapter,..."  
+gulp build --modules="rtdModule,optableRtdProvider,appnexusBidAdapter,..."
 ```
 
 > Note that Optable RTD module is dependent on the global real-time data module, `rtdModule`.
 
 ### Preloading Optable SDK bundle
 
-In order to use the module you first need to register with Optable and obtain a bundle URL.  The bundle URL may be specified as a `bundleUrl` parameter to the script, or otherwise it can be added directly to the page source as:
+In order to use the module you first need to register with Optable and obtain a bundle URL. The bundle URL may be specified as a `bundleUrl` parameter to the script, or otherwise it can be added directly to the page source as:
 
-```
-<script async src="<bundleURL>" />
+```html
+<script async src="<bundleURL>"></script>
 ```
 
 In this case bundleUrl parameter is not needed and the script will await bundle loading before delegating to it.
 
 ### Configuration
 
-This module is configured as part of the `realTimeData.dataProviders`.  We recommend setting `auctionDelay` to 1000 ms and make sure `waitForIt` is set to `true` for the `Optable` RTD provider.
+This module is configured as part of the `realTimeData.dataProviders`. We recommend setting `auctionDelay` to 1000 ms and make sure `waitForIt` is set to `true` for the `Optable` RTD provider.
 
 ```javascript
 pbjs.setConfig({
-    debug: true, // we recommend turning this on for testing as it adds more logging
-    realTimeData: {
-        auctionDelay: 1000,
-        dataProviders: [
-            {
-                name: 'optable',
-                waitForIt: true, // should be true, otherwise the auctionDelay will be ignored
-                params: {
-                    bundleUrl: '<optional your bundle url>',
-                    adserverTargeting: '<optional, false by default, set to true to also set GAM targeting keywords to ad slots>',
-                    ppidMapping: { 
-                        // optional mapping between eids sources and optable custom identifier names
-                        "example.com": "c0",
-                        "source-id.com": "c1", //...
-                    }
-                },
-            },
-        ],
-    },
+  debug: true, // we recommend turning this on for testing as it adds more logging
+  realTimeData: {
+    auctionDelay: 1000,
+    dataProviders: [
+      {
+        name: 'optable',
+        waitForIt: true, // should be true, otherwise the auctionDelay will be ignored
+        params: {
+          bundleUrl: '<optional, your bundle url>',
+          adserverTargeting: '<optional, true by default, set to true to also set GAM targeting keywords to ad slots>',
+          ppidMapping: {
+            // optional mapping between eids sources and optable custom identifier names
+            "example.com": "c0",
+            "source-id.com": "c1", //...
+          }
+        },
+      },
+    ],
+  },
 });
 ```
 
 ### Additional input to the module
 
-Besides PPID (publisher provided IDs) in the `user.ext.eids` the module will pick up the following keys: 
+Besides PPID (publisher provided IDs) in the `user.ext.eids` the module will pick up the following keys:
+
 - `user.ext.optable.email` - a SHA256-hashed user email
 - `user.ext.optable.phone` - a SHA256-hashed [E.164 normalized phone]() (meaning a phone number consisting of digits only without spaces or any additional characters, f.e. a US number would be: `12345678999`)
 - `user.ext.optable.postal_code` - a ZIP postal code string
 
-Each of these identifiers is completely optional and can be provided through `pbjs.mergeConfig` like so: 
+Each of these identifiers is completely optional and can be provided through `pbjs.mergeConfig` like so:
 
-```
+```javascript
 pbjs.mergeConfig({
-    ortb2: {
-        user: {
-            ext: {
-                optable: {
-                    email: await sha256("test@example.com"),
-                    phone: await sha256("12345678999"),
-                    postal_code: "61054"
-                }
-            }
+  ortb2: {
+    user: {
+      ext: {
+        optable: {
+          email: await sha256("test@example.com"),
+          phone: await sha256("12345678999"),
+          postal_code: "61054"
         }
+      }
     }
+  }
 })
 ```
 
-Where `sha256` function can be defined as: 
+Where `sha256` function can be defined as:
 
-```
+```javascript
 async function sha256(input) {
   return [...new Uint8Array(
     await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input))
@@ -109,26 +110,29 @@ async function sha256(input) {
 }
 ```
 
-### Parameters 
+### Parameters
 
 {: .table .table-bordered .table-striped }
-| Name                  | Type    | Description                                                                                      | Default            |
-|:----------------------|:--------|:-------------------------------------------------------------------------------------------------|:-------------------|
-| name                  | String  | Real time data module name                                                                       | Always 'optable' |
-| waitForIt             | Boolean | Should be set `true` together with auctionDelay: 1000                   | `false` |
-| params                | Object  |                                                                                                  |                    |
-| params.bundleUrl    | String  | Optable bundle URL                                                        | '' |
-| params.adserverTargeting | boolean  | If set to `true` targeting keywords will be passed to the ad server upon auction completion | false |
 
-## Example 
+| Name                     | Type    | Description                                                                                  | Default          |
+|--------------------------|---------|----------------------------------------------------------------------------------------------|------------------|
+| name                     | String  | Real time data module name                                                                   | Always `optable` |
+| waitForIt                | Boolean | Should be set `true` together with auctionDelay: 1000                                        | `false`          |
+| params                   | Object  |                                                                                              |                  |
+| params.bundleUrl         | String  | Optable bundle URL                                                                           | `null`           |
+| params.adserverTargeting | Boolean | If set to `true`, targeting keywords will be passed to the ad server upon auction completion | `true`           |
+
+## Example
 
 If you want to see an example of how the optable RTD module works, run the following command:
 
-`gulp serve --modules=rtdModule,optableRtdProvider,consentManagementTcf,tcfControl, consentManagementGpp,appnexusBidAdapter`
+```bash
+gulp serve --modules=optableRtdProvider,consentManagementGpp,consentManagementTcf,appnexusBidAdapter
+```
 
 and then open the following URL in your browser:
 
-`http://localhost:9999/integrationExamples/gpt/optableRtdProvider_example.html`
+[`http://localhost:9999/integrationExamples/gpt/optableRtdProvider_example.html`](http://localhost:9999/integrationExamples/gpt/optableRtdProvider_example.html)
 
 Open the browser console to see the logs.
 
@@ -137,5 +141,3 @@ Open the browser console to see the logs.
 Any suggestions or questions can be directed to [prebid@optable.co](mailto:prebid@optable.co).
 
 Alternatively please open a new [issue](https://github.com/prebid/prebid-server-java/issues/new) or [pull request](https://github.com/prebid/prebid-server-java/pulls) in this repository.
-
-

--- a/dev-docs/modules/optableRtdProvider.md
+++ b/dev-docs/modules/optableRtdProvider.md
@@ -61,7 +61,7 @@ pbjs.setConfig({
                 waitForIt: true, // should be true, otherwise the auctionDelay will be ignored
                 params: {
                     bundleUrl: '<optional your bundle url>',
-                    gamTargeting: '<optional, false by default, set to true to also set GAM targeting keywords to ad slots>',
+                    adserverTargeting: '<optional, false by default, set to true to also set GAM targeting keywords to ad slots>',
                     ppidMapping: { 
                         // optional mapping between eids sources and optable custom identifier names
                         "example.com": "c0",
@@ -118,7 +118,7 @@ async function sha256(input) {
 | waitForIt             | Boolean | Should be set `true` together with auctionDelay: 1000                   | `false` |
 | params                | Object  |                                                                                                  |                    |
 | params.bundleUrl    | String  | Optable bundle URL                                                        | '' |
-| params.gamTargeting | boolean  | If set to `true` targeting keywords will be passed to GAM ad units | false |
+| params.adserverTargeting | boolean  | If set to `true` targeting keywords will be passed to the ad server upon auction completion | false |
 | params.ppidMapping | map  | Optional mapping between PPID sources and custom identifier names  | null |
 
 ## Example 

--- a/dev-docs/modules/optableRtdProvider.md
+++ b/dev-docs/modules/optableRtdProvider.md
@@ -72,26 +72,20 @@ pbjs.setConfig({
 ### Additional input to the module
 
 Optable bundle may use PPIDs (publisher provided IDs) from the `user.ext.eids` as input.
-In addition other arbitrary keys can be used as input, f.e. the following:
+In addition, other arbitrary keys can be used as input, f.e. the following:
 
-* `user.ext.optable.email` - a SHA256-hashed user email
-* `user.ext.optable.phone` - a SHA256-hashed [E.164 normalized phone](https://unifiedid.com/docs/getting-started/gs-normalization-encoding#phone-number-normalization) (meaning a phone number consisting of digits and leading plus sign without spaces or any additional characters, f.e. a US number would be: `+12345678999`)
-* `user.ext.optable.postal_code` - a ZIP postal code string
+* `optableRtdConfig.email` - a SHA256-hashed user email
+* `optableRtdConfig.phone` - a SHA256-hashed [E.164 normalized phone](https://unifiedid.com/docs/getting-started/gs-normalization-encoding#phone-number-normalization) (meaning a phone number consisting of digits and leading plus sign without spaces or any additional characters, f.e. a US number would be: `+12345678999`)
+* `optableRtdConfig.postal_code` - a ZIP postal code string
 
-Each of these identifiers is completely optional and can be provided through `pbjs.mergeConfig` like so:
+Each of these identifiers is completely optional and can be provided through `pbjs.mergeConfig(...)` like so:
 
 ```javascript
 pbjs.mergeConfig({
-  ortb2: {
-    user: {
-      ext: {
-        optable: {
-          email: await sha256("test@example.com"),
-          phone: await sha256("12345678999"),
-          postal_code: "61054"
-        }
-      }
-    }
+  optableRtdConfig: {
+    email: await sha256("test@example.com"),
+    phone: await sha256("12345678999"),
+    postal_code: "61054"
   }
 })
 ```
@@ -106,24 +100,31 @@ async function sha256(input) {
 }
 ```
 
-To handle PPIDs and the above input - a custom `handleRtd` function may need to be provided. In the custom `handleRtd` implementation make sure to erase any `user.ext.optable` fields not meant to be propagated to the bidders.
+To handle PPIDs and the above input - a custom `handleRtd` function may need to be provided.
 
 ### Parameters
 
 {: .table .table-bordered .table-striped }
 
-| Name                     | Type     | Description                                                                                                                                                                                                                                   | Default          | Notes    |
-|--------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|----------|
-| name                     | String   | Real time data module name                                                                                                                                                                                                                    | Always `optable` |          |
-| waitForIt                | Boolean  | Should be set `true` together with `auctionDelay: 1000`                                                                                                                                                                                       | `false`          |          |
-| params                   | Object   |                                                                                                                                                                                                                                               |                  |          |
-| params.bundleUrl         | String   | Optable bundle URL                                                                                                                                                                                                                            | `null`           | Optional |
-| params.adserverTargeting | Boolean  | If set to `true`, targeting keywords will be passed to the ad server upon auction completion                                                                                                                                                  | `true`           | Optional |
-| params.handleRtd         | Function | An optional function that uses Optable data to enrich `reqBidsConfigObj` with the real-time data. If not provided, the module will do a default call to Optable bundle. The function signature is `[async] (reqBidsConfigObj, mergeFn) => {}` | `null`           | Optional |
+| Name                     | Type     | Description                                                                                                                                                                                                                                                     | Default          | Notes    |
+|--------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|----------|
+| name                     | String   | Real time data module name                                                                                                                                                                                                                                      | Always `optable` |          |
+| waitForIt                | Boolean  | Should be set `true` together with `auctionDelay: 1000`                                                                                                                                                                                                         | `false`          |          |
+| params                   | Object   |                                                                                                                                                                                                                                                                 |                  |          |
+| params.bundleUrl         | String   | Optable bundle URL                                                                                                                                                                                                                                              | `null`           | Optional |
+| params.adserverTargeting | Boolean  | If set to `true`, targeting keywords will be passed to the ad server upon auction completion                                                                                                                                                                    | `true`           | Optional |
+| params.handleRtd         | Function | An optional function that uses Optable data to enrich `reqBidsConfigObj` with the real-time data. If not provided, the module will do a default call to Optable bundle. The function signature is `[async] (reqBidsConfigObj, optableExtraData, mergeFn) => {}` | `null`           | Optional |
 
 ## Publisher Customized RTD Handler Function
 
-When there is more pre-processing or post-processing needed prior/post calling Optable bundle - a custom `handleRtd` function can be supplied to do that. This function will also be responsible for the `reqBidsConfigObj` enrichment.  `mergeFn` parameter taken by `handleRtd` is a standard Prebid.js utility function that take an object to be enriched and an object to enrich with: the second object's fields will be merged into the first one (also see the code of an example mentioned below):
+When there is more pre-processing or post-processing needed prior/post calling Optable bundle - a custom `handleRtd`
+function can be supplied to do that.
+This function will also be responsible for the `reqBidsConfigObj` enrichment.
+It will also receive the `optableExtraData` object, which can contain the extra data required for the enrichment and
+shouldn't be shared with other RTD providers/bidders.
+`mergeFn` parameter taken by `handleRtd` is a standard Prebid.js utility function that take an object to be enriched and
+an object to enrich with: the second object's fields will be merged into the first one (also see the code of an example
+mentioned below):
 
 ```javascript
 mergeFn(

--- a/dev-docs/modules/optableRtdProvider.md
+++ b/dev-docs/modules/optableRtdProvider.md
@@ -1,0 +1,134 @@
+---
+layout: page_v2
+title: Optable RTD Provider Module
+display_name: Optable RTD Module
+description: Optable Real Time Data Module
+page_type: module
+module_type: rtd
+module_code : optable
+enable_download : true
+vendor_specific: true
+sidebarType : 1
+---
+
+{: .alert.alert-warning :}
+This module may load a publisher-specific JavaScript bundle.  The external resource provides flexibility in ID handling without the need to modify the RTD submodule source code.
+
+# Optable RTD Submodule
+{:.no_toc}
+
+* TOC
+{:toc}
+
+## Description
+
+Optable module enriches an OpenRTB request by setting `user.ext.eids` and `user.ext.data` using an identity graph and audience segments service hosted by Optable on behalf of the publisher. As input the module may consume user's sha256-hashed email, phone, post_code or (non-hashed) publisher provided identifiers (PPIDs).
+
+## Usage
+
+### Integration
+
+Compile the Optable RTD Module with other modules and adapters into your Prebid.js build:
+
+```bash
+gulp build --modules="rtdModule,optableRtdProvider,appnexusBidAdapter,..."  
+```
+
+> Note that Optable RTD module is dependent on the global real-time data module, `rtdModule`.
+
+### Preloading Optable SDK bundle
+
+In order to use the module you first need to register with Optable and obtain a bundle URL.  The bundle URL may be specified as a `bundleUrl` parameter to the script, or otherwise it can be added directly to the page source as:
+
+```
+<script async src="<bundleURL>" />
+```
+
+In this case bundleUrl parameter is not needed and the script will await bundle loading before delegating to it.
+
+### Configuration
+
+This module is configured as part of the `realTimeData.dataProviders`.  We recommend setting `auctionDelay` to 1000 ms and make sure `waitForIt` is set to `true` for the `Optable` RTD provider.
+
+```javascript
+pbjs.setConfig({
+    debug: true, // we recommend turning this on for testing as it adds more logging
+    realTimeData: {
+        auctionDelay: 1000,
+        dataProviders: [
+            {
+                name: 'optable',
+                waitForIt: true, // should be true, otherwise the auctionDelay will be ignored
+                params: {
+                    bundleUrl: '<optional your bundle url>',
+                    propagateTargeting: '<optional, false by default, set to true to also set GAM targeting keywords to ad slots>',
+                    ppid_mapping: { 
+                        // optional mapping between eids sources and optable custom identifier names
+                        "example.com": "c0",
+                        "source-id.com": "c1", //...
+                    }
+                },
+            },
+        ],
+    },
+});
+```
+
+### Additional input to the module
+
+Besides PPID (publisher provided IDs) in the `user.ext.eids` the module will pick up the following keys: 
+- `user.ext.optable.email` - a SHA256-hashed user email
+- `user.ext.optable.phone` - a SHA256-hashed [E.164 normalized phone]() (meaning a phone number consisting of digits only without spaces or any additional characters, f.e. a US number would be: `12345678999`)
+- `user.ext.optable.postal_code` - a ZIP postal code string
+
+Each of these identifiers is completely optional and can be provided through `pbjs.mergeConfig` like so: 
+
+```
+pbjs.mergeConfig({
+    ortb2: {
+        user: {
+            ext: {
+                optable: {
+                    email: await sha256("test@example.com"),
+                    phone: await sha256("12345678999"),
+                    postal_code: "61054"
+                }
+            }
+        }
+    }
+})
+```
+
+Where `sha256` function can be defined as: 
+
+```
+async function sha256(input) {
+  return [...new Uint8Array(
+    await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input))
+  )].map(b => b.toString(16).padStart(2, "0")).join("");
+}
+```
+
+### Parameters 
+
+{: .table .table-bordered .table-striped }
+| Name                  | Type    | Description                                                                                      | Default            |
+|:----------------------|:--------|:-------------------------------------------------------------------------------------------------|:-------------------|
+| name                  | String  | Real time data module name                                                                       | Always 'optable' |
+| waitForIt             | Boolean | Should be set `true` together with auctionDelay: 1000                   | `false` |
+| params                | Object  |                                                                                                  |                    |
+| params.bundleUrl    | String  | Optable bundle URL                                                        | '' |
+| params.propagateTargeting | boolean  | If set to `true` targeting keywords will be passed to GAM ad units | false |
+| params.ppid_mapping | map  | Optional mapping between PPID sources and custom identifier names  | null |
+
+## Example 
+
+If you want to see an example of how the optable RTD module works, run the following command:
+
+`gulp serve --modules=rtdModule,optableRtdProvider,appnexusBidAdapter`
+
+and then open the following URL in your browser:
+
+`http://localhost:9999/integrationExamples/gpt/optableRtdProvider_example.html`
+
+Open the browser console to see the logs.

--- a/dev-docs/modules/optableRtdProvider.md
+++ b/dev-docs/modules/optableRtdProvider.md
@@ -61,8 +61,8 @@ pbjs.setConfig({
                 waitForIt: true, // should be true, otherwise the auctionDelay will be ignored
                 params: {
                     bundleUrl: '<optional your bundle url>',
-                    propagateTargeting: '<optional, false by default, set to true to also set GAM targeting keywords to ad slots>',
-                    ppid_mapping: { 
+                    gamTargeting: '<optional, false by default, set to true to also set GAM targeting keywords to ad slots>',
+                    ppidMapping: { 
                         // optional mapping between eids sources and optable custom identifier names
                         "example.com": "c0",
                         "source-id.com": "c1", //...
@@ -118,8 +118,8 @@ async function sha256(input) {
 | waitForIt             | Boolean | Should be set `true` together with auctionDelay: 1000                   | `false` |
 | params                | Object  |                                                                                                  |                    |
 | params.bundleUrl    | String  | Optable bundle URL                                                        | '' |
-| params.propagateTargeting | boolean  | If set to `true` targeting keywords will be passed to GAM ad units | false |
-| params.ppid_mapping | map  | Optional mapping between PPID sources and custom identifier names  | null |
+| params.gamTargeting | boolean  | If set to `true` targeting keywords will be passed to GAM ad units | false |
+| params.ppidMapping | map  | Optional mapping between PPID sources and custom identifier names  | null |
 
 ## Example 
 

--- a/dev-docs/modules/optableRtdProvider.md
+++ b/dev-docs/modules/optableRtdProvider.md
@@ -119,16 +119,23 @@ async function sha256(input) {
 | params                | Object  |                                                                                                  |                    |
 | params.bundleUrl    | String  | Optable bundle URL                                                        | '' |
 | params.adserverTargeting | boolean  | If set to `true` targeting keywords will be passed to the ad server upon auction completion | false |
-| params.ppidMapping | map  | Optional mapping between PPID sources and custom identifier names  | null |
 
 ## Example 
 
 If you want to see an example of how the optable RTD module works, run the following command:
 
-`gulp serve --modules=rtdModule,optableRtdProvider,appnexusBidAdapter`
+`gulp serve --modules=rtdModule,optableRtdProvider,consentManagementTcf,tcfControl, consentManagementGpp,appnexusBidAdapter`
 
 and then open the following URL in your browser:
 
 `http://localhost:9999/integrationExamples/gpt/optableRtdProvider_example.html`
 
 Open the browser console to see the logs.
+
+## Maintainer contacts
+
+Any suggestions or questions can be directed to [prebid@optable.co](mailto:prebid@optable.co).
+
+Alternatively please open a new [issue](https://github.com/prebid/prebid-server-java/issues/new) or [pull request](https://github.com/prebid/prebid-server-java/pulls) in this repository.
+
+

--- a/dev-docs/modules/optableRtdProvider.md
+++ b/dev-docs/modules/optableRtdProvider.md
@@ -22,7 +22,7 @@ This module may load a publisher-specific JavaScript bundle. The external resour
 
 ## Description
 
-The Optable module enhances an OpenRTB request by populating `user.ext.eids` and `user.ext.data` using an identity graph and audience segmentation service hosted by Optable on behalf of the publisher. This RTD submodule primarily relies on the Optable bundle loaded on the page, which leverages the Optable-specific Visitor ID and other PPIDs to interact with the identity graph, enriching the bid request with additional user IDs and audience data.
+Optable RTD submodule enriches the OpenRTB request by populating `user.ext.eids` and `user.ext.data` using an identity graph and audience segmentation service hosted by Optable on behalf of the publisher. This RTD submodule primarily relies on the Optable bundle loaded on the page, which leverages the Optable-specific Visitor ID and other PPIDs to interact with the identity graph, enriching the bid request with additional user IDs and audience data.
 
 ## Usage
 

--- a/dev-docs/modules/optableRtdProvider.md
+++ b/dev-docs/modules/optableRtdProvider.md
@@ -22,7 +22,7 @@ This module may load a publisher-specific JavaScript bundle. The external resour
 
 ## Description
 
-Optable module enriches an OpenRTB request by setting `user.ext.eids` and `user.ext.data` using an identity graph and audience segments service hosted by Optable on behalf of the publisher. As input the module may consume user's sha256-hashed email, phone, post_code or (non-hashed) publisher provided identifiers (PPIDs).
+The Optable module enhances an OpenRTB request by populating `user.ext.eids` and `user.ext.data` using an identity graph and audience segmentation service hosted by Optable on behalf of the publisher. This RTD submodule primarily relies on the Optable bundle loaded on the page, which leverages the Optable-specific Visitor ID and other PPIDs to interact with the identity graph, enriching the bid request with additional user IDs and audience data.
 
 ## Usage
 
@@ -62,11 +62,6 @@ pbjs.setConfig({
         params: {
           bundleUrl: '<optional, your bundle url>',
           adserverTargeting: '<optional, true by default, set to true to also set GAM targeting keywords to ad slots>',
-          ppidMapping: {
-            // optional mapping between eids sources and optable custom identifier names
-            "example.com": "c0",
-            "source-id.com": "c1", //...
-          }
         },
       },
     ],
@@ -76,7 +71,8 @@ pbjs.setConfig({
 
 ### Additional input to the module
 
-Besides PPID (publisher provided IDs) in the `user.ext.eids` the module will pick up the following keys:
+Optable bundle may use PPIDs (publisher provided IDs) from the `user.ext.eids` as input.
+In addition other arbitrary keys can be used as input, f.e. the following:
 
 - `user.ext.optable.email` - a SHA256-hashed user email
 - `user.ext.optable.phone` - a SHA256-hashed [E.164 normalized phone]() (meaning a phone number consisting of digits only without spaces or any additional characters, f.e. a US number would be: `12345678999`)
@@ -109,6 +105,8 @@ async function sha256(input) {
   )].map(b => b.toString(16).padStart(2, "0")).join("");
 }
 ```
+
+To handle PPIDs and the above input - a custom `handleRtd` function may need to be provided.
 
 ### Parameters
 


### PR DESCRIPTION
Optable RTD submodule enriches the OpenRTB request by populating user.ext.eids and user.ext.data using an identity graph and audience segmentation service hosted by Optable on behalf of the publisher. This RTD submodule primarily relies on the Optable bundle loaded on the page, which leverages the Optable-specific Visitor ID and other PPIDs to interact with the identity graph, enriching the bid request with additional user IDs and audience data.

## 🏷 Type of documentation
- [x] new RTD submodule


## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked -> https://github.com/prebid/Prebid.js/pull/12850
