### PR TITLE
Fix typo in renderer.md

### DIFF
--- a/dev-docs/renderer.md
+++ b/dev-docs/renderer.md
@@ -30,7 +30,7 @@ In simple terms, a renderer offers publishers:
 
 Renderers can be specified at multiple levels:
 
-1. MediaType Level (adUnit.mediaTypes.video|banner|native.renderer): If a renderer is associated with a specific mediaType (video, banner, or native), it will be used to display any demand associated with that mediaType. This is the preferred method for all ad types.
+1. MediaType Level (adUnit.mediaTypes.video\|banner\|native.renderer): If a renderer is associated with a specific mediaType (video, banner, or native), it will be used to display any demand associated with that mediaType. This is the preferred method for all ad types.
 2. AdUnit Level (adUnit.renderer): Applied to all bids for this ad unit that don't override it. This is a legacy approach; using the mediaType-level renderer is preferred.
 3. Bidder Level (adUnit.bids[].renderer): Applied only to this bidder, overriding adUnit renderer if both exist.
 4. Default: If no renderer is specified at any level, Prebid will use the default renderer for the media type, if one exists. For banner and native ads, Prebid.js has built-in default rendering capabilities.


### PR DESCRIPTION
## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [x] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

Problem: useless table because of unescaped `|` in text.

<img width="1573" alt="Screenshot 2025-04-09 at 18 07 11" src="https://github.com/user-attachments/assets/24f1c5bd-cdb4-4304-a203-7ac7d8b299cf" />