### PR TITLE
Appnexus cache-reference-cleanup

### DIFF
--- a/_includes/video/pb-is-jw01.html
+++ b/_includes/video/pb-is-jw01.html
@@ -44,7 +44,7 @@
         pbjs.setConfig({
           debug: true,
           cache: {
-            url: "https://prebid.adnxs.com/pbc/v1/cache",
+            url: "https://prebid.example.com/pbc/v1/cache",
           },
         });
 

--- a/_includes/video/pb-is-jw02.html
+++ b/_includes/video/pb-is-jw02.html
@@ -48,7 +48,7 @@
         pbjs.setConfig({
           debug: true,
           cache: {
-            url: "https://prebid.adnxs.com/pbc/v1/cache",
+            url: "https://prebid.example.com/pbc/v1/cache",
           },
         });
 

--- a/_includes/video/pb-is-vjs.html
+++ b/_includes/video/pb-is-vjs.html
@@ -65,7 +65,7 @@
         pbjs.setConfig({
           debug: true,
           cache: {
-            url: "https://prebid.adnxs.com/pbc/v1/cache",
+            url: "https://prebid.example.com/pbc/v1/cache",
           },
         });
 

--- a/_includes/video/pb-lf-fw.html
+++ b/_includes/video/pb-lf-fw.html
@@ -95,7 +95,7 @@
         pbjs.setConfig({
           debug: true,
           cache: {
-            url: 'https://prebid.adnxs.com/pbc/v1/cache'
+            url: 'https://prebid.example.com/pbc/v1/cache'
           },
           adpod: {
             brandCategoryExclusion: true

--- a/adops/setting-up-prebid-video-in-freewheel.md
+++ b/adops/setting-up-prebid-video-in-freewheel.md
@@ -136,7 +136,7 @@ The scheme, host, and path should point to your Prebid Server cache. For instanc
 utilize Xandr's AppNexus cache:
 
 ```text
-https://prebid.adnxs.com/pbc/v1/cache
+https://prebid.example.com/pbc/v1/cache
 ```
 
 The query should have one key-value items:
@@ -152,13 +152,13 @@ The second macro, `#{request.keyValue(“hb_cache_id”)`, formats the unique Pr
 In real-time, when the dynamic URL is formatted it will appear like:
 
 ```text
-https://prebid.adnxs.com/pbc/v1/cache?uuid=12.00_391_30s_6c422e51-46cf-4b0a-ae41-64c61c1ca125
+https://prebid.example.com/pbc/v1/cache?uuid=12.00_391_30s_6c422e51-46cf-4b0a-ae41-64c61c1ca125
 ```
 
 In order for the above URL to format correctly ensure that the URL in the text box appears as:  
 
 ```text
-https://prebid.adnxs.com/pbc/v1/cache?uuid=#{ad.placement.name}_#{request.keyValue("hb_cache_id")}
+https://prebid.example.com/pbc/v1/cache?uuid=#{ad.placement.name}_#{request.keyValue("hb_cache_id")}
 ```
 
 Your ad ops should now be completed and set up for premium long-form video.

--- a/assets/js/video/pb-ve-jwplayer-platform-h.js
+++ b/assets/js/video/pb-ve-jwplayer-platform-h.js
@@ -35,7 +35,7 @@ function loadVideoData() {
         pbjs.setConfig({
             debug: true,
             cache: {
-                url: 'https://prebid.adnxs.com/pbc/v1/cache'
+                url: 'https://prebid.example.com/pbc/v1/cache'
             }
         });
 

--- a/dev-docs/bidders/adklip.md
+++ b/dev-docs/bidders/adklip.md
@@ -38,7 +38,7 @@ Note that the Adklip adapter expects a client-side Prebid Cache to be enabled fo
 ```js
 pbjs.setConfig({
     cache: {
-        url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        url: 'https://prebid.example.com/pbc/v1/cache'
     }
 });
 ```

--- a/dev-docs/bidders/aso.md
+++ b/dev-docs/bidders/aso.md
@@ -58,7 +58,7 @@ Note that the Adserver.Online adapter expects a client-side Prebid Cache to be e
 ```js
 pbjs.setConfig({
     cache: {
-        url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        url: 'https://prebid.example.com/pbc/v1/cache'
     }
 });
 ```

--- a/dev-docs/bidders/bcmint.md
+++ b/dev-docs/bidders/bcmint.md
@@ -38,7 +38,7 @@ Note that the BCM International adapter expects a client-side Prebid Cache to be
 ```js
 pbjs.setConfig({
     cache: {
-        url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        url: 'https://prebid.example.com/pbc/v1/cache'
     }
 });
 ```

--- a/dev-docs/bidders/bidgency.md
+++ b/dev-docs/bidders/bidgency.md
@@ -38,7 +38,7 @@ Note that the Bidgency Group adapter expects a client-side Prebid Cache to be en
 ```js
 pbjs.setConfig({
     cache: {
-        url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        url: 'https://prebid.example.com/pbc/v1/cache'
     }
 });
 ```

--- a/dev-docs/bidders/consumable-server.md
+++ b/dev-docs/bidders/consumable-server.md
@@ -125,7 +125,7 @@ To call Consumable from a web browser using Prebid Server, you must first config
    ```javascript
     pbjs.setConfig({
         cache: {
-            url: 'https://prebid.adnxs.com/pbc/v1/cache'
+            url: 'https://prebid.example.com/pbc/v1/cache'
         }
     });
    ```

--- a/dev-docs/bidders/consumable.md
+++ b/dev-docs/bidders/consumable.md
@@ -125,7 +125,7 @@ In this configuration, Prebid.js makes a call to Prebid Server and then Prebid S
    ```javascript
     pbjs.setConfig({
         cache: {
-                url: 'https://prebid.adnxs.com/pbc/v1/cache'
+                url: 'https://prebid.example.com/pbc/v1/cache'
             }
     });
     ```

--- a/dev-docs/bidders/cordless.md
+++ b/dev-docs/bidders/cordless.md
@@ -38,7 +38,7 @@ Note that the Cordless.co adapter expects a client-side Prebid Cache to be enabl
 ```js
 pbjs.setConfig({
     cache: {
-        url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        url: 'https://prebid.example.com/pbc/v1/cache'
     }
 });
 ```

--- a/dev-docs/bidders/epsilon.md
+++ b/dev-docs/bidders/epsilon.md
@@ -89,7 +89,7 @@ Example first party data configuration that is available to all adUnits
 pbjs.setConfig({
     debug: true,
     cache: {
-    url: 'https://prebid.adnxs.com/pbc/v1/cache'
+    url: 'https://prebid.example.com/pbc/v1/cache'
     },
     ortb2: { 
         site: { 

--- a/dev-docs/bidders/kuantyx.md
+++ b/dev-docs/bidders/kuantyx.md
@@ -38,7 +38,7 @@ Note that the Kuantyx adapter expects a client-side Prebid Cache to be enabled f
 ```js
 pbjs.setConfig({
     cache: {
-        url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        url: 'https://prebid.example.com/pbc/v1/cache'
     }
 });
 ```

--- a/dev-docs/bidders/pubmatic.md
+++ b/dev-docs/bidders/pubmatic.md
@@ -178,7 +178,7 @@ For Video ads, prebid cache needs to be enabled for PubMatic adapter.
 ```javascript
 pbjs.setConfig({
     cache: {
-        url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        url: 'https://prebid.example.com/pbc/v1/cache'
     }
 });
 ```

--- a/dev-docs/bidders/showheroes-bs.md
+++ b/dev-docs/bidders/showheroes-bs.md
@@ -126,7 +126,7 @@ pbjs.que.push(function(){
     pbjs.addAdUnits(videoAdUnit);
     pbjs.setConfig({
                 cache: {
-                    url: 'https://prebid.adnxs.com/pbc/v1/cache'
+                    url: 'https://prebid.example.com/pbc/v1/cache'
                 },
                 ...,
             });

--- a/dev-docs/bidders/visx.md
+++ b/dev-docs/bidders/visx.md
@@ -87,7 +87,7 @@ The YOC VIS.X Prebid.js adapter responds with VAST XML (in the `vastXml` field) 
 ```javascript
 pbjs.setConfig({
         cache: {
-            url: 'https://prebid.adnxs.com/pbc/v1/cache'
+            url: 'https://prebid.example.com/pbc/v1/cache'
         }
 });
 ```

--- a/dev-docs/plugins/bc/bc-prebid-plugin-api.md
+++ b/dev-docs/plugins/bc/bc-prebid-plugin-api.md
@@ -130,7 +130,7 @@ If the results of the prebid process is being determined outside of the plugin, 
         }]
     },
     "prebidConfigOptions": {
-        "cache": {"url": "https://prebid.adnxs.com/pbc/v1/cache"},
+        "cache": {"url": "https://prebid.example.com/pbc/v1/cache"},
     "   enableSendAllBids": true
     },
     "prebidTimeout": 700,

--- a/dev-docs/plugins/bc/bc-prebid-plugin-integration-studio.md
+++ b/dev-docs/plugins/bc/bc-prebid-plugin-integration-studio.md
@@ -150,7 +150,7 @@ var adOptions =
         }]
     },
     "prebidConfigOptions": {
-        "cache": {"url": "https://prebid.adnxs.com/pbc/v1/cache"},
+        "cache": {"url": "https://prebid.example.com/pbc/v1/cache"},
         "enableSendAllBids": true
     },
     "prebidTimeout": 700,
@@ -353,7 +353,7 @@ None
     },
     "prebidConfigOptions": {
         "cache": {
-            "url": "https://prebid.adnxs.com/pbc/v1/cache"
+            "url": "https://prebid.example.com/pbc/v1/cache"
         },
         "enableSendAllBids": true
     },

--- a/dev-docs/plugins/bc/bc-prebid-plugin-multiad-options.md
+++ b/dev-docs/plugins/bc/bc-prebid-plugin-multiad-options.md
@@ -109,7 +109,7 @@ The following is a sample JSON definition of the plugin configuration defining c
     },
     "prebidConfigOptions" : {
         "cache": {
-            "url": "https://prebid.adnxs.com/pbc/v1/cache"
+            "url": "https://prebid.example.com/pbc/v1/cache"
         },
         "enableSendAllBids" : true
     },
@@ -204,7 +204,7 @@ The following is a sample JSON definition of the plugin configuration defining c
     },
     "prebidConfigOptions" : {
         "cache": {
-            "url": "https://prebid.adnxs.com/pbc/v1/cache"
+            "url": "https://prebid.example.com/pbc/v1/cache"
         },
         "enableSendAllBids" : true
     },
@@ -310,7 +310,7 @@ The following is a sample JSON definition of the plugin configuration defining c
     },
     "prebidConfigOptions" : {
         "cache": {
-            "url": "https://prebid.adnxs.com/pbc/v1/cache"
+            "url": "https://prebid.example.com/pbc/v1/cache"
         },
         "enableSendAllBids" : true
     },
