### PR TITLE
New Adapter: ferio docs (+ myfeature alias and lunamedia adapter maintenance transfer)

### DIFF
--- a/dev-docs/bidders/featuretv.md
+++ b/dev-docs/bidders/featuretv.md
@@ -1,0 +1,37 @@
+---
+layout: bidder
+title: FeatureTV
+description: FeatureTV Bidder Adapter
+biddercode: featuretv
+aliasCode: ferio
+gvl_id: none
+usp_supported: true
+gpp_sids: none
+schain_supported: true
+media_types: banner, video, native
+floors_supported: true
+fpd_supported: true
+userIds: all
+pbjs: true
+pbs: false
+multiformat_supported: will-bid-on-any
+sidebarType: 1
+---
+
+## Note
+
+The FeatureTV bidder adapter is a client-side alias of the `ferio` adapter and
+requires setup before beginning. Please contact <prebid@ferio.cloud> for more
+information.
+
+User syncs for the alias only run when the publisher enables
+`userSync.aliasSyncEnabled` via `pbjs.setConfig`.
+
+## Prebid.js Bid Params
+
+{: .table .table-bordered .table-striped }
+| Name | Scope | Description | Example | Type |
+| --------------- | ---------- | ------------------------------------ | ----------------------------------- | ---------- |
+| `publisherId` | required | Publisher ID on the Ferio platform | `'pubwZR87JRDZSf6V'` | `string` |
+| `adUnitId` | required | Ad unit ID on the Ferio platform | `'3855715c-2ceb-4ba5-a876-8c43a987f210'` | `string` |
+| `tenantId` | required | Tenant ID on the Ferio platform | `'featuretv-pbjs'` | `string` |

--- a/dev-docs/bidders/ferio.md
+++ b/dev-docs/bidders/ferio.md
@@ -37,3 +37,4 @@ The Ferio bidder adapter requires setup before beginning. Please contact <prebid
 | --------------- | ---------- | ------------------------------------ | ----------------------------------- | ---------- |
 | `publisherId` | required | Publisher ID on the Ferio platform | `'pubwZR87JRDZSf6V'` | `string` |
 | `adUnitId` | required | Ad unit ID on the Ferio platform | `'e38ea96e-d044-4973-9c2b-fb3fc7a901be'` | `string` |
+| `tenantId` | required | Tenant ID on the Ferio platform | `'anyclip-pbjs'` | `string` |

--- a/dev-docs/bidders/ferio.md
+++ b/dev-docs/bidders/ferio.md
@@ -12,7 +12,7 @@ floors_supported: true
 fpd_supported: true
 userIds: all
 pbjs: true
-pbs: true
+pbs: false
 multiformat_supported: will-bid-on-any
 sidebarType: 1
 ---
@@ -28,13 +28,4 @@ The Ferio bidder adapter requires setup before beginning. Please contact <prebid
 | --------------- | ---------- | ------------------------------------ | ----------------------------------- | ---------- |
 | `publisherId` | required | Publisher ID on the Ferio platform | `'pubwZR87JRDZSf6V'` | `string` |
 | `adUnitId` | required | Ad unit ID on the Ferio platform | `'3855715c-2ceb-4ba5-a876-8c43a987f210'` | `string` |
-| `tenantId` | required | Tenant ID on the Ferio platform | `'client-pbjs'` | `string` |
-
-## Prebid Server Bid Params
-
-{: .table .table-bordered .table-striped }
-| Name | Scope | Description | Example | Type |
-| --------------- | ---------- | ------------------------------------ | ----------------------------------- | ---------- |
-| `publisherId` | required | Publisher ID on the Ferio platform | `'pubwZR87JRDZSf6V'` | `string` |
-| `adUnitId` | required | Ad unit ID on the Ferio platform | `'e38ea96e-d044-4973-9c2b-fb3fc7a901be'` | `string` |
 | `tenantId` | required | Tenant ID on the Ferio platform | `'client-pbjs'` | `string` |

--- a/dev-docs/bidders/ferio.md
+++ b/dev-docs/bidders/ferio.md
@@ -28,7 +28,7 @@ The Ferio bidder adapter requires setup before beginning. Please contact <prebid
 | --------------- | ---------- | ------------------------------------ | ----------------------------------- | ---------- |
 | `publisherId` | required | Publisher ID on the Ferio platform | `'pubwZR87JRDZSf6V'` | `string` |
 | `adUnitId` | required | Ad unit ID on the Ferio platform | `'3855715c-2ceb-4ba5-a876-8c43a987f210'` | `string` |
-| `tenantId` | required | Tenant ID on the Ferio platform | `'anyclip-pbjs'` | `string` |
+| `tenantId` | required | Tenant ID on the Ferio platform | `'client-pbjs'` | `string` |
 
 ## Prebid Server Bid Params
 
@@ -37,4 +37,4 @@ The Ferio bidder adapter requires setup before beginning. Please contact <prebid
 | --------------- | ---------- | ------------------------------------ | ----------------------------------- | ---------- |
 | `publisherId` | required | Publisher ID on the Ferio platform | `'pubwZR87JRDZSf6V'` | `string` |
 | `adUnitId` | required | Ad unit ID on the Ferio platform | `'e38ea96e-d044-4973-9c2b-fb3fc7a901be'` | `string` |
-| `tenantId` | required | Tenant ID on the Ferio platform | `'anyclip-pbjs'` | `string` |
+| `tenantId` | required | Tenant ID on the Ferio platform | `'client-pbjs'` | `string` |

