### PR TITLE
Adelerate Bidder: initial docs

### DIFF
--- a/dev-docs/bidders/adelerate.md
+++ b/dev-docs/bidders/adelerate.md
@@ -16,7 +16,7 @@ fpd_supported: true
 multiformat_supported: will-bid-on-any
 userId: all
 pbjs: true
-pbs: true
+pbs: false
 pbs_app_supported: true
 safeframes_ok: true
 sidebarType: 1

--- a/dev-docs/bidders/adelerate.md
+++ b/dev-docs/bidders/adelerate.md
@@ -32,7 +32,7 @@ sidebarType: 1
 | `floor`         | optional | Minimum CPM in USD. Floors module is preferred.      | `0.50`      | `number` |
 | `floorCurrency` | optional | Currency for the floor param. Defaults to `USD`.     | `'EUR'`     | `string` |
 
-### Note
+## Note
 
 Adelerate is not currently registered on the IAB Europe Global Vendor List, so this adapter does not declare a `gvlid`.
 Under GDPR, Prebid core will withhold bid requests and user syncs to this bidder unless the publisher's CMP setup explicitly permits.

--- a/dev-docs/bidders/adelerate.md
+++ b/dev-docs/bidders/adelerate.md
@@ -26,7 +26,7 @@ safeframes_ok: true
 | `floor`         | optional | Minimum CPM in USD. Floors module is preferred.      | `0.50`      | `number` |
 | `floorCurrency` | optional | Currency for the floor param. Defaults to `USD`.     | `'EUR'`     | `string` |
 
-### Note                                                                                                                       
+### Note
 
 Adelerate is not currently registered on the IAB Europe Global Vendor List, so this adapter does not declare a `gvlid`.
 Under GDPR, Prebid core will withhold bid requests and user syncs to this bidder unless the publisher's CMP setup explicitly permits.

--- a/dev-docs/bidders/adelerate.md
+++ b/dev-docs/bidders/adelerate.md
@@ -1,0 +1,33 @@
+---
+layout: bidder
+title: Adelerate
+description: Adelerate's Prebid Bidder Adapter for banner, video, and native demand
+biddercode: adelerate
+media_types: video, native
+usp_supported: true
+gpp_supported: true
+coppa_supported: true
+schain_supported: true
+bidder_supports_deals: true
+userId: all
+pbjs: true
+pbs: true
+pbs_app_supported: true
+safeframes_ok: true
+---
+
+### Bid Params
+
+{: .table .table-bordered .table-striped }
+| Name            | Scope    | Description                                          | Example     | Type     |
+|-----------------|----------|------------------------------------------------------|-------------|----------|
+| `placementId`   | required | The placement ID provided by Adelerate.              | `'abc123'`  | `string` |
+| `publisherId`   | required | The publisher ID provided by Adelerate.              | `'pub-456'` | `string` |
+| `floor`         | optional | Minimum CPM in USD. Floors module is preferred.      | `0.50`      | `number` |
+| `floorCurrency` | optional | Currency for the floor param. Defaults to `USD`.     | `'EUR'`     | `string` |
+
+### Note                                                                                                                       
+
+Adelerate is not currently registered on the IAB Europe Global Vendor List, so this adapter does not declare a `gvlid`.
+Under GDPR, Prebid core will withhold bid requests and user syncs to this bidder unless the publisher's CMP setup explicitly permits.
+A `gvlid` will be added once IAB Europe registration is finalized.

--- a/dev-docs/bidders/adelerate.md
+++ b/dev-docs/bidders/adelerate.md
@@ -22,7 +22,7 @@ safeframes_ok: true
 sidebarType: 1
 ---
 
-### Bid Params
+## Bid Params
 
 {: .table .table-bordered .table-striped }
 | Name            | Scope    | Description                                          | Example     | Type     |

--- a/dev-docs/bidders/adelerate.md
+++ b/dev-docs/bidders/adelerate.md
@@ -4,16 +4,22 @@ title: Adelerate
 description: Adelerate's Prebid Bidder Adapter for banner, video, and native demand
 biddercode: adelerate
 media_types: video, native
+dsa_supported: true
 usp_supported: true
-gpp_supported: true
+gpp_sids: tcfca, usnat, usstate_all, usp
 coppa_supported: true
 schain_supported: true
-bidder_supports_deals: true
+dchain_supported: true
+deals_supported: true
+floors_supported: true
+fpd_supported: true
+multiformat_supported: will-bid-on-any
 userId: all
 pbjs: true
 pbs: true
 pbs_app_supported: true
 safeframes_ok: true
+sidebarType: 1
 ---
 
 ### Bid Params


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.

⚠️ The documentation is merged after the related code changes are merged and release ⚠️
-->

Adds documentation for the Adelerate bidder adapter (new). Covers both the Prebid.js client-side adapter and 
the Prebid Server server-side adapter — supports banner, video (instream/outstream), and native. 

Note: Adelerate is not yet registered on the IAB Europe Global Vendor List, so the adapter declares no `gvlid` 
and is intended for non-TCF traffic until registration is finalized. 

Related PRs: 
- [prebid/Prebid.js#14854](https://github.com/prebid/Prebid.js/pull/14854)
- [prebid/prebid-server#4767](https://github.com/prebid/prebid-server/pull/4767)

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked -> see "Related PRs" above
- [x] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
