### PR TITLE
Add filename setting for uniquestWidgetBidAdapter to ensure proper download on download page.

### DIFF
--- a/dev-docs/bidders/uniquestWidget.md
+++ b/dev-docs/bidders/uniquestWidget.md
@@ -3,6 +3,7 @@ layout: bidder
 title: UNIQUEST Widget
 description: Prebid UNIQUEST Widget Bidder Adapter
 biddercode : uniquest_widget
+filename : uniquestWidgetBidAdapter
 pbjs: true
 media_types: banner
 sidebarType: 1


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.

⚠️ The documentation is merged after the related code changes are merged and release ⚠️
-->

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [x] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)

## Other
### Short Description

The adapter appeared on the download page, but downloading a custom Prebid.js bundle resulted in an error unless the `filename` field was explicitly specified.

This update adds the required `filename` setting so that the uniquestWidgetBidAdapter downloads correctly and is properly included in custom builds.