@@ -406,7 +406,7 @@ The following is a sample JSON definition of the plugin configuration defining c
     },
     "prebidConfigOptions" : {
         "cache": {
-            "url": "https://prebid.adnxs.com/pbc/v1/cache"
+            "url": "https://prebid.example.com/pbc/v1/cache"
         },
         "enableSendAllBids" : true
     },
@@ -502,7 +502,7 @@ The following is a sample JSON definition of the plugin configuration defining c
     },
     "prebidConfigOptions" : {
         "cache": {
-            "url": "https://prebid.adnxs.com/pbc/v1/cache"
+            "url": "https://prebid.example.com/pbc/v1/cache"
         },
         "enableSendAllBids" : true
     },

--- a/dev-docs/plugins/bc/bc-prebid-plugin-sample-studio-integration-general-method.md
+++ b/dev-docs/plugins/bc/bc-prebid-plugin-sample-studio-integration-general-method.md
@@ -72,7 +72,7 @@ This page presents a sample publisher page using the General Integration Method 
             }]
         },
         "prebidConfigOptions": {
-         "cache": {"url": "https://prebid.adnxs.com/pbc/v1/cache"},
+         "cache": {"url": "https://prebid.example.com/pbc/v1/cache"},
         "enableSendAllBids": true
         },
         "prebidTimeout": 700,

