### PR TITLE
Contxtful - Add GVL vendor ID

### DIFF
--- a/dev-docs/bidders/contxtful.md
+++ b/dev-docs/bidders/contxtful.md
@@ -3,7 +3,8 @@ layout: bidder
 title: Contxtful
 description: Prebid Contxtful Bidder Adapter
 biddercode: contxtful
-tcfeu_supported: false
+gvl_id: 1569
+tcfeu_supported: true
 usp_supported: true
 coppa_supported: true
 schain_supported: true

--- a/dev-docs/bidders/contxtful.md
+++ b/dev-docs/bidders/contxtful.md
@@ -21,17 +21,18 @@ multiformat_supported: will-bid-on-any
 ortb_blocking_supported: true
 ---
 
-### Note
+## Note
 
 The Contxtful bidder adapter requires some setup. Contact us at [contact@contxtful.com](mailto:contact@contxtful.com)
 
-### Bid Params
+## Bid Params
 
 {: .table .table-bordered .table-striped }
-| Name        | Scope    | Description                                                | Example                      | Type                 |
-|-------------|----------|------------------------------------------------------------|------------------------------|----------------------|
-| `placementId`      | required | The placement identifier                                          | `'p12345678'` | `string`             |
-| `customerId`      | required | The customer identifier              | `'DEMO123456'`       | `string`           |
+
+| Name           | Scope    | Description                  | Example        | Type     |
+|----------------|----------|------------------------------|----------------|----------|
+| `placementId`  | required | The placement identifier     | `'p12345678'`  | `string` |
+| `customerId`   | required | The customer identifier      | `'DEMO123456'` | `string` |
 
 ### Configuration - Prebid.js Adapter
 

--- a/dev-docs/bidders/contxtful.md
+++ b/dev-docs/bidders/contxtful.md
@@ -62,6 +62,9 @@ pbjs.setConfig({
             }
          }
       ]
+   },
+   "gvlMapping":{
+       "contxtful": 1569
    }
 }
 );
@@ -94,6 +97,9 @@ pbjs.setConfig({
             }
          }
       ]
+   },
+   "gvlMapping":{
+       "contxtful": 1569
    }
 }
 );

--- a/dev-docs/modules/contxtfulRtdProvider.md
+++ b/dev-docs/modules/contxtfulRtdProvider.md
@@ -59,13 +59,14 @@ pbjs.setConfig({
 ## Parameters
 
 {: .table .table-bordered .table-striped }
-| Name                | Type     | Scope    | Description                                |
-|---------------------|----------|----------|--------------------------------------------|
-| `version`           | `String` | Required | Specifies the version of the Contxtful Receptivity API. |
-| `customer`          | `String` | Required | Your unique customer identifier.           |
-| `hostname`          | `String` | Optional | Target URL for CONTXTFUL external JavaScript file. Default is "api.receptivity.io". Changing default behaviour is not recommended. Please reach out to [contact@contxtful.com](mailto:contact@contxtful.com) if you experience issues. |
-| `adServerTargeting` | `Boolean`| Optional | Enables the `getTargetingData` to inject targeting value in ad units. Setting to true enables the feature, false disables the feature. Default is true      |
-| `bidders`           | `Array`  | Optional | Setting this array enables Receptivity in the `ortb2` object through `getBidRequestData` for all the listed `bidders`. Default is `[]` (an empty array). RECOMMENDED : Add all the bidders active like this `["bidderCode1", "bidderCode", "..."]` |
+
+| Name                | Type      | Scope    | Description                                                                                                                                                                                                                                      |
+|---------------------|-----------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `version`           | `String`  | Required | Specifies the version of the Contxtful Receptivity API.                                                                                                                                                                                          |
+| `customer`          | `String`  | Required | Your unique customer identifier.                                                                                                                                                                                                                 |
+| `hostname`          | `String`  | Optional | Target URL for CONTXTFUL external JavaScript file. Default is "api.receptivity.io". Changing default behaviour is not recommended. Please reach out to [contact@contxtful.com](mailto:contact@contxtful.com) if you experience issues.           |
+| `adServerTargeting` | `Boolean` | Optional | Enables the `getTargetingData` to inject targeting value in ad units. Setting to true enables the feature, false disables the feature. Default is true.                                                                                          |
+| `bidders`           | `Array`   | Optional | Setting this array enables Receptivity in the `ortb2` object through `getBidRequestData` for all the listed `bidders`. Default is `[]` (an empty array). RECOMMENDED: Add all the bidders active like this `["bidderCode1", "bidderCode", "..."]`|
 
 ## Usage: Injection in Ad Servers
 

--- a/dev-docs/modules/contxtfulRtdProvider.md
+++ b/dev-docs/modules/contxtfulRtdProvider.md
@@ -52,6 +52,9 @@ pbjs.setConfig({
         }
       }
     ]
+  },
+  "gvlMapping": {
+    "contxtful": 1569
   }
 });
 ```

--- a/dev-docs/modules/contxtfulRtdProvider.md
+++ b/dev-docs/modules/contxtfulRtdProvider.md
@@ -7,6 +7,8 @@ page_type: module
 module_type: rtd
 module_code : contxtfulRtdProvider
 enable_download : true
+gvl_id: 1569
+gdpr_supported: true
 vendor_specific: true
 sidebarType : 1
 ---


### PR DESCRIPTION
Add gvl_id: 1569 to bidder and RTD module documentation.
Set tcfeu_supported: true and gdpr_supported: true.

## 🏷 Type of documentation
- [x] update bid adapter

Related Pull Requests:
- https://github.com/prebid/Prebid.js/pull/14661
- https://github.com/prebid/prebid-server/pull/4735
