### PR TITLE
humansecurityMalvDefense Rtd Provider: replacement for cleanioRtdProvider

### DIFF
--- a/dev-docs/modules/cleanioRtdProvider.md
+++ b/dev-docs/modules/cleanioRtdProvider.md
@@ -6,10 +6,18 @@ description: clean.io Real-time Anti-Malvertising Module
 page_type: module
 module_type: rtd
 module_code : cleanioRtdProvider
-enable_download : true
+enable_download : false
 vendor_specific: true
 sidebarType : 1
 ---
+
+> **Warning!**
+>
+> The **cleanioRtdProvider** module has been renamed to [humansecurityMalvDefenseRtdProvider](humansecurityMalvDefenseRtdProvider.md) following HUMAN Security's acquisition of the Clean.io project in 2022.
+> **cleanioRtdProvider** module is maintained for backward compatibility until the next major Prebid release.
+>
+> Please use **humansecurityMalvDefenseRtdProvider** instead of **cleanioRtdProvider** in your Prebid integration.
+>
 
 # clean.io Real-time Anti-Malvertising Module
 
@@ -49,6 +57,7 @@ pbjs.setConfig({
 ### Configuration parameters
 
 {: .table .table-bordered .table-striped }
+
 | Name | Type  | Scope | Description |
 | :------------ | :------------ | :------------ |:------------ |
 | ``cdnUrl`` | ``string`` | Required | CDN URL of the script, which is to be used for protection. |
@@ -57,6 +66,7 @@ pbjs.setConfig({
 ## Integration modes
 
 {: .table .table-bordered .table-striped }
+
 | Integration Mode | Parameter Value | Description |
 | :------------ | :------------ | :------------ |
 | Full page protection | ``'full'`` | Preferred mode. The module will add the protector agent script directly to the page, and it will protect all placements. This mode will make the most out of various behavioral detection mechanisms, and will also prevent typical malicious behaviors. Please note that in this mode, depending on Prebid library naming, Chrome may mistakenly tag non-ad-related content as ads: <https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/ad_tagging.md>. |

--- a/dev-docs/modules/cleanioRtdProvider.md
+++ b/dev-docs/modules/cleanioRtdProvider.md
@@ -11,13 +11,14 @@ vendor_specific: true
 sidebarType : 1
 ---
 
-> **Warning!**
->
-> The **cleanioRtdProvider** module has been renamed to [humansecurityMalvDefenseRtdProvider](humansecurityMalvDefenseRtdProvider.md) following HUMAN Security's acquisition of the Clean.io project in 2022.
-> **cleanioRtdProvider** module is maintained for backward compatibility until the next major Prebid release.
->
-> Please use **humansecurityMalvDefenseRtdProvider** instead of **cleanioRtdProvider** in your Prebid integration.
->
+
+{: .alert.alert-warning :}
+**Warning!**
+
+The **cleanioRtdProvider** module has been renamed to [humansecurityMalvDefenseRtdProvider](humansecurityMalvDefenseRtdProvider.md) following HUMAN Security's acquisition of the Clean.io project in 2022.
+ **cleanioRtdProvider** module is maintained for backward compatibility until the next major Prebid release.
+
+Please use **humansecurityMalvDefenseRtdProvider** instead of **cleanioRtdProvider** in your Prebid integration.
 
 # clean.io Real-time Anti-Malvertising Module
 

--- a/dev-docs/modules/cleanioRtdProvider.md
+++ b/dev-docs/modules/cleanioRtdProvider.md
@@ -15,7 +15,7 @@ sidebarType : 1
 {: .alert.alert-warning :}
 **Warning!**
 
-The **cleanioRtdProvider** module has been renamed to [humansecurityMalvDefenseRtdProvider](humansecurityMalvDefenseRtdProvider.md) following HUMAN Security's acquisition of the Clean.io project in 2022.
+The **cleanioRtdProvider** module has been renamed to [humansecurityMalvDefenseRtdProvider](humansecurityMalvDefenseRtdProvider.html) following HUMAN Security's acquisition of the Clean.io project in 2022.
  **cleanioRtdProvider** module is maintained for backward compatibility until the next major Prebid release.
 
 Please use **humansecurityMalvDefenseRtdProvider** instead of **cleanioRtdProvider** in your Prebid integration.

--- a/dev-docs/modules/humansecurityMalvDefenseRtdProvider.md
+++ b/dev-docs/modules/humansecurityMalvDefenseRtdProvider.md
@@ -1,0 +1,74 @@
+---
+layout: page_v2
+title: HUMAN Security Malvertising Defense Real-Time Data Submodule
+display_name: HUMAN Security Malvertising Defense RTD Submodule
+description: The HUMAN Malvertising Defense RTD blocks 0-/1-click redirects and deceptive creatives in real time, lets safe ads render, and can optionally include HUMAN Ad Quality for broader protection.
+page_type: module
+module_type: rtd
+module_code : humansecurityMalvDefense
+enable_download : true
+vendor_specific: true
+sidebarType : 1
+---
+
+# HUMAN Security Malvertising Defense Real-Time Data Submodule
+
+## Overview
+
+The HUMAN Security Malvertising Defense RTD submodule offers a robust, easy-to-implement anti-malvertising solution for publishers. 
+Its automatic updates continuously detect and block on-page malicious ad behaviors — such as unwanted redirects and deceptive ads with harmful landing pages. 
+This safeguards revenue and visitor experience without extra maintenance, and with minimal impact on page load speed and overall site performance. 
+Publishers can also opt in to add HUMAN Ad Quality monitoring for broader protection.
+
+Using this module requires prior agreement with [HUMAN Security](https://www.humansecurity.com/) to obtain the necessary distribution key.
+
+{% include dev-docs/loads-external-javascript.md %}
+
+## Integration
+
+To integrate, add the HUMAN Security Malvertising Defense submodule to your Prebid.js package with:
+
+```bash
+gulp build --modules="rtdModule,humansecurityMalvDefenseRtdProvider,..."
+```
+
+> `rtdModule` is a required module to use HUMAN Security RTD module.
+
+## Configuration
+
+This module is configured as part of the `realTimeData.dataProviders` object.
+
+When built into Prebid.js, this module can be configured through the following `pbjs.setConfig` call:
+
+```javascript
+pbjs.setConfig({
+    realTimeData: {
+        dataProviders: [{
+            name: 'humansecurityMalvDefense',
+            params: {
+                cdnUrl: 'https://cadmus.script.ac/<yourUniqueId>/script.js', // Contact HUMAN Security to get your own CDN URL
+                protectionMode: 'full', // Supported modes are 'full', 'bids' and 'bids-nowait', see below.
+            }
+        }]
+    }
+});
+```
+
+### Configuration parameters
+
+{: .table .table-bordered .table-striped }
+
+| Name | Type | Scope | Description |
+| :------------ | :------------ | :------------ |:------------ |
+| ``cdnUrl`` | ``string`` | Required | CDN URL of the script, which is to be used for protection. |
+| ``protectionMode`` | ``'full'`` or ``'bids'`` or ``'bids-nowait'`` | Required | Integration mode. Please refer to the "Integration modes" section for details. |
+
+### Integration modes
+
+{: .table .table-bordered .table-striped }
+
+| Integration Mode | Parameter Value | Description  |
+| :------------ | :------------ | :------------ |
+| Full page protection | ``'full'`` | Preferred mode. The module will add the protector agent script directly to the page, and it will protect all placements. This mode will make the most out of various behavioral detection mechanisms, and will also prevent typical malicious behaviors. |
+| Bids-only protection | ``'bids'`` | The module will protect specific bid responses - specifically, the HTML that represents the ad payload - by wrapping them with the agent script. Ads served outside of Prebid will not be protected in this mode, as the module can only access ads delivered through Prebid. |
+| Bids-only protection with no delay on bid rendering | ``'bids-nowait'`` | Same as above, but in this mode, the script will also *not* wrap those bid responses, which arrived prior to successful preloading of agent script.   |


### PR DESCRIPTION
## 🏷 Type of documentation
- [x] text edit only (wording, typos)

Submitting update HUMAN Security Malv Defense RTD Submodule documentation alongside the submodule.

In 2022, HUMAN Security acquired the Clean.io project ([link](https://www.humansecurity.com/newsroom/human-acquires-anti-malvertising-leader-cleanio-to-enhance-protection-across-the-media-ecosystem/)). This PR introduces the `humansecurityMalvDefenseRtdModule` as a replacement for `cleanioRtdModule`, with minimal changes aside from naming and CDN links.

`cleanioRtdModule` module is maintained for backward compatibility until the next major Prebid release.

## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked -> https://github.com/prebid/Prebid.js/pull/13517
