### PR TITLE
updated prev auct info docs to include the new highestBidCurrency field

### DIFF
--- a/dev-docs/modules/previousAuctionInfo.md
+++ b/dev-docs/modules/previousAuctionInfo.md
@@ -62,6 +62,7 @@ ortb2: {
           source: "pbjs",
           adUnitCode: "div-gpt-ad-123-0",
           highestBidCpm: 0.052275935, // default is null
+          highestBidCurrency: "USD", // default is null
           bidderCpm: 0.04, // default is null
           bidderOriginalCpm: 0.04, // default is null
           bidderCurrency: "USD", // default is null
@@ -87,6 +88,7 @@ ortb2: {
 | ortb2.ext.prebid.previousauctioninfo[].source | string | Where the previous auction info was collected |  |
 | ortb2.ext.prebid.previousauctioninfo[].adUnitCode | string | Ad unit code of the ad slot that was bid on |  |
 | ortb2.ext.prebid.previousauctioninfo[].highestBidCpm | float | The highest Prebid bid cpm observed for the relative ad slot of a previous auction | null |
+| ortb2.ext.prebid.previousauctioninfo[].highestBidCurrency | string | The currency of the highest Prebid bid observed for an ad slot of a previous auction | null |
 | ortb2.ext.prebid.previousauctioninfo[].bidderCpm | float | The bid cpm submitted by the bidder receiving the previous auction info payload | null |
 | ortb2.ext.prebid.previousauctioninfo[].bidderOriginalCpm | float | The original bid cpm submitted by the bidder receiving the previous auction info payload | null |
 | ortb2.ext.prebid.previousauctioninfo[].bidderCurrency | string | The bidder currency submitted by the bidder receiving the previous auction info payload | null |

--- a/dev-docs/modules/previousAuctionInfo.md
+++ b/dev-docs/modules/previousAuctionInfo.md
@@ -67,7 +67,7 @@ ortb2: {
           bidderOriginalCpm: 0.04, // default is null
           bidderCurrency: "USD", // default is null
           bidderOriginalCurrency: "USD", // default is null
-          bidderErrorCode: -1, // default is null
+          rejectionReason: "Invalid request ID", // default is null
           timestamp: 1739400860310
         }
       ]
@@ -93,5 +93,5 @@ ortb2: {
 | ortb2.ext.prebid.previousauctioninfo[].bidderOriginalCpm | float | The original bid cpm submitted by the bidder receiving the previous auction info payload | null |
 | ortb2.ext.prebid.previousauctioninfo[].bidderCurrency | string | The bidder currency submitted by the bidder receiving the previous auction info payload | null |
 | ortb2.ext.prebid.previousauctioninfo[].bidderOriginalCurrency | string | The original bidder currency submitted by the bidder receiving the previous auction info payload | null |
-| ortb2.ext.prebid.previousauctioninfo[].bidderErrorCode | integer | Whether an error was present or not | null |
+| ortb2.ext.prebid.previousauctioninfo[].rejectionReason | string | The error reason, if one was present | null |
 | ortb2.ext.prebid.previousauctioninfo[].timestamp | integer | Time that the previous auction info payload was collected |  |


### PR DESCRIPTION
- added information to the previous auction info module about the new highestBidCurrency field that is now being collected in previous auction info payloads

## 🏷 Type of documentation
- [x] new examples

## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
