### PR TITLE
docs for gzip support for bid requests

### DIFF
--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -273,15 +273,15 @@ Building the request will use data from several places:
 
 #### Compression Support for Outgoing Requests
 
-Prebid.js core now includes support for gzip compression of bidder request payloads (This can help reduce payload size and improve performance).
+Prebid.js core now includes support for gzip compression of bidder request payloads (This helps reduce payload size and improve performance).
 
-The following criteria must be met for a request to be compressed:
+Prebid will pass compressed payloads if the following criteria are met:
 
-* Browser supports gzip compression
-* Participating bidders have enabled compression support within their bid adapter by updating their outgoing bidder requests to include `request.options.endpointCompression = true`
+* `request.options.endpointCompression = true` is set by a bidder with outgoing requests (An example of this can be viewed [here](https://github.com/prebid/Prebid.js/blob/master/modules/pubmaticBidAdapter.js#L730))
+* The browser supports gzip compression (Prebid core has a built-in utility function to check this)
 * Participating bidders have implemented compression support on their server-side endpoint
 
-If the above criteria is met, Prebid core will automatically compress outgoing data payloads.
+If the above criteria is met, the new Gzip compression can be utilized.
 
 Note: If the Prebid.js debugging query param `?pbjs_debug=true` is present in the URL or `debug: true` has been configured in `pbjs.setConfig()`, the gzip compression feature will be disabled and all bidder requests will be sent uncompressed.
 

--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -271,6 +271,20 @@ Building the request will use data from several places:
 * **BidRequest Params**: Several important parameters such as first-party data, userId, GDPR, USP, and supply chain values are on the `bidderRequest` object.
 * **Prebid Config**: Publishers can set a number of config values that bid adapters should consider reading.
 
+#### Compression Support for Outgoing Requests
+
+Prebid.js core now includes support for gzip compression of bidder request payloads (This can help reduce payload size and improve performance).
+
+The following criteria must be met for a request to be compressed:
+
+* Browser supports gzip compression
+* Participating bidders have enabled compression support within their bid adapter by updating their outgoing bidder requests to include `request.options.endpointCompression = true`
+* Participating bidders have implemented compression support on their server-side endpoint
+
+If the above criteria is met, Prebid core will automatically compress outgoing data payloads.
+
+Note: If the Prebid.js debugging query param `?pbjs_debug=true` is present in the URL or `debug: true` has been configured in `pbjs.setConfig()`, the gzip compression feature will be disabled and all bidder requests will be sent uncompressed.
+
 #### Ad Unit Params in the validBidRequests Array
 
 Here is a sample array entry for `validBidRequests[]`:

--- a/dev-docs/bidders/pubmatic.md
+++ b/dev-docs/bidders/pubmatic.md
@@ -229,7 +229,5 @@ AdUnit-specific data is supported using `AdUnit.ortb2Imp.ext.*`
 
 ### Endpoint Compression
 
-If the browser a Prebid auction is running in supports gzip compression, the PubMatic bid adapter will automatically compress all outgoing bid requests to the PubMatic server-side endpoint (which provides support for receiving gzip compressed requests). If gzip compression is not supported by the browser, bid requests will be sent uncompressed.
-
-Note: If the Prebid.js debugging query param, `?pbjs_debug=true`, is present in the URL, the feature will be disabled and all bid requests will be sent uncompressed.
+This adapter utilizes gzip compression support built into Prebid.js core. For more information, see [Compression Support for Outgoing Requests](https://docs.prebid.org/dev-docs/bidder-adaptor.html#compression-support-for-outgoing-requests)
 <!-- workaround bug where code blocks at end of a file are incorrectly formatted-->

--- a/dev-docs/bidders/pubmatic.md
+++ b/dev-docs/bidders/pubmatic.md
@@ -226,4 +226,10 @@ Publishers should use the `ortb2` method of setting [First Party Data](https://d
 - `ortb2.user.*`
 
 AdUnit-specific data is supported using `AdUnit.ortb2Imp.ext.*`
+
+### Endpoint Compression
+
+If the browser a Prebid auction is running in supports gzip compression, the PubMatic bid adapter will automatically compress all outgoing bid requests to the PubMatic server-side endpoint (which provides support for receiving gzip compressed requests). If gzip compression is not supported by the browser, bid requests will be sent uncompressed.
+
+Note: If the Prebid.js debugging query param, `?pbjs_debug=true`, is present in the URL, the feature will be disabled and all bid requests will be sent uncompressed.
 <!-- workaround bug where code blocks at end of a file are incorrectly formatted-->

--- a/dev-docs/publisher-api-reference/bidderSettings.md
+++ b/dev-docs/publisher-api-reference/bidderSettings.md
@@ -48,6 +48,7 @@ Some sample scenarios where publishers may wish to alter the default settings:
 | allowAlternateBidderCodes | standard or adapter-specific | 6.23.0 | true in v6.x <br /> false from v7.0| Allow adapters to bid with alternate bidder codes. |  
 | allowedAlternateBidderCodes | standard or adapter-specific | 6.23.0 | n/a | Array of bidder codes for which an adapter can bid. <br />`undefined` or `['*']` will allow adapter to bid with any bidder code. |
 | adjustAlternateBids | standard or adapter-specific | 7.48.0 | false | Optionally allow alternate bidder codes to use an adapter's bidCpmAdjustment function by default instead of the standard bidCpmAdjustment function if present (note: if a bidCpmAdjustment function exists for the alternate bidder code within bidderSettings, then this will be used instead of falling back to the adapter's bidCpmAdjustment function). |
+| endpointCompression | standard or adapter-specific | 9.42.0 | false | Compresses bid requests sent to bidder endpoints using gzip if browser supports it (`note: bidder endpoints must support gzip compressed bid requests`). |
 
 ##### 2.1. adserverTargeting
 
@@ -343,5 +344,31 @@ pbjs.bidderSettings = {
 ```
 
 In the above example, if PubMatic were to return the "groupm" bidder code then the bidCpmAdjustment function under `pubmatic` would be used instead of what is available under `standard`.
+
+##### 2.11. endpointCompression
+
+{: .alert.alert-warning :}
+Note: The bidder's endpoint must already support receiving gzip compressed bid requests (otherwise this feature will not work and most likely throw an error with the bidder's endpoint).
+
+If this setting is enabled (`true`), Prebid.js will attempt to gzip-compress bid requests sent to bidder endpoints when possible.
+
+Compression is performed client-side using the browser's [CompressionStream](https://developer.mozilla.org/en-US/docs/Web/API/CompressionStream) API, if available. If CompressionStream is not supported by the user's browser, the bid request will be sent uncompressed.
+
+This setting can be enabled either:
+
+- globally for all bidders (under the `standard` section), or
+- specifically for one or more bidders.
+
+The default value is `false`, meaning requests are not compressed unless explicitly configured by the publisher.
+
+**Example enabling endpoint compression for a specific bidder (PubMatic):**
+
+```javascript
+pbjs.bidderSettings = {
+  pubmatic: {
+    endpointCompression: true
+  }
+};
+```
 
 <hr class="full-rule" />

--- a/dev-docs/publisher-api-reference/bidderSettings.md
+++ b/dev-docs/publisher-api-reference/bidderSettings.md
@@ -48,7 +48,6 @@ Some sample scenarios where publishers may wish to alter the default settings:
 | allowAlternateBidderCodes | standard or adapter-specific | 6.23.0 | true in v6.x <br /> false from v7.0| Allow adapters to bid with alternate bidder codes. |  
 | allowedAlternateBidderCodes | standard or adapter-specific | 6.23.0 | n/a | Array of bidder codes for which an adapter can bid. <br />`undefined` or `['*']` will allow adapter to bid with any bidder code. |
 | adjustAlternateBids | standard or adapter-specific | 7.48.0 | false | Optionally allow alternate bidder codes to use an adapter's bidCpmAdjustment function by default instead of the standard bidCpmAdjustment function if present (note: if a bidCpmAdjustment function exists for the alternate bidder code within bidderSettings, then this will be used instead of falling back to the adapter's bidCpmAdjustment function). |
-| endpointCompression | standard or adapter-specific | 9.42.0 | false | Compresses bid requests sent to bidder endpoints using gzip if browser supports it (`note: bidder endpoints must support gzip compressed bid requests`). |
 
 ##### 2.1. adserverTargeting
 
@@ -344,31 +343,5 @@ pbjs.bidderSettings = {
 ```
 
 In the above example, if PubMatic were to return the "groupm" bidder code then the bidCpmAdjustment function under `pubmatic` would be used instead of what is available under `standard`.
-
-##### 2.11. endpointCompression
-
-{: .alert.alert-warning :}
-Note: The bidder's endpoint must already support receiving gzip compressed bid requests (otherwise this feature will not work and most likely throw an error with the bidder's endpoint).
-
-If this setting is enabled (`true`), Prebid.js will attempt to gzip-compress bid requests sent to bidder endpoints when possible.
-
-Compression is performed client-side using the browser's [CompressionStream](https://developer.mozilla.org/en-US/docs/Web/API/CompressionStream) API, if available. If CompressionStream is not supported by the user's browser, the bid request will be sent uncompressed.
-
-This setting can be enabled either:
-
-* globally for all bidders (under the `standard` section), or
-* specifically for one or more bidders.
-
-The default value is `false`, meaning requests are not compressed unless explicitly configured by the publisher.
-
-**Example enabling endpoint compression for a specific bidder (PubMatic):**
-
-```javascript
-pbjs.bidderSettings = {
-  pubmatic: {
-    endpointCompression: true
-  }
-};
-```
 
 <hr class="full-rule" />

--- a/dev-docs/publisher-api-reference/bidderSettings.md
+++ b/dev-docs/publisher-api-reference/bidderSettings.md
@@ -356,8 +356,8 @@ Compression is performed client-side using the browser's [CompressionStream](htt
 
 This setting can be enabled either:
 
-- globally for all bidders (under the `standard` section), or
-- specifically for one or more bidders.
+* globally for all bidders (under the `standard` section), or
+* specifically for one or more bidders.
 
 The default value is `false`, meaning requests are not compressed unless explicitly configured by the publisher.
 


### PR DESCRIPTION
Adds documentation for the PBJS endpointCompression bidderSettings feature.  This feature allows Publishers to optionally enables bid requests to be Gzip compressed before being sent out to bid adapter endpoints.

## 🏷 Type of documentation
- [x] new feature

## 📋 Checklist
GH Issue: https://github.com/prebid/Prebid.js/issues/12973
PR: https://github.com/prebid/Prebid.js/pull/13033
