### PR TITLE
Add Rediads user ID module documentation

### DIFF
--- a/dev-docs/bidders/rediads.md
+++ b/dev-docs/bidders/rediads.md
@@ -23,18 +23,19 @@ multiformat_supported: will-bid-on-one
 sidebarType: 1
 ---
 
-### Bid Params
+## Bid Params
 
 {: .table .table-bordered .table-striped }
-| Name         | Scope    | Description                                                                 | Example              | Type           |
-|--------------|----------|-----------------------------------------------------------------------------|----------------------|----------------|
-| account_id   | required | Account ID generated on the Rediads Platform.                               | '123xyz'             | string       |
-| endpoint     | optional | Only to be used if RediAds team provides you with one.                      | 'bidding2'        | string       |
-| slot         | optional | Unique identifier for the ad slot generated on the platform.                | '54321'              | string       |
+
+| Name       | Scope    | Description                                                  | Example    | Type   |
+| ---------- | -------- | ------------------------------------------------------------ | ---------- | ------ |
+| account_id | required | Account ID generated on the Rediads Platform.                | `'123xyz'` | string |
+| endpoint   | optional | Only to be used if RediAds team provides you with one.       | `'bidding2'` | string |
+| slot       | optional | Unique identifier for the ad slot generated on the platform. | `'54321'` | string |
 
 ---
 
-### Enabling Test Bids
+## Enabling Test Bids
 
 To enable test bids for the Rediads Bidder Adapter, append rediads-test-bids to the hash of the page URL.
 
@@ -47,9 +48,9 @@ This will activate test bids for debugging and validation purposes.
 
 ---
 
-### AdUnit Examples
+## AdUnit Examples
 
-#### AdUnit Format for Banner
+### AdUnit Format for Banner
 
 ```javascript
 var adUnits = [
@@ -73,7 +74,7 @@ var adUnits = [
 ];
 ```
 
-### First Party Data Support
+## First Party Data Support
 The following fields are supported for First Party Data (FPD):
 
 - `ortb2.site.*`
@@ -83,7 +84,7 @@ The following fields are supported for First Party Data (FPD):
 
 For additional implementation or support, contact us at <support@rediads.com>.
 
-### User ID Support
+## User ID Support
 
 The Rediads bidder supports the `rediadsId` user ID submodule. To build both together:
 

--- a/dev-docs/bidders/rediads.md
+++ b/dev-docs/bidders/rediads.md
@@ -27,11 +27,11 @@ sidebarType: 1
 
 {: .table .table-bordered .table-striped }
 
-| Name       | Scope    | Description                                                  | Example    | Type   |
-| ---------- | -------- | ------------------------------------------------------------ | ---------- | ------ |
-| account_id | required | Account ID generated on the Rediads Platform.                | `'123xyz'` | string |
+| Name       | Scope    | Description                                                  | Example      | Type   |
+| ---------- | -------- | ------------------------------------------------------------ | ------------ | ------ |
+| account_id | required | Account ID generated on the Rediads Platform.                | `'123xyz'`   | string |
 | endpoint   | optional | Only to be used if RediAds team provides you with one.       | `'bidding2'` | string |
-| slot       | optional | Unique identifier for the ad slot generated on the platform. | `'54321'` | string |
+| slot       | optional | Unique identifier for the ad slot generated on the platform. | `'54321'`    | string |
 
 ---
 

--- a/dev-docs/bidders/rediads.md
+++ b/dev-docs/bidders/rediads.md
@@ -16,6 +16,7 @@ safeframes_ok: false
 deals_supported: false
 floors_supported: true
 fpd_supported: true
+userIds: rediadsId
 ortb_blocking_supported: partial
 privacy_sandbox: no
 multiformat_supported: will-bid-on-one
@@ -81,3 +82,11 @@ The following fields are supported for First Party Data (FPD):
 - `ortb2.devices.locations parameters`
 
 For additional implementation or support, contact us at <support@rediads.com>.
+
+### User ID Support
+
+The Rediads bidder supports the `rediadsId` user ID submodule. To build both together:
+
+```bash
+gulp build --modules=rediadsBidAdapter,userId,rediadsIdSystem
+```

