### PR TITLE
IntentIq ID: shouldSetPPID parameter documentation

### DIFF
--- a/dev-docs/modules/userid-submodules/intentiq.md
+++ b/dev-docs/modules/userid-submodules/intentiq.md
@@ -61,6 +61,7 @@ Please find below list of parameters that could be used in configuring Intent IQ
 | params.additionalParameters [0].parameterName | Required | String | Name of the custom parameter. This will be sent as a query parameter. | `"abc"` |
 | params.additionalParameters [0].parameterValue | Required | String / Number | Value to assign to the parameter. | `123` |
 | params.additionalParameters [0].destination | Required | Array | Array of numbers either `1` or `0`. Controls where this parameter is sent `[sendWithSync, sendWithVr, winreport]`. | `[1, 0, 0]` |
+| params.shouldSetPPID | Optional | Boolean | Enables the Intent IQ ID to be sent to Google Ad Manager as a Publisher Provided ID (PPID). Requires `gam`<wbr>`ObjectReference` to be provided in the configuration. | `true` |
 
 ### Configuration example
 
@@ -83,6 +84,7 @@ pbjs.setConfig({
                 sourceMetaData: "123.123.123.123", // Optional parameter
                 sourceMetaDataExternal: 123456, // Optional parameter
                 reportMethod: "GET", // Optional parameter
+                shouldSetPPID: true, // Optional parameter
                 additionalParameters: [ // Optional parameter
                     {
                       parameterName: "abc",


### PR DESCRIPTION
Added a new optional parameter `shouldSetPPID` to allow sending the Intent IQ ID to Google Ad Manager as a Publisher Provided ID (PPID), requiring `gamObjectReference` to be set.

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Related pull requests in prebid.js or server are linked -> https://github.com/prebid/Prebid.js/pull/13566