### PR TITLE
Remove unnecessary flag from Scalibur Prebid adapter documentation

### DIFF
--- a/dev-docs/bidders/scalibur.md
+++ b/dev-docs/bidders/scalibur.md
@@ -5,7 +5,6 @@ description: Prebid Scalibur Bidder Adapter
 biddercode: scalibur
 gvl_id: 1471
 media_types: banner, video
-gpp_supported: true
 gpp_sids: tcfeu, usstate_all, usp
 coppa_supported: true
 schain_supported: true


### PR DESCRIPTION
This PR removes an unnecessary flag from the **Scalibur** Prebid adapter documentation.
The flag was no longer used in the adapter’s implementation and caused potential confusion for users.

### Type of Change

* [x] Documentation update

---

### Additional Context

No functional code changes were made — this update only cleans up outdated documentation for better clarity and accuracy.

---