### PR TITLE
Updated Multi Format Support field

### DIFF
--- a/dev-docs/bidders/onetag.md
+++ b/dev-docs/bidders/onetag.md
@@ -17,7 +17,7 @@ floors_supported: true
 sidebarType: 1
 coppa_supported: true
 privacy_sandbox: topics
-multiformat_supported: will-bid-on-one
+multiformat_supported: will-bid-on-any
 ---
 
 


### PR DESCRIPTION
Updated Multi Format Support field to "will-bid-on-any" value, in order to reflect backend bidding type.

## 🏷 Type of documentation
- [x] text edit only (wording, typos)