### PR TITLE
51degrees: add ThirdPartyCookiesEnabled support

### DIFF
--- a/dev-docs/modules/51DegreesRtdProvider.md
+++ b/dev-docs/modules/51DegreesRtdProvider.md
@@ -27,7 +27,11 @@ The Cloud API is **free** to integrate and use. To increase limits please check 
 
 51Degrees module enriches an OpenRTB request with [51Degrees Device Data](https://51degrees.com/documentation/index.html).
 
-51Degrees module sets the following fields of the device object: `make`, `model`, `os`, `osv`, `h`, `w`, `ppi`, `pxratio` - interested bidder adapters may use these fields as needed. In addition the module sets `device.ext.fiftyonedegrees.deviceId` to a permanent device ID which can be rapidly looked up in on premise data exposing over 250 properties including the device age, chip set, codec support, and price, operating system and app/browser versions, age, and embedded features. The module also sets `device.ext.fiftyonedegrees.tpc` to indicate whether third-party cookies are enabled in the browser, with possible values of `"True"`, `"False"`, or `"Unknown"` (the latter indicating that a detection attempt was made but failed).
+51Degrees module sets the following fields of the device object: `devicetype`, `make`, `model`, `os`, `osv`, `h`, `w`, `ppi`, `pxratio`. Interested bidder adapters may use these fields as needed. 
+
+The module also adds a `device.ext.fod` extension object (fod == fifty one degrees) and sets `device.ext.fod.deviceId` to a permanent device ID, which can be rapidly looked up in on-premise data, exposing over 250 properties, including device age, chipset, codec support, price, operating system and app/browser versions, age, and embedded features. 
+
+It also sets `device.ext.fod.tpc` key to a binary value to indicate whether third-party cookies are enabled in the browser (1 if enabled, 0 if disabled).
 
 The module supports on premise and cloud device detection services with free options for both. 
 

--- a/dev-docs/modules/51DegreesRtdProvider.md
+++ b/dev-docs/modules/51DegreesRtdProvider.md
@@ -27,11 +27,11 @@ The Cloud API is **free** to integrate and use. To increase limits please check 
 
 51Degrees module enriches an OpenRTB request with [51Degrees Device Data](https://51degrees.com/documentation/index.html).
 
-51Degrees module sets the following fields of the device object: `make`, `model`, `os`, `osv`, `h`, `w`, `ppi`, `pxratio` - interested bidder adapters may use these fields as needed. In addition the module sets `device.ext.fiftyonedegrees_deviceId` to a permanent device ID which can be rapidly looked up in on premise data exposing over 250 properties including the device age, chip set, codec support, and price, operating system and app/browser versions, age, and embedded features.
+51Degrees module sets the following fields of the device object: `make`, `model`, `os`, `osv`, `h`, `w`, `ppi`, `pxratio` - interested bidder adapters may use these fields as needed. In addition the module sets `device.ext.fiftyonedegrees.deviceId` to a permanent device ID which can be rapidly looked up in on premise data exposing over 250 properties including the device age, chip set, codec support, and price, operating system and app/browser versions, age, and embedded features. The module also sets `device.ext.fiftyonedegrees.tpc` to indicate whether third-party cookies are enabled in the browser, with possible values of `"True"`, `"False"`, or `"Unknown"` (the latter indicating that a detection attempt was made but failed).
 
 The module supports on premise and cloud device detection services with free options for both. 
 
-A free resource key for use with 51Degrees cloud service can be obtained from [51Degrees cloud configuration](https://configure.51degrees.com/HNZ75HT1?utm_source=Prebid&utm_medium=Documentation).  This is the simplest approach to trial the module.
+A free resource key for use with 51Degrees cloud service can be obtained from [51Degrees cloud configuration](https://configure.51degrees.com/7bL8jDGz?utm_source=Prebid&utm_medium=Documentation).  This is the simplest approach to trial the module.
 
 An interface compatible self hosted service can be used with .NET, Java, Node, PHP, and Python.  See [51Degrees examples](https://51degrees.com/documentation/_examples__device_detection__getting_started__web__on_premise.html).
 
@@ -53,14 +53,14 @@ gulp build --modules="rtdModule,51DegreesRtdProvider,appnexusBidAdapter,..."
 
 #### Resource Key
 
-In order to use the module please first obtain a Resource Key using the [Configurator tool](https://configure.51degrees.com/HNZ75HT1?utm_source=Prebid&utm_medium=Documentation) - choose the following properties:
+In order to use the module please first obtain a Resource Key using the [Configurator tool](https://configure.51degrees.com/7bL8jDGz?utm_source=Prebid&utm_medium=Documentation) - choose the following properties:
 
 * DeviceId
 * DeviceType
 * HardwareVendor
 * HardwareName
 * HardwareModel
-* PlatformName 
+* PlatformName
 * PlatformVersion
 * ScreenPixelsHeight
 * ScreenPixelsWidth
@@ -69,6 +69,7 @@ In order to use the module please first obtain a Resource Key using the [Configu
 * ScreenInchesHeight
 * ScreenInchesWidth
 * PixelRatio
+* ThirdPartyCookiesEnabled
 
 The Cloud API is **free** to integrate and use. To increase limits please check [51Degrees pricing](https://51degrees.com/pricing).
 
@@ -123,7 +124,7 @@ pbjs.setConfig({
                 waitForIt: true, // should be true, otherwise the auctionDelay will be ignored
                 params: {
                     resourceKey: '<YOUR_RESOURCE_KEY>',
-                    // Get your resource key from https://configure.51degrees.com/HNZ75HT1?utm_source=Prebid&utm_medium=Documentation
+                    // Get your resource key from https://configure.51degrees.com/7bL8jDGz?utm_source=Prebid&utm_medium=Documentation
                     // alternatively, you can use the on-premise version of the 51Degrees service and connect to your chosen end point
                     // onPremiseJSUrl: 'https://localhost/51Degrees.core.js'
                 },


### PR DESCRIPTION
Amending 51DegreesRtdProvider documentation on ThirdPartyCookiesEnabled mapped to `device.ext.fiftyonedegrees.tpc` indicating whether third-party cookies are enabled in the browser. 

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] new feature

## 📋 Checklist
- [x] Related pull requests in prebid.js: https://github.com/prebid/Prebid.js/pull/14262