### PR TITLE
Fix default for includebidderkeys & includewinners targeting params

### DIFF
--- a/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.md
+++ b/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.md
@@ -589,8 +589,8 @@ to set these params on the response at `response.seatbid[i].bid[j].ext.prebid.ta
 | mediatypepricegranularity.native | no | Defines how PBS quantizes bid prices into buckets for native. | (see below) | object |
 | mediatypepricegranularity.TYPE.precision | no | How many decimal places are there in price buckets. | Defaults to 2 | integer |
 | mediatypepricegranularity.TYPE.ranges | no | Same as pricegranularity.ranges | (see below) | array of objects |
-| includewinners | no | Whether to include targeting for the winning bids in response.seatbid[].bid[]. ext.prebid.targeting. Defaults to false. | true | boolean |
-| includebidderkeys | no | Whether to include targeting for the best bid from each bidder in response.seatbid[].bid[]. ext.prebid.targeting. Defaults to false. | true | boolean |
+| includewinners | no | Whether to include targeting for the winning bids in response.seatbid[].bid[]. ext.prebid.targeting. Defaults to true. | true | boolean |
+| includebidderkeys | no | Whether to include targeting for the best bid from each bidder in response.seatbid[].bid[]. ext.prebid.targeting. Defaults to true. | true | boolean |
 | includeformat | no | Whether to include the "hb_format" targeting key. Defaults to false. | false | boolean |
 | preferdeals | no | If targeting is returned and this is true, PBS will choose the highest value deal before choosing the highest value non-deal. Defaults to false. | true | boolean |
 | alwaysincludedeals | no | If true, generate hb_ATTR_BIDDER values for all bids that have a dealid | true | boolean |
@@ -611,10 +611,10 @@ to set these params on the response at `response.seatbid[i].bid[j].ext.prebid.ta
                               // "pricegranularity": "medium"
           }]
         },
-        "includewinners": true,     // Optional param defaulting to false
-        "includebidderkeys": false, // Optional param defaulting to false
+        "includewinners": true,     // Optional param defaulting to true
+        "includebidderkeys": false, // Optional param defaulting to true
         "includeformat": false,     // Optional param defaulting to false
-        "preferdeals": true         // Optional param defaulting to false
+        "preferdeals": true,        // Optional param defaulting to false
         "alwaysincludedeals": true  // Optional param defaulting to false
       }
     }
@@ -626,7 +626,7 @@ The list of price granularity ranges must be given in order of increasing `max` 
 
 For backwards compatibility the following strings will also be allowed as price granularity definitions. There is no guarantee that these will be honored in the future. "One of ['low', 'med', 'high', 'auto', 'dense']" See [price granularity definitions](/adops/price-granularity.html).
 
-One of "includewinners" or "includebidderkeys" should be true if you want targeting - both default to false if unset. If both are false, then no targeting keys will be set, which is better configured by omitting targeting altogether.
+One of "includewinners" or "includebidderkeys" should be true if you want targeting - both default to true if unset. If both are true, then all the targeting keys will be set, which is better configured by omitting targeting altogether.
 
 The parameter "includeformat" indicates the type of the bid (banner, video, etc) for multiformat requests. It will add the key `hb_format` and/or `hb_format_{bidderName}` as per "includewinners" and "includebidderkeys" above.
 


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.

⚠️ The documentation is merged after the related code changes are merged and release ⚠️
-->

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] text edit only (wording, typos)
- [x] bugfix (code examples)

The default value for these two targeting params is `true` (when not explicitly set).

In PBS-Go: 

https://github.com/prebid/prebid-server/blob/f358e247272b6d2c3efade217e4cafa1b23762cb/ortb/default.go#L10-L11

In PBS-Java (easier to see in the tests):

https://github.com/prebid/prebid-server-java/blob/01acd952715516a4c80be35f5f1d7fa915e635ad/src/test/java/org/prebid/server/auction/requestfactory/Ortb2ImplicitParametersResolverTest.java#L2065

and

https://github.com/prebid/prebid-server-java/blob/01acd952715516a4c80be35f5f1d7fa915e635ad/src/test/java/org/prebid/server/auction/requestfactory/Ortb2ImplicitParametersResolverTest.java#L1897
