### PR TITLE
Update medianet.md: video is optional and not required

### DIFF
--- a/dev-docs/bidders/medianet.md
+++ b/dev-docs/bidders/medianet.md
@@ -36,7 +36,7 @@ endpoint_compression: false
 | `cid`      | required | The customer id provided by Media.net. | `'8CUX0H51C'` | `string` |
 | `crid`     | required | The placement id provided by Media.net | `'1234567'`   | `string` |
 | `bidfloor` | optional | Bidfloor for the impression          | `1.0`         | `float`  |
-| `video`    | required for video Ad units | Object containing video targeting parameters.  See [Video Object](#media.net-video-object) for details.|`video: { maxduration: 60 }`         | `object`  |
+| `video`    | optional for video Ad units | Object containing video targeting parameters.  See [Video Object](#media.net-video-object) for details.|`video: { maxduration: 60 }`         | `object`  |
 
 <a name="media.net-video-object"></a>
 


### PR DESCRIPTION
The `video` in the Bid Params is optional for video ad units and not required.

Reasons:

* The example further down in the docs "Example of Instream Video Ad-unit" doesn't contain a `video` in the bids params.
* The actual code in the bid adapter can deal with missing video. See https://github.com/prebid/Prebid.js/blob/fb3f801f4099798b1dd6e1aeb9e3dfc6e41982c9/modules/medianetBidAdapter.js#L215 :

```javascript
  const videoInMediaType = deepAccess(bidRequest, 'mediaTypes.video') || {};
  const videoInParams = deepAccess(bidRequest, 'params.video') || {};
  const videoCombinedObj = Object.assign({}, videoInParams, videoInMediaType);
```

<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.

⚠️ The documentation is merged after the related code changes are merged and release ⚠️
-->

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [x] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
