### PR TITLE
fix optable module code to optableRtdProvider

### DIFF
--- a/dev-docs/modules/optableRtdProvider.md
+++ b/dev-docs/modules/optableRtdProvider.md
@@ -5,7 +5,7 @@ display_name: Optable RTD Module
 description: Optable Real Time Data Module
 page_type: module
 module_type: rtd
-module_code : optable
+module_code : optableRtdProvider
 enable_download : true
 vendor_specific: true
 sidebarType : 1


### PR DESCRIPTION
If Optable RTD Provider was selected on the Download Prebid.js page - it tried to include a non-existant module `optable` and failed the build.  Fixed.

## 🏷 Type of documentation
- [x] bugfix in the module metadata