### PR TITLE
fix(download): correct Define Media bidder module casing

### DIFF
--- a/dev-docs/bidders/defineMedia.md
+++ b/dev-docs/bidders/defineMedia.md
@@ -15,14 +15,14 @@ prebid_member: false
 sidebarType: 1
 ---
 
-### Registration
+## Registration
 
 Please reach out to our account management team to get started. Contact information is available under [definemedia.de](https://definemedia.de).
 
-### Bid Params
+## Bid Params
 
 {: .table .table-bordered .table-striped }
-| Name | Scope | Type    | Description                                                                                                                                                  | Example
-| ---- | ----- |---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------| -------
-| `supplierDomainName` | required | String  | The domain name of the last supplier in the chain. Under this domain a sellers.json must be available under https://${supplierDomainName}/sellers.json       | definemedia.de
-| `devMode` | optional | boolean | This parameter enables our development endpoint instead of the production endpoint. All requests done with this parameter set to "true" are *NOT* billable | true
+| Name                 | Scope    | Type    | Description                                                                                                                                                | Example        |
+| :------------------- | :------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------- |
+| `supplierDomainName` | required | String  | The domain name of the last supplier in the chain. Under this domain a sellers.json must be available under https://${supplierDomainName}/sellers.json     | definemedia.de |
+| `devMode`            | optional | boolean | This parameter enables our development endpoint instead of the production endpoint. All requests done with this parameter set to "true" are *NOT* billable | true           |

--- a/dev-docs/bidders/defineMedia.md
+++ b/dev-docs/bidders/defineMedia.md
@@ -2,7 +2,7 @@
 layout: bidder
 title: DEFINE MEDIA
 description: Prebid DEFINE MEDIA Bidder Adapter
-biddercode: definemedia
+biddercode: defineMedia
 tcfeu_supported: true
 gvl_id: 440
 media_types: banner

--- a/dev-docs/bidders/defineMedia.md
+++ b/dev-docs/bidders/defineMedia.md
@@ -3,6 +3,8 @@ layout: bidder
 title: DEFINE MEDIA
 description: Prebid DEFINE MEDIA Bidder Adapter
 biddercode: defineMedia
+redirect_from:
+	- /dev-docs/bidders/definemedia.html
 tcfeu_supported: true
 gvl_id: 440
 media_types: banner


### PR DESCRIPTION
## Description

This change renames the Define Media bidder doc from `definemedia.md` to `defineMedia.md`.

On the download page, bidder checkbox IDs and `moduleCode` values are derived from the bidder doc filename. Because the file was lowercase, the page generated `definemediaBidAdapter` instead of `defineMediaBidAdapter`.

As a result, selecting Define Media on the package builder page could omit the actual adapter module from the build. Renaming the doc restores the expected camelCase module name.

Repro:
https://docs.prebid.org/download.html?modules=consentManagementGpp%2CconsentManagementTcf%2CgppControl_usnat%2CgppControl_usstates%2CgptPreAuction%2CstorageControl%2CtcfControl%2CappnexusBidAdapter%2CdefineMediaBidAdapter%2CdefinemediaBidAdapter

## 🏷 Type of documentation
- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
- [ ] Related pull requests in prebid.js or server are linked
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)