### PR TITLE
Update nextMillennium.md: placement_id to optional

### DIFF
--- a/dev-docs/bidders/nextMillennium.md
+++ b/dev-docs/bidders/nextMillennium.md
@@ -26,7 +26,7 @@ sidebarType: 1
 {: .table .table-bordered .table-striped }
 | Name           | Scope | Description                              | Example   | Type    |
 |----------------+-------+-----------------------------------+-----------+---------|
-| `placement_id` | required | Placement ID, provided by nextMillennium | `'12345'` | String  |
+| `placement_id` | optional | Placement ID, provided by nextMillennium | `'12345'` | String  |
 | `group_id`     | optional | Group ID, provided by nextMillennium     | `'12345'` | String  |
 
 Required one of the two parameters placement_id or group_id.


### PR DESCRIPTION
Only ONE of `placement_id` or `group_id` is required.
Changed `placement_id` to state "optional" so it is less confusing (there is already a note after the table stating that one of them is required)

## 🏷 Type of documentation
- [x] text edit only (wording, typos)