### PR TITLE
NewsPassID Adapter: README updates

### DIFF
--- a/dev-docs/bidders/newspassid.md
+++ b/dev-docs/bidders/newspassid.md
@@ -8,6 +8,7 @@ gvl_id: 1317
 tcfeu_supported: true
 usp_supported: true
 coppa_supported: true
+gpp_supported: true
 schain_supported: true
 userIds: all
 safeframes_ok: true
@@ -38,7 +39,7 @@ This requires setup on the NewsPassID provider's end before beginning. Don't hes
 
 ### Integration
 
-#### Step 1: Add your NewsPassID accountId to the Prebid.js bidder config before users syncs and initial ads are requested (Recommended)
+#### Step 1: Configure NewsPassID publisher ID in global pbjs config to enable user syncs (Recommended)
 
 ```javascript
 window.pbjs = window.pbjs || { que: [] };
@@ -67,7 +68,7 @@ const adUnits = [
         bidder: 'newspassid',
         params: {
             publisherId: 'test-publisher', /* an ID to identify the publisher account  - required if you skip step 1 */
-            placementId: 'test-group1' /* An ID used to identify the ad placement configuration within a publisher account - required */                          
+            placementId: 'test-group1' /* An ID used to identify the ad placement configuration - required */                          
         }
       }
     ]


### PR DESCRIPTION
Updating the `newspassid` bid adapter readme:
- Removing `accountId` reference which was meant to be `publisherId` to match the bidder param
- Adding `gpp_supported` flag
- Mild text cleanup for better clarity for users

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [x] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
N/A
