### PR TITLE
Removed tagUrl parameter

### DIFF
--- a/dev-docs/modules/anonymisedRtdProvider.md
+++ b/dev-docs/modules/anonymisedRtdProvider.md
@@ -67,4 +67,3 @@ For any questions or assistance with integrating Prebid, `anonymisedRtdProvider`
 | params.bidders | `Array` | Bidders with which to share segment information | Optional |
 | params.segtax | `Integer` | The taxonomy for Anonymised | '1000' always |
 | params.tagConfig | `Object` | Configuration for the Anonymised Marketing Tag | Optional. Defaults to `{}`. |
-| params.tagUrl | `String` | The URL of the Anonymised Marketing Tag script | Optional. Defaults to `https://static.anonymised.io/light/loader.js`. |

--- a/dev-docs/modules/anonymisedRtdProvider.md
+++ b/dev-docs/modules/anonymisedRtdProvider.md
@@ -67,3 +67,4 @@ For any questions or assistance with integrating Prebid, `anonymisedRtdProvider`
 | params.bidders | `Array` | Bidders with which to share segment information | Optional |
 | params.segtax | `Integer` | The taxonomy for Anonymised | '1000' always |
 | params.tagConfig | `Object` | Configuration for the Anonymised Marketing Tag | Optional. Defaults to `{}`. |
+| params.tagUrl | `String` | The URL of the Anonymised Marketing Tag script | **Deprecated.** Optional. Defaults to `https://static.anonymised.io/light/loader.js`. |

--- a/dev-docs/modules/anonymisedRtdProvider.md
+++ b/dev-docs/modules/anonymisedRtdProvider.md
@@ -59,9 +59,10 @@ For any questions or assistance with integrating Prebid, `anonymisedRtdProvider`
 **Config Syntax details:**
 
 {: .table .table-bordered .table-striped }
-| Name  |Type | Description   | Notes  |
-| :------------ | :------------ | :------------ |:------------ |
-| name | `String` | Anonymised Rtd module name | 'anonymised' always|
+
+| Name | Type | Description | Notes |
+| :------------ | :------------ | :------------ | :------------ |
+| name | `String` | Anonymised Rtd module name | 'anonymised' always |
 | waitForIt | `Boolean` | Required to ensure that the auction is delayed until prefetch is complete | Optional. Defaults to false |
 | params.cohortStorageKey | `String` | the `localStorage` key, under which Anonymised Marketing Tag stores the segment IDs | 'cohort_ids' always |
 | params.bidders | `Array` | Bidders with which to share segment information | Optional |


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.

⚠️ The documentation is merged after the related code changes are merged and release ⚠️
-->
The obsolete `params.tagUrl` config option has been removed. The Anonymised Marketing Tag is now always loaded from the hardcoded URL (https://static.anonymised.io/light/loader.js), preventing publishers from overriding it with an arbitrary external script.

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] update bid adapter

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked -> https://github.com/prebid/Prebid.js/pull/14675
