### PR TITLE
Adkernel: fix for infinety alias

### DIFF
--- a/dev-docs/bidders/infinety.md
+++ b/dev-docs/bidders/infinety.md
@@ -2,6 +2,7 @@
 layout: bidder
 title: Infinety
 description: Infinety Adaptor
+biddercode: infinety
 aliasCode: adkernel
 tcfeu_supported: true
 dsa_supported: false


### PR DESCRIPTION
Missing field fix for commit https://github.com/prebid/prebid.github.io/pull/6280


## 🏷 Type of documentation
- [x] update bid adapter
