### PR TITLE
Deprecate 'openwebxchange' bidder page (use 'openweb')

### DIFF
--- a/dev-docs/bidders/openwebxchange.md
+++ b/dev-docs/bidders/openwebxchange.md
@@ -1,9 +1,3 @@
-⚠️ Deprecated
-
-The OpenWebXChange bidder has been deprecated and replaced by the `openweb` adapter.
-Please update your configuration to use the `openweb` bidder moving forward.
-layout: bidder
-pbjs_version_notes: This adapter has been replaced by 'openweb'. Please use the 'openweb' bidder.
 title: OpenWebXChange
 description: Prebid OpenWebXChange Bidder Adapter
 multiformat_supported: will-bid-on-any
@@ -20,8 +14,12 @@ userIds: all
 gvl_id: 280
 sidebarType: 1
 ---
+## Notes
 
-### Note
+{:.alert.alert-warning }
+
+Deprecated!! This bidder has been replaced by the `openweb` adapter.  
+Please use the `openweb` bidder moving forward.
 
 The OpenWebXChange adapter requires setup and approval.
 


### PR DESCRIPTION
This PR marks the 'openwebxchange' bidder as deprecated.
It has been replaced by the maintained 'openweb' bidder, which supports Prebid Server and current configurations.
Submitted by Liran (OpenWeb monetization team).