--- a/examples/video/instream/jwplayer/pb-ve-jwplayer-hosted.html
+++ b/examples/video/instream/jwplayer/pb-ve-jwplayer-hosted.html
@@ -86,7 +86,7 @@ sidebarType: 4
         pbjs.setConfig({
             debug: true,
             cache: {
-                url: 'https://prebid.adnxs.com/pbc/v1/cache'
+                url: 'https://prebid.example.com/pbc/v1/cache'
             }
         });
 

--- a/examples/video/instream/jwplayer/pb-ve-jwplayer-platform.html
+++ b/examples/video/instream/jwplayer/pb-ve-jwplayer-platform.html
@@ -88,7 +88,7 @@ sidebarType: 4
           pbjs.setConfig({
               debug: true,
               cache: {
-                  url: 'https://prebid.adnxs.com/pbc/v1/cache'
+                  url: 'https://prebid.example.com/pbc/v1/cache'
               }
           });
 

--- a/examples/video/instream/videoModule/videojs/video-module-videojs.html
+++ b/examples/video/instream/videoModule/videojs/video-module-videojs.html
@@ -114,7 +114,7 @@ sidebarType: 4
                         },]
                     },
                     cache: {
-                        url: 'https://prebid.adnxs.com/pbc/v1/cache'
+                        url: 'https://prebid.example.com/pbc/v1/cache'
                     },
                     targetingControls: {
                         allowTargetingKeys: ['BIDDER', 'AD_ID', 'PRICE_BUCKET', 'SIZE', 'DEAL', 'SOURCE', 'FORMAT', 'UUID', 'CACHE_ID', 'CACHE_HOST', 'ADOMAIN']
@@ -227,7 +227,7 @@ sidebarType: 4
         ],
       },
       cache: {
-        url: "https://prebid.adnxs.com/pbc/v1/cache",
+        url: "https://prebid.example.com/pbc/v1/cache",
       },
       targetingControls: {
         allowTargetingKeys: [

--- a/examples/video/instream/videojs/pb-ve-videojs.html
+++ b/examples/video/instream/videojs/pb-ve-videojs.html
@@ -97,7 +97,7 @@ sidebarType: 4
           pbjs.setConfig({
               debug: true,
               cache: {
-                  url: 'https://prebid.adnxs.com/pbc/v1/cache'
+                  url: 'https://prebid.example.com/pbc/v1/cache'
               }
           });
 

--- a/examples/video/long-form/long-form-video-with-freewheel.html
+++ b/examples/video/long-form/long-form-video-with-freewheel.html
@@ -81,7 +81,7 @@
         pbjs.setConfig({
           debug: true,
           cache: {
-            url: 'https://prebid.adnxs.com/pbc/v1/cache'
+            url: 'https://prebid.example.com/pbc/v1/cache'
           },
           adpod: {
             brandCategoryExclusion: true


### PR DESCRIPTION
Replacing remaining documentation references to Appnexus-hosted Prebid Cache with generic examples.