### PR TITLE
One PBS bidder to a page

### DIFF
--- a/dev-docs/pbs-bidders.md
+++ b/dev-docs/pbs-bidders.md
@@ -1,11 +1,11 @@
 ---
 layout: page_v2
-title: Prebid.js Bidder Params
+title: Prebid Server Bidder Params
 description: Documentation on bidders' params
-sidebarType: 1
+sidebarType: 5
 ---
 
-# Prebid.js Bidder Params
+# Prebid Server Bidder Params
 
 This page contains documentation on the specific parameters required by each supported bidder.
 These docs only apply to Prebid Server-based bidders. For Prebid.js, see the
@@ -15,7 +15,7 @@ For each bidder listed below, you'll find the following information:
 
 {: .table .table-bordered .table-striped }
 | **Features**                     | A table of features supported by the adapter.  |
-| **"Send All Bids" Ad Server Keys**  | Used for sending all bids to the ad server, as described in [Send All Bids vs Send Top Price]({{site.baseurl}}/adops/send-all-vs-top-price.html) |
+| **"Send All Bids" Ad Server Keys**  | Used for sending all bids to the ad server, as described in [Send All Bids vs Send Top Price](/adops/send-all-vs-top-price.html) |
 | **Bid Params**                      | Ad request parameters required by a given bidder, such as the tag ID, site ID, or query string parameters                                     |
 
 You can also download the full <a href="/dev-docs/bidder-data.csv" download>CSV data file</a>.
@@ -25,7 +25,7 @@ You can also download the full <a href="/dev-docs/bidder-data.csv" download>CSV 
 {: .alert.alert-warning :}
 Publishers are advised to check with legal counsel before doing business with any particular bidder.
 
-## Search a bidder
+## Search a Prebid Server bidder
 
 <input type="text" id="autocomplete-filter" class="autocomplete-filter">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/awesomplete/1.1.5/awesomplete.min.js" integrity="sha512-HcBl0GSJvt4Qecm4srHapirUx0HJDi2zYXm6KUKNNUGdTIN9cBwakVZHWmRVj4MKgy1AChqhWGYcMDbRKgO0zg==" crossorigin="anonymous"></script>

--- a/dev-docs/pbs-bidders.md
+++ b/dev-docs/pbs-bidders.md
@@ -1,70 +1,135 @@
 ---
 layout: page_v2
-title: Prebid Server Bidder Params
+title: Prebid.js Bidder Params
 description: Documentation on bidders' params
-sidebarType: 5
+sidebarType: 1
 ---
 
-# Prebid Server Bidder Params
+# Prebid.js Bidder Params
 
 This page contains documentation on the specific parameters required by each supported bidder.
-These docs only apply to Prebid Server bidders. For Prebid.js bidders see the
+These docs only apply to Prebid Server-based bidders. For Prebid.js, see the
 [Prebid.js Bidders](/dev-docs/bidders.html) page.
 
 For each bidder listed below, you'll find the following information:
 
 {: .table .table-bordered .table-striped }
 | **Features**                     | A table of features supported by the adapter.  |
-| **"Send All Bids" Ad Server Keys**  | Used for sending all bids to the ad server, as described in [Send All Bids vs Send Top Price](/adops/send-all-vs-top-price.html) |
+| **"Send All Bids" Ad Server Keys**  | Used for sending all bids to the ad server, as described in [Send All Bids vs Send Top Price]({{site.baseurl}}/adops/send-all-vs-top-price.html) |
 | **Bid Params**                      | Ad request parameters required by a given bidder, such as the tag ID, site ID, or query string parameters                                     |
 
 You can also download the full <a href="/dev-docs/bidder-data.csv" download>CSV data file</a>.
 
-{% assign bidder_pages = site.pages | where: "layout", "bidder" | where: "pbs", true %}
+{% assign bidder_pages = site.pages | where: "layout", "bidder" | where: "pbs", true | sort_natural: "title" %}
 
 {: .alert.alert-warning :}
 Publishers are advised to check with legal counsel before doing business with any particular bidder.
 
-## Prebid Server Bidder List
+## Search a bidder
 
-<ul>
+<input type="text" id="autocomplete-filter" class="autocomplete-filter">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/awesomplete/1.1.5/awesomplete.min.js" integrity="sha512-HcBl0GSJvt4Qecm4srHapirUx0HJDi2zYXm6KUKNNUGdTIN9cBwakVZHWmRVj4MKgy1AChqhWGYcMDbRKgO0zg==" crossorigin="anonymous"></script>
+<script>
+var AutocompleteList = [{% for page in bidder_pages %}{ label: '{{ page.title }}', value: '{{ page.url }}' },{% endfor %}];
+</script>
+<script src="{{site.baseurl}}/assets/js/autocomplete.js"></script>
+<div class="c-bidder-list-group" markdown="1">
+
+## Full List
+
+### #-A
+
+<ul class="c-bidder-list">
 {% for page in bidder_pages %}
-<li>
-<a href="#{{ page.biddercode }}">{{ page.title }}</a>
-</li>
+  {% assign firstletter = page.title | slice:0 | downcase %}
+  {% unless firstletter == "0" or firstletter == "1" or firstletter == "2" or firstletter == "3" or firstletter == "4" or firstletter == "5" or firstletter == "6" or firstletter == "7" or firstletter == "8" or firstletter == "9" or firstletter == "a" %}{% continue %}{% endunless %}
+  <li>
+  <a href="{{ page.url }}">{{ page.title }}</a>
+  </li>
 {% endfor %}
 </ul>
 