--- a/dev-docs/modules/userid-submodules/rediads.md
+++ b/dev-docs/modules/userid-submodules/rediads.md
@@ -1,0 +1,125 @@
+---
+layout: userid
+title: Rediads ID
+description: Rediads User ID sub-module
+useridmodule: rediadsIdSystem
+bidRequestUserId: rediadsId
+eidsource: rediads.com
+example: '"ruid_7b9c1d3f-1e2b-4e7b-9e5a-acde12345678"'
+---
+
+## Overview
+
+The Rediads User ID submodule generates a first-party browser identifier for publisher-side identity and makes it available to Prebid bidders through both `bidRequest.userId.rediadsId` and `bidRequest.userIdAsEids`.
+
+This submodule is implemented as a Prebid User ID module and uses Prebid-managed storage.
+
+## Registration
+
+For setup information, contact [support@rediads.com](mailto:support@rediads.com).
+
+## Installation
+
+Build Prebid.js with the User ID core module, the Rediads ID submodule, and optionally the Rediads bidder:
+
+```bash
+gulp build --modules=rediadsBidAdapter,userId,rediadsIdSystem
+```
+
+If you only need the user ID module, you can omit `rediadsBidAdapter`:
+
+```bash
+gulp build --modules=userId,rediadsIdSystem
+```
+
+## Configuration
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+    userIds: [{
+      name: 'rediadsId',
+      params: {
+        source: 'rediads.com'
+      },
+      storage: {
+        type: 'html5',
+        name: 'rediads_id',
+        expires: 30,
+        refreshInSeconds: 3600
+      }
+    }]
+  }
+});
+```
+
+## Parameters
+
+{: .table .table-bordered .table-striped }
+
+| Param under `userSync.userIds[]` | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| `name` | Required | String | Module identifier. Must be `"rediadsId"`. | `"rediadsId"` |
+| `params` | Optional | Object | Rediads-specific configuration. | |
+| `params.source` | Optional | String | EID source to emit. Defaults to `"rediads.com"`. | `"rediads.com"` |
+| `storage` | Recommended | Object | Prebid-managed storage configuration. | |
+| `storage.type` | Recommended | String | Storage type. Use `"html5"`, `"cookie"`, or `"cookie&html5"` as needed. | `"html5"` |
+| `storage.name` | Recommended | String | Storage key name. | `"rediads_id"` |
+| `storage.expires` | Optional | Number | Lifetime of the stored ID in days. Defaults to `30`. | `30` |
+| `storage.refreshInSeconds` | Optional | Number | Refresh interval in seconds. Defaults to `3600`. | `3600` |
+
+## Privacy Handling
+
+The Rediads ID submodule follows the standard Prebid User ID privacy flow.
+
+- If COPPA applies, the module does not create or return an ID.
+- If GDPR applies without a valid consent string and Purpose 1 consent, the module does not create or return an ID.
+- If US Privacy or GPP opt-out signals restrict sharing, the module may still retain its local ID state but does not emit EIDs for bidder sharing.
+
+The module uses Prebid's vendorless TCF marker so purpose-level enforcement applies without requiring a separate vendor registration in the module config.
+
+## Bid Request Output
+
+When available, the Rediads ID is exposed on the bid request as:
+
+```javascript
+bidRequest.userId.rediadsId
+```
+
+Example:
+
+```json
+{
+  "uid": "ruid_7b9c1d3f-1e2b-4e7b-9e5a-acde12345678",
+  "source": "rediads.com",
+  "atype": 1,
+  "ext": {
+    "canShare": true
+  }
+}
+```
+
+## EID Output
+
+When sharing is permitted, the module contributes the following EID:
+
+```json
+{
+  "source": "rediads.com",
+  "uids": [{
+    "id": "ruid_7b9c1d3f-1e2b-4e7b-9e5a-acde12345678",
+    "atype": 1
+  }]
+}
+```
+
+## Testing
+
+After building Prebid.js with `userId` and `rediadsIdSystem`, you can verify the module with:
+
+```javascript
+pbjs.getUserIds()
+pbjs.getUserIdsAsEids()
+```
+
+You should see `rediadsId` in `getUserIds()` and a `rediads.com` entry in `getUserIdsAsEids()` when privacy settings allow sharing.


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.

⚠️ The documentation is merged after the related code changes are merged and release ⚠️
-->

## 🏷 Type of documentation
- [ ] new bid adapter
- [ ] update bid adapter
- [x] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## Description

This PR adds documentation for the new `rediadsIdSystem` Prebid User ID submodule.

Changes included in this PR:
- adds a new User ID submodule documentation page for Rediads
- documents installation and build commands for `rediadsIdSystem`
- documents publisher configuration for `userSync.userIds`
- documents expected `bidRequest.userId.rediadsId` and EID output
- updates the Rediads bidder documentation to indicate support for `rediadsId`

Files changed:
- `dev-docs/modules/userid-submodules/rediads.md`
- `dev-docs/bidders/rediads.md`