--- a/dev-docs/bidders/ferio.md
+++ b/dev-docs/bidders/ferio.md
@@ -1,0 +1,39 @@
+---
+layout: bidder
+title: Ferio
+description: Ferio Prebid Bidder Adapter
+biddercode: ferio
+gvl_id: none
+usp_supported: true
+gpp_sids: none
+schain_supported: true
+media_types: banner, video, native
+floors_supported: true
+fpd_supported: true
+userIds: all
+pbjs: true
+pbs: true
+multiformat_supported: will-bid-on-any
+sidebarType: 1
+---
+
+## Note
+
+The Ferio bidder adapter requires setup before beginning. Please contact <prebid@ferio.cloud> for more information.
+
+## Prebid.js Bid Params
+
+{: .table .table-bordered .table-striped }
+| Name | Scope | Description | Example | Type |
+| --------------- | ---------- | ------------------------------------ | ----------------------------------- | ---------- |
+| `publisherId` | required | Publisher ID on the Ferio platform | `'pubwZR87JRDZSf6V'` | `string` |
+| `adUnitId` | required | Ad unit ID on the Ferio platform | `'3855715c-2ceb-4ba5-a876-8c43a987f210'` | `string` |
+| `tenantId` | required | Tenant ID on the Ferio platform | `'anyclip-pbjs'` | `string` |
+
+## Prebid Server Bid Params
+
+{: .table .table-bordered .table-striped }
+| Name | Scope | Description | Example | Type |
+| --------------- | ---------- | ------------------------------------ | ----------------------------------- | ---------- |
+| `publisherId` | required | Publisher ID on the Ferio platform | `'pubwZR87JRDZSf6V'` | `string` |
+| `adUnitId` | required | Ad unit ID on the Ferio platform | `'e38ea96e-d044-4973-9c2b-fb3fc7a901be'` | `string` |

--- a/dev-docs/bidders/lunamediahb.md
+++ b/dev-docs/bidders/lunamediahb.md
@@ -1,7 +1,7 @@
 ---
 layout: bidder
 title: LunamediaHB
-description: Prebid Lunamedia Bidder Adapter
+description: LunamediaHB Bidder Adapter
 biddercode: lunamediahb
 usp_supported: true
 schain_supported: true
@@ -9,14 +9,24 @@ gvl_id: 998
 tcfeu_supported: true
 coppa_supported: true
 media_types: banner, video, native
+floors_supported: true
+fpd_supported: true
+userIds: all
 pbjs: true
 pbs: false
+multiformat_supported: will-bid-on-any
 sidebarType: 1
 ---
 
-### Prebid.Server Bid Params
+## Note
+
+The LunamediaHB bidder adapter is maintained by Ferio and requires setup before beginning. Please contact <prebid@ferio.cloud> for more information.
+
+### Prebid.js Bid Params
 
 {: .table .table-bordered .table-striped }
-| Name           | Scope    | Description                                              | Example    | Type      |
-|----------------|----------|----------------------------------------------------------|------------|-----------|
-| `placementId` | required | Placement Id will be generated on Lunamedia Platform. | `'0'`        | `string` |
+| Name | Scope | Description | Example | Type |
+| --------------- | ---------- | ------------------------------------ | ----------------------------------- | ---------- |
+| `publisherId` | required | Publisher ID on the LunamediaHB platform. | `'publisher-123'` | `string` |
+| `adUnitId` | required | Ad unit ID on the LunamediaHB platform. | `'ad-unit-456'` | `string` |
+| `tenantId` | required | Tenant ID on the LunamediaHB platform. | `'tenant-789'` | `string` |

--- a/dev-docs/bidders/myfeature.md
+++ b/dev-docs/bidders/myfeature.md
@@ -1,8 +1,8 @@
 ---
 layout: bidder
-title: FeatureTV
-description: FeatureTV Bidder Adapter
-biddercode: featuretv
+title: MyFeature
+description: MyFeature Bidder Adapter
+biddercode: myfeature
 aliasCode: ferio
 gvl_id: none
 usp_supported: true
@@ -20,7 +20,7 @@ sidebarType: 1
 
 ## Note
 
-The FeatureTV bidder adapter is a client-side alias of the `ferio` adapter and
+The MyFeature bidder adapter is a client-side alias of the `ferio` adapter and
 requires setup before beginning. Please contact <prebid@ferio.cloud> for more
 information.
 
@@ -34,4 +34,4 @@ User syncs for the alias only run when the publisher enables
 | --------------- | ---------- | ------------------------------------ | ----------------------------------- | ---------- |
 | `publisherId` | required | Publisher ID on the Ferio platform | `'pubwZR87JRDZSf6V'` | `string` |
 | `adUnitId` | required | Ad unit ID on the Ferio platform | `'3855715c-2ceb-4ba5-a876-8c43a987f210'` | `string` |
-| `tenantId` | required | Tenant ID on the Ferio platform | `'featuretv-pbjs'` | `string` |
+| `tenantId` | required | Tenant ID on the Ferio platform | `'myfeature-pbjs'` | `string` |


### PR DESCRIPTION
## 🏷 Type of documentation
- [x] new bid adapter

## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked
- [x] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)


## Notes
- Also adds the myfeature alias page (aliasCode: ferio, client-side only / pbs: false)

- Also the LunamediaHB bidder adapter maintenance transfer to Ferio. Corresponding pr: https://github.com/prebid/Prebid.js/pull/15099
