### PR TITLE
alwaysHasCapacity flag

### DIFF
--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -238,7 +238,8 @@ export const spec = {
     onSetTargeting: function(bid) {},
     onBidderError: function({ error, bidderRequest }) {},
     onAdRenderSucceeded: function(bid) {},
-    supportedMediaTypes: [BANNER, VIDEO, NATIVE, AUDIO]
+    supportedMediaTypes: [BANNER, VIDEO, NATIVE, AUDIO],
+    alwaysHasCapacity: true // When true, this bidder will be omitted in checking if origin has http capacity
 }
 registerBidder(spec);
 
@@ -1190,6 +1191,7 @@ export const spec = {
         code: BIDDER_CODE,
     gvlid: 0000000000,
     supportedMediaTypes: [BANNER, VIDEO, NATIVE],
+    alwaysHasCapacity: true,
         aliases: [{code: "myAlias", gvlid: 99999999999} ],
         /**
          * Determines whether or not the given bid request is valid.

--- a/dev-docs/modules/prebidServer.md
+++ b/dev-docs/modules/prebidServer.md
@@ -99,6 +99,7 @@ There are many configuration options for s2sConfig:
 | `customHeaders` | Optional | Object | These custom headers will be included in the XHR call to the bidder's endpoint. This will allow you to send data specific to your use case. The format consists of an object where the keys represent the header names and the values correspond to the respective header values. Here is an example how a customHeader object might look like - `{"Header1": "Value1", "Header2": "Value2"}`|
 | `endpointCompression` | Optional | Boolean | Gzip compress the auction request payload when supported and debug mode is off. Adds `gzip=1` to the request URL. |
 | `filterBidderlessCalls` | Optional | Boolean | When `true`, ad units that have no bidders defined are excluded from Prebid Server requests. Defaults to `false`. | `true` |
+| `alwaysHasCapacity` | Optional | Boolean | When `true`, this prebid server instance will be omitted in checking if origin has http capacity, defaults to `false` |
 
 If `endpoint` and `syncEndpoint` are objects, these are the supported properties:
 

--- a/dev-docs/publisher-api-reference/setConfig.md
+++ b/dev-docs/publisher-api-reference/setConfig.md
@@ -115,6 +115,14 @@ pbjs.setConfig({ maxRequestsPerOrigin: 6 });
 pbjs.setConfig({ maxRequestsPerOrigin: 1 });
 ```
 
+Note: Prebid adapters or Prebid Server instances can be omitted from this capacity check if they declare `alwaysHasCapacity: true`. See [bidder adapter configuration](/dev-docs/bidder-adaptor.html) and [Prebid Server configuration](/dev-docs/modules/prebidServer.html) for more details.
+
+Although, `maxRequestsPerOrigin` can still be forced by the publisher using:
+
+```javascript
+pbjs.setConfig({ maxRequestsPerOrigin: 1, forceMaxRequestsPerOrigin: true });
+```
+
 ### Disable Ajax Timeout
 
 <a name="setConfig-Disable-Ajax-Timeout"></a>


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.

⚠️ The documentation is merged after the related code changes are merged and release ⚠️
-->

This PR adds new flag to both bidder spec and s2sConfig - `alwaysHasCapacity`. Can be used to omit the bidder in `maxRequestPerOrigin` check. This can be still overwritten with another newly introduced config flag `forceMaxRequestPerOrigin`

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [x] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
[https://github.com/prebid/Prebid.js/pull/14326](https://github.com/prebid/Prebid.js/pull/14326)