### PR TITLE
fix: pbAdSlot example showing pbjs.addAdUnits as variadic

### DIFF
--- a/features/pbAdSlot.md
+++ b/features/pbAdSlot.md
@@ -113,31 +113,34 @@ In this example, the publisher utilizes the same 'slotname' in the page for mult
 - defineSlot('/1111/homepage', [[728,90]], 'div-j98s9u9usj987665da');
 
 ```javascript
-pbjs.addAdUnits({
-    code: 'div-293rj893p9wje9we9fj',
-    ortb2Imp: {
-        ext: {
-            gpid: "/1111/homepage#300x250",
-            data: {
-                pbadslot: "/1111/homepage#300x250"
+pbjs.addAdUnits([
+    {
+        code: 'div-293rj893p9wje9we9fj',
+        ortb2Imp: {
+            ext: {
+                gpid: "/1111/homepage#300x250",
+                data: {
+                    pbadslot: "/1111/homepage#300x250"
+                }
             }
-        }
+        },
+        mediaTypes: ...
+        bids: ...
     },
-    mediaTypes: ...
-    bids: ...
-},{
-    code: 'div-j98s9u9usj987665da',
-    ortb2Imp: {
-        ext: {
-            gpid: "/1111/homepage#728x90",
-            data: {
-                pbadslot: "/1111/homepage#728x90"
+    {
+        code: 'div-j98s9u9usj987665da',
+        ortb2Imp: {
+            ext: {
+                gpid: "/1111/homepage#728x90",
+                data: {
+                    pbadslot: "/1111/homepage#728x90"
+                }
             }
-        }
-    },
-    mediaTypes: ...
-    bids: ...
-});
+        },
+        mediaTypes: ...
+        bids: ...
+    }
+]);
 ```
 
 ## Prebid Server


### PR DESCRIPTION
I was following along the documentation for pbAdSlot, found the example code was showing `pbjs.addAdUnits(unit1, unit2)` but the function is not variadic. Only takes one argument of AdUnit | Array<AdUnit>.

I also checked the rest of the docs for any other instance of this, however this is the only case I found :) 

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [X] bugfix (code examples)
- [ ] new examples
