### PR TITLE
Update some JS video examples to use local cache

### DIFF
--- a/_includes/loadScript.html
+++ b/_includes/loadScript.html
@@ -1,0 +1,11 @@
+<script type="text/javascript">
+  function loadScript(url) {
+    const scr = document.createElement('script');
+    scr.src = url;
+    return new Promise((resolve, reject) => {
+      scr.onerror = reject;
+      scr.onload = resolve;
+      document.head.appendChild(scr);
+    });
+  }
+</script>

--- a/_includes/video/mock-video-bid.html
+++ b/_includes/video/mock-video-bid.html
@@ -1,0 +1,21 @@
+<script>
+    window.pbjs = window.pbjs || {};
+    pbjs.que = pbjs.que || [];
+    pbjs.que.push(() => {
+      pbjs.setConfig({
+        debugging: {
+          enabled: true,
+          intercept: [
+            {
+              when: {},
+              then: {
+                cpm: 1,
+                mediaType: "video",
+                vastXml: "<?xml version=\"1.0\" encoding=\"UTF-8\"?><VAST version=\"3.0\"><Ad><InLine><AdSystem>GDFP</AdSystem><AdTitle>Demo</AdTitle><Description><![CDATA[Demo]]></Description><Creatives><Creative><Linear ><Duration>00:00:11</Duration><VideoClicks><ClickThrough><![CDATA[https://adplayer.pro/]]></ClickThrough></VideoClicks><MediaFiles><MediaFile delivery=\"progressive\" width=\"640\" height=\"360\" type=\"video/mp4\" scalable=\"true\" maintainAspectRatio=\"true\"><![CDATA[https://static.adplayer.pro/video/demo_v2.mp4]]></MediaFile></MediaFiles></Linear></Creative></Creatives></InLine></Ad></VAST>"
+              }
+            },
+          ]
+        }
+      })
+    })
+</script>

--- a/_includes/video/pb-is-jw01.html
+++ b/_includes/video/pb-is-jw01.html
@@ -3,68 +3,66 @@
   <head>
     {% include head--common.html %}
     {% include prebidjs-non-prod.html %}
+    {% include loadScript.html %}
+    {% include video/mock-video-bid.html %}
 
     <!--pbjs and player code -->
