### PR TITLE
Update ttd.md to include the useHttp2 parameter

### DIFF
--- a/dev-docs/bidders/ttd.md
+++ b/dev-docs/bidders/ttd.md
@@ -44,6 +44,7 @@ Name | Scope | Description | Example | Type
 `banner` | optional | Display banner targeting parameters. See the banner section below. | `{}` | `object`
 `bidfloor` | optional | Sets a bid floor price | `0.95` | `Float`
 `customBidderEndpoint` | optional | Only set if TTD has provided a custom endpoint. If set the custom endpoint will take precedent over the hard-coded endpoints | `https://customBidderEndpoint/bid/bidder/` | `String`
+`useHttp2` | optional | When true, the adapter will use an endpoint that supports HTTP2. | `true` | `boolean`
 
 ### Banner Object
 


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.

⚠️ The documentation is merged after the related code changes are merged and release ⚠️
-->

The TTD bid adapter supports a parameter that allows switching between an HTTP2 and an HTTP1 endpoint. See https://github.com/prebid/Prebid.js/blob/master/modules/ttdBidAdapter.js#L286 .
This parameter is missing in the documentation.

This PR adds this parameter.

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
