### PR TITLE
Add vendor-exceptions include

### DIFF
--- a/_includes/dev-docs/vendor-exception.md
+++ b/_includes/dev-docs/vendor-exception.md
@@ -1,0 +1,3 @@
+{: .alert.alert-warning :}
+Prebid.org recommends working with a privacy lawyer before making enforcement exceptions for any vendor.
+{% if include.gvlId %}We recommend publishers let Prebid.js make use of their registered GVL ID {{ include.gvlId }} instead of a vendor exception.{% endif %}

--- a/dev-docs/modules/permutiveRtdProvider.md
+++ b/dev-docs/modules/permutiveRtdProvider.md
@@ -60,6 +60,7 @@ as well as enabling settings for specific use cases mentioned above (e.g. acbidd
 ## Parameters
 
 {: .table .table-bordered .table-striped }
+
 | Name                   | Type                 | Description                                                                                   | Default            |
 | ---------------------- | -------------------- | --------------------------------------------------------------------------------------------- | ------------------ |
 | name                   | String               | This should always be `permutive`                                                             | -                  |
@@ -78,8 +79,7 @@ If you are also using the [TCF Control Module](/dev-docs/modules/tcfControl.html
 
 ### Instructions
 
-{: .alert.alert-warning :}
-Prebid.org recommends working with a privacy lawyer before making enforcement exceptions for any vendor. Specifically for Permutive, we recommend publishers let Prebid.js make use of their registered GVL ID 361 instead of a vendor exception.
+{% include dev-docs/vendor-exception.md gvlId="361" %}
 
 1. Publisher enables rules within Prebid.js configuration. 
 2. Label Permutive as an exception, as shown below.

--- a/dev-docs/modules/tcfControl.md
+++ b/dev-docs/modules/tcfControl.md
@@ -40,6 +40,7 @@ The TCF Control Module adds the following:
 The following table details the Prebid.js activities that fall under the [Transparency and Consent Framework (TCF)](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/) scope:
 
 {: .table .table-bordered .table-striped }
+
 | In-Scope Activity | TCF Legal Basis Required | Activity | Prebid.js Version |
 | --- | --- | --- | --- |
 | Invoke usersync pixels | Purpose 1 - Store and/or access information on a device | May prevent one or more vendor usersyncs. | 3.14+ |
@@ -67,6 +68,7 @@ and (2) setConfig `consentManagement.gdpr.cmpApi` to either 'iab' or 'static'
 The following fields related to anonymizing aspects of the auction are supported in the [`consentManagement`](/dev-docs/modules/consentManagementTcf.html) object:
 
 {: .table .table-bordered .table-striped }
+
 | Param | Type | Description | Example |
 | --- | --- | --- | --- |
 | gdpr.rules | `Array of Objects` | Lets the publisher override the default behavior. | |
@@ -98,8 +100,7 @@ pbjs.setConfig({
 The following examples cover a range of use cases and show how Prebid.js supports
 configuration of different business rules.
 
-{: .alert.alert-warning :}
-Prebid.org recommends working with a privacy lawyer before making enforcement exceptions for any vendor.
+{% include dev-docs/vendor-exception.md %}
 
 1. Restrict device access activity and basic ads. These are the default values (in Prebid.js 4.0) if the module is included in the build.
 

--- a/dev-docs/modules/userid-submodules/utiq.md
+++ b/dev-docs/modules/userid-submodules/utiq.md
@@ -42,8 +42,7 @@ If you use the Prebid.js [TCF Control Module](/dev-docs/modules/tcfControl.html)
 
 To do that, you can use below configuration:
 
-{: .alert.alert-warning :}
-Prebid.org recommends working with a privacy lawyer before making enforcement exceptions for any vendor.
+{% include dev-docs/vendor-exception.md %}
 
 ```javascript
 pbjs.setConfig({

--- a/guide.md
+++ b/guide.md
@@ -326,6 +326,22 @@ The docs offer a set of predefined disclosures that should be used where appropr
 {%raw%}{% include legal-warning.html %}{%endraw%}
 ```
 
+#### Vendor exception disclosure
+
+{% include dev-docs/vendor-exception.md %}
+
+```liquid
+{%raw%}{% include dev-docs/vendor-exception.md %}{%endraw%}
+```
+
+You can also add a `gvlId` parameter if the vendor has in fact an ID.
+
+{% include dev-docs/vendor-exception.md gvlId="123" %}
+
+```liquid
+{%raw%}{% include dev-docs/vendor-exception.md gvlId="123" %}{%endraw%}
+```
+
 ## Partners
 
 TBD


### PR DESCRIPTION
This creates a separate include for the vendor exception warning added in #5862 by @bretg

## 🏷 Type of documentation

- [x] new feature
