### PR TITLE
Update ix-server.md

### DIFF
--- a/dev-docs/bidders/ix-server.md
+++ b/dev-docs/bidders/ix-server.md
@@ -178,7 +178,7 @@ To call Index from a web browser using Prebid Server, you must first configure P
     ```javascript
     pbjs.setConfig({
         cache: {
-            url: 'https://prebid.adnxs.com/pbc/v1/cache'
+            url: 'https://my-pbs.example.com/cache'
         }
     });
     ```


### PR DESCRIPTION
updated Prebid Cache url

<!--

 In our Prebid.js docs, for using Prebid Cache, we still reference Xandr’s old Prebid Cache url. We’ve been asked to use a generic “replace me” url instead, as MSFT is shutting down their public Prebid Cache. 

⚠️ The documentation is merged after the related code changes are merged and release ⚠️
-->

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [x] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
