### PR TITLE
Update getBidResponses.md

### DIFF
--- a/dev-docs/publisher-api-reference/getBidResponses.md
+++ b/dev-docs/publisher-api-reference/getBidResponses.md
@@ -195,7 +195,7 @@ This function returns the bid responses at the given moment.
             "pbLg" : "5.00",
             "width" : 0,
             "requestTimestamp" : 1516315716062,
-            "creativeId" : 81589325,
+            "creativeId" : "81589325",
             "pbCg" : "",
             "adUnitCode" : "div-banner-outstream-native",
             "size" : "0x0",


### PR DESCRIPTION
The creativeId is a string and not a number

At least, it is on my version of Prebid (V9.50). I haven't checked the latest version

<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.

⚠️ The documentation is merged after the related code changes are merged and release ⚠️
-->

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [x] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
