### PR TITLE
Start.io Bid Adapter: Enable coppa, usp, floors and ortb_blocking support

### DIFF
--- a/dev-docs/bidders/startio.md
+++ b/dev-docs/bidders/startio.md
@@ -4,21 +4,21 @@ title: Start.io
 biddercode: startio
 description: Prebid Start.io Adapter
 tcfeu_supported: true
-coppa_supported: false
+coppa_supported: true
 gpp_supported: false
-floors_supported: false
+floors_supported: true
 media_types: banner, video, native
 multiformat_supported: will-bid-on-any
 safeframes_ok: false
 schain_supported: false
 gvl_id: 1216
-usp_supported: false
+usp_supported: true
 pbjs: true
 pbs: true
 prebid_member: false
 fpd_supported: false
 privacy_sandbox: no
-ortb_blocking_supported: false
+ortb_blocking_supported: true
 sidebarType: 1
 ---
 


### PR DESCRIPTION
## 🏷 Type of documentation
- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📄 Description of change
Following features are now supported by the the Start.io Prebid.js adapter:
- `coppa_supported`
- `floors_supported`
- `usp_supported`
- `ortb_blocking_supported`

## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked:
https://github.com/prebid/Prebid.js/pull/13433