-## Bidder Documentation
+### B-C
 
+<ul class="c-bidder-list">
 {% for page in bidder_pages %}
-
-<div class="bs-docs-section" markdown="1">
-<a name="{{ page.biddercode }}" ></a>
-<h2>{{ page.title }}</h2>
-
-<h4>Features</h4>
-
-{% include dev-docs/bidder-meta-data.html page=page %}
-
-<h3>"Send All Bids" Ad Server Keys</h3>
-
-<font size="-1">These are the bidder-specific keys that would be targeted within GAM in a Send-All-Bids scenario. GAM truncates keys to 20 characters.</font>
-
-{: .table .table-bordered .table-striped }
-| <code>{{ "hb_pb_" | append: page.biddercode | slice: 0,20 }}</code> | <code>{{ "hb_bidder_" | append: page.biddercode | slice: 0,20 }}</code> | <code>{{ "hb_adid_" | append: page.biddercode | slice: 0,20 }}</code> |
-| <code>{{ "hb_size_" | append: page.biddercode | slice: 0,20 }}</code> | <code>{{ "hb_source_" | append: page.biddercode | slice: 0,20 }}</code> | <code>{{ "hb_format_" | append: page.biddercode | slice: 0,20 }}</code> |
-| <code>{{ "hb_cache_host_" | append: page.biddercode | slice: 0,20 }}</code> | <code>{{ "hb_cache_id_" | append: page.biddercode | slice: 0,20 }}</code> | <code>{{ "hb_uuid_" | append: page.biddercode | slice: 0,20 }}</code> |
-| <code>{{ "hb_cache_path_" | append: page.biddercode | slice: 0,20 }}</code> | <code>{{ "hb_deal_" | append: page.biddercode | slice: 0,20 }}</code> | |
-
-{% if page.prevBiddercode %}
-
-This bidder previously had a bidder code of `{{ page.prevBiddercode }}`, but prefers new configurations to use `{{ page.biddercode }}`.
-
-{% endif %}
-
-{{ page.content }}
-
-</div>
-
+  {% assign firstletter = page.title | slice:0 | downcase %}
+  {% unless firstletter == "b" or firstletter == "c" %}{% continue %}{% endunless %}
+  <li>
+  <a href="{{ page.url }}">{{ page.title }}</a>
+  </li>
 {% endfor %}
+</ul>
+
+### D-G
+
+<ul class="c-bidder-list">
+{% for page in bidder_pages %}
+  {% assign firstletter = page.title | slice:0 | downcase %}
+  {% unless firstletter == "d" or firstletter == "e" or firstletter == "f" or firstletter == "g" %}{% continue %}{% endunless %}
+  <li>
+  <a href="{{ page.url }}">{{ page.title }}</a>
+  </li>
+{% endfor %}
+</ul>
+
+### H-L
+
+<ul class="c-bidder-list">
+{% for page in bidder_pages %}
+  {% assign firstletter = page.title | slice:0 | downcase %}
+  {% unless firstletter == "h" or firstletter == "i" or firstletter == "j" or firstletter == "k" or firstletter == "l" %}{% continue %}{% endunless %}
+  <li>
+  <a href="{{ page.url }}">{{ page.title }}</a>
+  </li>
+{% endfor %}
+</ul>
+
+### M-O
+
+<ul class="c-bidder-list">
+{% for page in bidder_pages %}
+  {% assign firstletter = page.title | slice:0 | downcase %}
+  {% unless firstletter == "m" or firstletter == "n" or firstletter == "o" %}{% continue %}{% endunless %}
+  <li>
+  <a href="{{ page.url }}">{{ page.title }}</a>
+  </li>
+{% endfor %}
+</ul>
+
+### P-R
+
+<ul class="c-bidder-list">
+{% for page in bidder_pages %}
+  {% assign firstletter = page.title | slice:0 | downcase %}
+  {% unless firstletter == "p" or firstletter == "q" or firstletter == "r" %}{% continue %}{% endunless %}
+  <li>
+  <a href="{{ page.url }}">{{ page.title }}</a>
+  </li>
+{% endfor %}
+</ul>
+
+### S-T
+
+<ul class="c-bidder-list">
+{% for page in bidder_pages %}
+  {% assign firstletter = page.title | slice:0 | downcase %}
+  {% unless firstletter == "s" or firstletter == "t" %}{% continue %}{% endunless %}
+  <li>
+  <a href="{{ page.url }}">{{ page.title }}</a>
+  </li>
+{% endfor %}
+</ul>
+
+### U-Z
+
+<ul class="c-bidder-list">
+{% for page in bidder_pages %}
+  {% assign firstletter = page.title | slice:0 | downcase %}
+  {% unless firstletter == "u" or firstletter == "v" or firstletter == "w" or firstletter == "x" or firstletter == "y" or firstletter == "z" %}{% continue %}{% endunless %}
+  <li>
+  <a href="{{ page.url }}">{{ page.title }}</a>
+  </li>
+{% endfor %}
+</ul>
+</div>


### PR DESCRIPTION
## 🏷 Type of documentation
- [ ] new bid adapter
- [ ] update bid adapter
- [X] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

Solves issue https://github.com/prebid/prebid.github.io/issues/4352

The overly-long PBS bidders page may be a cause for why the Algolia crawler results aren't working properly anymore.