+    <script type="text/javascript" class="cmplazyload" data-cmp-purpose="c51">
+      loadScript('https://cdn.jwplayer.com/libraries/dNV4UKpE.js')
+        .then(() => {
+          //Test Key - replace this with your own valid JWPlayer license key
+          jwplayer.key = "ssbF6k0i9BPe87xfG/s0ipdp5gwbLoZaDON/GQvuwPU9nVJy";
 
-    <script>
-      var pbjs = pbjs || {};
-      pbjs.que = pbjs.que || [];
+          window.pbjs = window.pbjs || {};
+          pbjs.que = pbjs.que || [];
 
-      // define invokeVideoPlayer in advance in case we get the bids back from prebid before the entire page loads
-      var tempTag = false;
-      var invokeVideoPlayer = function (url) {
-        tempTag = url;
-      };
-
-      var videoAdUnit = {
-        code: "video1",
-        mediaTypes: {
-          video: {
-            context: "instream",
-            playerSize: [640, 480],
-            mimes: ["video/mp4"],
-            protocols: [1, 2, 3, 4, 5, 6, 7, 8],
-            playbackmethod: [2],
-            skip: 1,
-          },
-        },
-        bids: [
-          {
-            bidder: "appnexus",
-            params: {
-              placementId: 13232361, // Add your own placement id here
+          var videoAdUnit = {
+            code: "video1",
+            mediaTypes: {
+              video: {
+                context: "instream",
+                playerSize: [640, 480],
+                mimes: ["video/mp4"],
+                protocols: [1, 2, 3, 4, 5, 6, 7, 8],
+                playbackmethod: [2],
+                skip: 1,
+              },
             },
-          },
-        ],
-      };
-
-      pbjs.que.push(function () {
-        pbjs.addAdUnits(videoAdUnit); // add your ad units to the bid request
-
-        pbjs.setConfig({
-          debug: true,
-          cache: {
-            url: "https://prebid.example.com/pbc/v1/cache",
-          },
-        });
-
-        pbjs.requestBids({
-          bidsBackHandler: function (bids) {
-            var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
-              adUnit: videoAdUnit,
-              params: {
-                iu: "/19968336/prebid_cache_video_adunit",
-                cust_params: {
-                  section: "blog",
-                  anotherKey: "anotherValue",
+            bids: [
+              {
+                bidder: "appnexus",
+                params: {
+                  placementId: 13232361, // Add your own placement id here
                 },
-                output: "vast",
+              },
+            ],
+          };
+
+          pbjs.que.push(function () {
+            pbjs.addAdUnits(videoAdUnit); // add your ad units to the bid request
+            pbjs.setConfig({
+              debug: true,
+              cache: {
+                useLocal: true
               },
             });
-            window.runJWPlayer(videoUrl);
-          },
-        });
-      });
+
+            pbjs.requestBids({
+              bidsBackHandler: function (bids) {
+                pbjs.adServers.gam.getVastXml({
+                  bid: bids.video1.bids[0],
+                  adUnit: videoAdUnit,
+                  params: {
+                    iu: '/41758329/localcache',
+                  },
+                }).then(vastXml => {
+                  window.runJWPlayer(vastXml);
+                })
+              },
+            });
+          });
+
+        })
     </script>
   </head>
 

--- a/_includes/video/pb-is-jw02.html
+++ b/_includes/video/pb-is-jw02.html
@@ -2,73 +2,67 @@
 <html lang="en" class="html--no-js">
   <head>
     {% include head--common.html %} {% include prebidjs-non-prod.html %}
+    {% include loadScript.html %}
+    {% include video/mock-video-bid.html %}
 
-    <!--pbjs and player code -->
-    <script type="text/plain" class="cmplazyload" data-cmp-purpose="c51">
-      function updateJWPlayer() {
-        jwplayer.key = "ssbF6k0i9BPe87xfG/s0ipdp5gwbLoZaDON/GQvuwPU9nVJy"; //Test Key - replace this with your own valid JWPlayer license key
-      }
-    </script>
 
-    <script
-      type="text/plain"
-      class="cmplazyload"
-      data-cmp-purpose="c51"
-      data-cmp-src="https://ssl.p.jwpcdn.com/player/v/8.0.5/jwplayer.js"
-    ></script>
+    <script type="text/javascript" class="cmplazyload" data-cmp-purpose="c51">
+      loadScript('https://ssl.p.jwpcdn.com/player/v/8.0.5/jwplayer.js')
+        .then(() => {
+          //Test Key - replace this with your own valid JWPlayer license key
+          jwplayer.key = "ssbF6k0i9BPe87xfG/s0ipdp5gwbLoZaDON/GQvuwPU9nVJy";
 
-    <script>
-      var pbjs = pbjs || {};
-      pbjs.que = pbjs.que || [];
+          window.pbjs = window.pbjs || {};
+          pbjs.que = pbjs.que || [];
 
-      var videoAdUnit = {
-        code: "video1",
-        mediaTypes: {
-          video: {
-            context: "instream",
-            playerSize: [640, 480],
-            mimes: ["video/mp4"],
-            protocols: [1, 2, 3, 4, 5, 6, 7, 8],
-            playbackmethod: [2],
-            skip: 1,
-          },
-        },
-        bids: [
-          {
-            bidder: "appnexus",
-            params: {
-              placementId: 13232361, // Add your own placement id here
+          var videoAdUnit = {
+            code: "video1",
+            mediaTypes: {
+              video: {
+                context: "instream",
+                playerSize: [640, 480],
+                mimes: ["video/mp4"],
+                protocols: [1, 2, 3, 4, 5, 6, 7, 8],
+                playbackmethod: [2],
+                skip: 1,
+              },
             },
-          },
-        ],
-      };
-
-      pbjs.que.push(function () {
-        pbjs.addAdUnits(videoAdUnit); // add your ad units to the bid request
-        pbjs.setConfig({
-          debug: true,
-          cache: {
-            url: "https://prebid.example.com/pbc/v1/cache",
-          },
-        });
-
-        pbjs.requestBids({
-          bidsBackHandler: function (bids) {
-            var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
-              adUnit: videoAdUnit,
-              params: {
-                iu: "/19968336/prebid_cache_video_adunit",
-                cust_params: {
-                  section: "blog",
-                  anotherKey: "anotherValue",
+            bids: [
+              {
+                bidder: "appnexus",
+                params: {
+                  placementId: 13232361, // Add your own placement id here
                 },
-                output: "vast",
+              },
+            ],
+          };
+
+          pbjs.que.push(function () {
+            pbjs.addAdUnits(videoAdUnit); // add your ad units to the bid request
+            pbjs.setConfig({
+              debug: true,
+              cache: {
+                useLocal: true
               },
             });
-            window.runJWPlayer(videoUrl);
-          },
-        });
-      });
+
+            pbjs.requestBids({
+              bidsBackHandler: function (bids) {
+                pbjs.adServers.gam.getVastXml({
+                  bid: bids.video1.bids[0],
+                  adUnit: videoAdUnit,
+                  params: {
+                    iu: '/41758329/localcache',
+                  },
+                }).then(vastXml => {
+                  window.runJWPlayer(vastXml);
+                })
+
+              },
+            });
+          });
+
+        })
     </script>
   </head>
 

--- a/_includes/video/pb-is-vjs.html
+++ b/_includes/video/pb-is-vjs.html
@@ -2,6 +2,7 @@
 <html lang="en" class="html--no-js">
   <head>
     {% include head--common.html %} {% include prebidjs-non-prod.html %}
+    {% include loadScript.html %}
 
     <!--pbjs and player code -->
 
@@ -15,78 +16,84 @@
       rel="stylesheet"
     />
     <!-- videojs-vast-vpaid -->
-    <script type="text/plain" class="cmplazyload" data-cmp-purpose="c51">
-      window.runVideoJSCode();
-    </script>
-    <script
-      type="text/plain"
-      class="cmplazyload"
-      data-cmp-purpose="c51"
-      data-cmp-src="https://cdnjs.cloudflare.com/ajax/libs/video.js/6.4.0/video.js"
-    ></script>
-    <script
-      type="text/plain"
-      class="cmplazyload"
-      data-cmp-purpose="c51"
-      data-cmp-src="https://cdnjs.cloudflare.com/ajax/libs/videojs-vast-vpaid/2.0.2/videojs_5.vast.vpaid.min.js"
-    ></script>
+    <script type="text/javascript" class="cmplazyload" data-cmp-purpose="c51">
+      loadScript('https://cdnjs.cloudflare.com/ajax/libs/video.js/6.4.0/video.js')
+        .then(() => loadScript('https://cdnjs.cloudflare.com/ajax/libs/videojs-vast-vpaid/2.0.2/videojs_5.vast.vpaid.min.js'))
+        .then(() => {
+          window.runVideoJSCode();
+          window.pbjs = window.pbjs || {};
+          pbjs.que = pbjs.que || [];
 
-    <script>
-      var pbjs = pbjs || {};
-      pbjs.que = pbjs.que || [];
+          /* Prebid video ad unit */
 
-      /* Prebid video ad unit */
-
-      var videoAdUnit = {
-        code: "video1",
-        mediaTypes: {
-          video: {
-            context: "instream",
-            playerSize: [640, 480],
-            mimes: ["video/mp4"],
-            protocols: [1, 2, 3, 4, 5, 6, 7, 8],
-            playbackmethod: [2],
-            skip: 1,
-          },
-        },
-        bids: [
-          {
-            bidder: "appnexus",
-            params: {
-              placementId: 13232361,
+          var videoAdUnit = {
+            code: 'video1',
+            mediaTypes: {
+              video: {
+                context: 'instream',
+                playerSize: [640, 480],
+                mimes: ['video/mp4'],
+                protocols: [1, 2, 3, 4, 5, 6, 7, 8],
+                playbackmethod: [2],
+                skip: 1,
+              },
             },
-          },
-        ],
-      };
-
-      pbjs.que.push(function () {
-        pbjs.addAdUnits(videoAdUnit);
-
-        pbjs.setConfig({
-          debug: true,
-          cache: {
-            url: "https://prebid.example.com/pbc/v1/cache",
-          },
-        });
-
-        pbjs.requestBids({
-          bidsBackHandler: function (bids) {
-            var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
-              adUnit: videoAdUnit,
-              params: {
-                iu: "/19968336/prebid_cache_video_adunit",
-                cust_params: {
-                  section: "blog",
-                  anotherKey: "anotherValue",
+            bids: [
+              {
+                bidder: 'appnexus',
+                params: {
+                  placementId: 13232361,
                 },
-                output: "vast",
+              },
+            ],
+          };
+
+          pbjs.que.push(function () {
+            pbjs.addAdUnits(videoAdUnit);
+            pbjs.setConfig({
+              debugging: {
+                enabled: true,
+                intercept: [
+                  {
+                    when: {
+                      adUnitCode: 'video1',
+                    },
+                    then: {
+                      cpm: 1,
+                      mediaType: "video",
+                      vastXml: "<?xml version=\"1.0\" encoding=\"UTF-8\"?><VAST version=\"3.0\"><Ad><InLine><AdSystem>GDFP</AdSystem><AdTitle>Demo</AdTitle><Description><![CDATA[Demo]]></Description><Creatives><Creative><Linear ><Duration>00:00:11</Duration><VideoClicks><ClickThrough><![CDATA[https://adplayer.pro/]]></ClickThrough></VideoClicks><MediaFiles><MediaFile delivery=\"progressive\" width=\"640\" height=\"360\" type=\"video/mp4\" scalable=\"true\" maintainAspectRatio=\"true\"><![CDATA[https://static.adplayer.pro/video/demo_v2.mp4]]></MediaFile></MediaFiles></Linear></Creative></Creatives></InLine></Ad></VAST>"
+                    }
+                  },
+                ]
+              }
+            })
+
+            pbjs.setConfig({
+              debug: true,
+              cache: {
+                useLocal: true
               },
             });
-            window.invokeVideoPlayer(videoUrl);
-          },
-        });
+
+            pbjs.requestBids({
+              bidsBackHandler: function (bids) {
+                window.invokeVideoPlayer((callback) => {
+                  pbjs.adServers.gam.getVastXml({
+                    bid: bids.video1.bids[0],
+                    adUnit: videoAdUnit,
+                    params: {
+                      iu: '/41758329/localcache',
+                    },
+                  }).then(vastXml => {
+                    callback(null, vastXml)
+                  })
+                });
+              },
+            });
+          });
       });
     </script>
+
   </head>
 
   <body></body>

--- a/_includes/video/pb-is-vjs.html
+++ b/_includes/video/pb-is-vjs.html
@@ -3,6 +3,7 @@
   <head>
     {% include head--common.html %} {% include prebidjs-non-prod.html %}
     {% include loadScript.html %}
+    {% include video/mock-video-bid.html %}
 
     <!--pbjs and player code -->
 
@@ -50,23 +51,6 @@
 
           pbjs.que.push(function () {
             pbjs.addAdUnits(videoAdUnit);
-            pbjs.setConfig({
-              debugging: {
-                enabled: true,
-                intercept: [
-                  {
-                    when: {
-                      adUnitCode: 'video1',
-                    },
-                    then: {
-                      cpm: 1,
-                      mediaType: "video",
-                      vastXml: "<?xml version=\"1.0\" encoding=\"UTF-8\"?><VAST version=\"3.0\"><Ad><InLine><AdSystem>GDFP</AdSystem><AdTitle>Demo</AdTitle><Description><![CDATA[Demo]]></Description><Creatives><Creative><Linear ><Duration>00:00:11</Duration><VideoClicks><ClickThrough><![CDATA[https://adplayer.pro/]]></ClickThrough></VideoClicks><MediaFiles><MediaFile delivery=\"progressive\" width=\"640\" height=\"360\" type=\"video/mp4\" scalable=\"true\" maintainAspectRatio=\"true\"><![CDATA[https://static.adplayer.pro/video/demo_v2.mp4]]></MediaFile></MediaFiles></Linear></Creative></Creatives></InLine></Ad></VAST>"
-                    }
-                  },
-                ]
-              }
-            })
 
             pbjs.setConfig({
               debug: true,

--- a/examples/video/instream/jwplayer/pb-ve-jwplayer-hosted.html
+++ b/examples/video/instream/jwplayer/pb-ve-jwplayer-hosted.html
@@ -57,8 +57,8 @@ sidebarType: 4
 
     // define invokeVideoPlayer in advance in case we get the bids back from prebid before the entire page loads<br>
     var tempTag = false;
-    var invokeVideoPlayer = function(url) {
-        tempTag = url;
+    var invokeVideoPlayer = function(vastXml) {
+        tempTag = vastXml;
     }
 
     var videoAdUnit = {
@@ -86,24 +86,18 @@ sidebarType: 4
         pbjs.setConfig({
             debug: true,
             cache: {
-                url: 'https://prebid.example.com/pbc/v1/cache'
+                useLocal: true
             }
         });
 
         pbjs.requestBids({
             bidsBackHandler: function(bids) {
-                var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
+                pbjs.adServers.gam.getVastXml({
                     adUnit: videoAdUnit,
                     params: {
-                        iu: '/19968336/prebid_cache_video_adunit',
-                        cust_params: {
-                            section: 'blog',
-                            anotherKey: 'anotherValue'
-                        },
-                        output: 'vast'
-                    }
-                });
-                invokeVideoPlayer(videoUrl);
+                      iu: '/41758329/localcache',
+                    },
+                }).then(vastXml => invokeVideoPlayer(vastXml));
             }
         });
     });
@@ -123,7 +117,7 @@ sidebarType: 4
   &lt;script&gt;
     var jwPlayerInstance = jwplayer("playerContainerJW");
 
-    invokeVideoPlayer = function(url) {
+    invokeVideoPlayer = function(vastXml) {
         jwPlayerInstance.setup({
             "file": "https://vjs.zencdn.net/v/oceans.mp4",
             "width": 640,
@@ -132,12 +126,14 @@ sidebarType: 4
             "mute": false,
             "advertising": {
                 client: "vast",
+                schedule: [
+                  {
+                    vastxml: vastXml,
+                    offset: 'pre'
+                  }
+                ]
             }
         });
-
-        jwPlayerInstance.on('beforePlay', function() {
-            jwPlayerInstance.playAd(url);
-        })
     }
 
     if (tempTag) {
@@ -155,10 +151,10 @@ sidebarType: 4
 
 <!--video player code-->
 <script>
-  function runJWPlayer(url) {
+  function runJWPlayer(vastXml) {
     const jwPlayerInstance = jwplayer("playerContainerJW");
 
-    invokeVideoPlayer = function (url) {
+    invokeVideoPlayer = function (vastXml) {
       jwPlayerInstance.setup({
         file: "https://vjs.zencdn.net/v/oceans.mp4",
         width: 640,
@@ -167,14 +163,16 @@ sidebarType: 4
         mute: true,
         advertising: {
           client: "vast",
+          schedule: [
+            {
+              vastxml: vastXml,
+              offset: 'pre'
+            }
+          ]
         },
-      });
-
-      jwPlayerInstance.on("beforePlay", function () {
-        jwPlayerInstance.playAd(url);
       });
     };
 
-    invokeVideoPlayer(url);
+    invokeVideoPlayer(vastXml);
   }
 </script>

--- a/examples/video/instream/jwplayer/pb-ve-jwplayer-platform.html
+++ b/examples/video/instream/jwplayer/pb-ve-jwplayer-platform.html
@@ -7,13 +7,6 @@ isVideo: true
 sidebarType: 4
 ---
 
-<script
-  type="text/plain"
-  class="cmplazyload"
-  data-cmp-purpose="c51"
-  data-cmp-src="https://cdn.jwplayer.com/libraries/dNV4UKpE.js"
-></script>
-
 <div class="container">
   <div class="row">
     <div class="vidHeader" style="width: 75vw">
@@ -57,8 +50,8 @@ sidebarType: 4
 
       // define invokeVideoPlayer in advance in case we get the bids back from prebid before the entire page loads<br>
       var tempTag = false;
-      var invokeVideoPlayer = function(url) {
-          tempTag = url;
+      var invokeVideoPlayer = function(vastXml) {
+          tempTag = vastXml;
       }
 
       var videoAdUnit = {
@@ -88,26 +81,20 @@ sidebarType: 4
           pbjs.setConfig({
               debug: true,
               cache: {
-                  url: 'https://prebid.example.com/pbc/v1/cache'
+                  useLocal: true
               }
           });
 
-          pbjs.requestBids({
-              bidsBackHandler: function(bids) {
-                  var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
-                      adUnit: videoAdUnit,
-                      params: {
-                          iu: '/19968336/prebid_cache_video_adunit',
-                          cust_params: {
-                              section: 'blog',
-                              anotherKey: 'anotherValue'
-                          },
-                          output: 'vast'
-                      }
-                  });
-                  invokeVideoPlayer(videoUrl);
-              }
-          });
+        pbjs.requestBids({
+            bidsBackHandler: function(bids) {
+                pbjs.adServers.gam.getVastXml({
+                    adUnit: videoAdUnit,
+                    params: {
+                      iu: '/41758329/localcache',
+                    },
+                }).then(vastXml => invokeVideoPlayer(vastXml));
+            }
+        });
       });
 
   &lt;/script&gt;
@@ -157,7 +144,7 @@ sidebarType: 4
   </div>
 
   <script>
-    function runJWPlayer(url) {
+    function runJWPlayer(vastXml) {
       // we initialize our player instance, specifying the div to load it into
       var playerInstance = jwplayer("myElement1");
 
@@ -173,7 +160,7 @@ sidebarType: 4
         advertising: {
           client: "vast",
           // url is the vast tag url that we passed in when we called invokeVideoPlayer in the header
-          tag: url,
+          vastxml: vastXml
         },
       });
     }

--- a/examples/video/instream/videojs/pb-ve-videojs.html
+++ b/examples/video/instream/videojs/pb-ve-videojs.html
@@ -92,31 +92,30 @@ sidebarType: 4
       };
 
       pbjs.que.push(function() {
-          pbjs.addAdUnits(videoAdUnit);
+        pbjs.addAdUnits(videoAdUnit);
 
-          pbjs.setConfig({
-              debug: true,
-              cache: {
-                  url: 'https://prebid.example.com/pbc/v1/cache'
-              }
-          });
+        pbjs.setConfig({
+          debug: true,
+          cache: {
+            useLocal: true
+          }
+        });
 
-          pbjs.requestBids({
-              bidsBackHandler: function(bids) {
-                  var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
-                      adUnit: videoAdUnit,
-                      params: {
-                          iu: '/19968336/prebid_cache_video_adunit',
-                          cust_params: {
-                              section: 'blog',
-                              anotherKey: 'anotherValue'
-                          },
-                          output: 'vast'
-                      }
-                  });
-                  invokeVideoPlayer(videoUrl);
-              }
-          });
+        pbjs.requestBids({
+          bidsBackHandler: function (bids) {
+            window.invokeVideoPlayer((callback) => {
+              pbjs.adServers.gam.getVastXml({
+                bid: bids.video1.bids[0],
+                adUnit: videoAdUnit,
+                params: {
+                  iu: '/41758329/localcache',
+                },
+              }).then(vastXml => {
+                callback(null, vastXml)
+              })
+            });
+          },
+        });
       });
 
   &lt;/script&gt;
@@ -148,50 +147,48 @@ sidebarType: 4
       page_load_time = new Date().getTime() - performance.timing.navigationStart;
       console.log(page_load_time + "ms -- Player loaded!");
 
-      function invokeVideoPlayer(url) {
+    function invokeVideoPlayer = function (getVastXml) {
+      page_load_time =
+        new Date().getTime() - performance.timing.navigationStart;
 
-          page_load_time = new Date().getTime() - performance.timing.navigationStart;
-          console.log(page_load_time + "ms -- Prebid VAST url = " + url);
+      /* Access the player instance by calling videojs() and passing
+         in the player's ID. Add a ready listener to make sure the
+         player is ready before interacting with it. */
 
-          /* Access the player instance by calling videojs() and passing
-             in the player's ID. Add a ready listener to make sure the
-             player is ready before interacting with it. */
+      videojs("vid1").ready(function () {
 
-          videojs("vid1").ready(function() {
+        page_load_time = new Date().getTime() - performance.timing.navigationStart;
+        console.log(page_load_time + "ms -- Player is ready!");
 
-              page_load_time = new Date().getTime() - performance.timing.navigationStart;
-              console.log(page_load_time + "ms -- Player is ready!");
+      /* PASS SETTINGS TO VAST PLUGIN
 
-              /* PASS SETTINGS TO VAST PLUGIN
+         Pass in a JSON object to the player's vastClient (defined
+         by the VAST/VPAID plugin we're using). The requires an
+         adTagUrl, which will be the URL returned by Prebid. You
+         can view all the options available for the vastClient
+         here:
 
-                 Pass in a JSON object to the player's vastClient (defined
-                 by the VAST/VPAID plugin we're using). The requires an
-                 adTagUrl, which will be the URL returned by Prebid. You
-                 can view all the options available for the vastClient
-                 here:
+         https://github.com/MailOnline/videojs-vast-vpaid#options */
 
-                 https://github.com/MailOnline/videojs-vast-vpaid#options */
+        var player = this;
+        var vastAd = player.vastClient({
+          adTagXML: getVastXml,
+          playAdAlways: true,
+          verbosity: 4,
+          vpaidFlashLoaderPath: "https://github.com/MailOnline/videojs-vast-vpaid/blob/RELEASE/bin/VPAIDFlash.swf?raw=true",
+          autoplay: true,
+        });
 
-              var player = this;
-              var vastAd = player.vastClient({
-                  adTagUrl: url,
-                  playAdAlways: true,
-                  verbosity: 4,
-                  vpaidFlashLoaderPath: "https://github.com/MailOnline/videojs-vast-vpaid/blob/RELEASE/bin/VPAIDFlash.swf?raw=true",
-                  autoplay: true
-              });
+        page_load_time = new Date().getTime() - performance.timing.navigationStart;
+        console.log(page_load_time + "ms -- Prebid VAST tag inserted!");
 
-              page_load_time = new Date().getTime() - performance.timing.navigationStart;
-              console.log(page_load_time + "ms -- Prebid VAST tag inserted!");
+        player.muted(true);
+        player.play();
 
-              player.muted(true);
-              player.play();
-
-              page_load_time = new Date().getTime() - performance.timing.navigationStart;
-              console.log(page_load_time + "ms -- invokeVideoPlayer complete!");
-
-          });
-      }
+        page_load_time = new Date().getTime() - performance.timing.navigationStart;
+        console.log(page_load_time + "ms -- invokeVideoPlayer complete!");
+      });
+    }
 
   &lt;/script&gt;
         </pre>
@@ -212,10 +209,9 @@ sidebarType: 4
     page_load_time = new Date().getTime() - performance.timing.navigationStart;
     console.log(page_load_time + "ms -- Player loaded!");
 
-    window.invokeVideoPlayer = function (url) {
+    window.invokeVideoPlayer = function (getVastXml) {
       page_load_time =
         new Date().getTime() - performance.timing.navigationStart;
-      console.log(page_load_time + "ms -- Prebid VAST url = " + url);
 
       /* Access the player instance by calling videojs()` and passing
                      in the player's ID. Add a `ready` listener to make sure the
@@ -238,12 +234,13 @@ sidebarType: 4
 
         var player = this;
         var vastAd = player.vastClient({
-          adTagUrl: url,
+          adTagXML: getVastXml,
           playAdAlways: true,
           verbosity: 4,
           vpaidFlashLoaderPath:
             "https://github.com/MailOnline/videojs-vast-vpaid/blob/RELEASE/bin/VPAIDFlash.swf?raw=true",
           autoplay: true,
+          adCancelTimeout: 10000
         });
 
         page_load_time =
@@ -258,6 +255,5 @@ sidebarType: 4
         console.log(page_load_time + "ms -- invokeVideoPlayer complete!");
       });
     };
-    window.resolveVideoJS();
   }
 </script>


### PR DESCRIPTION
## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] text edit only (wording, typos)

This updates some instream videos examples to work and use the local cache.

