### PR TITLE
Clickio: bidder doc update

### DIFF
--- a/dev-docs/bidders/clickio.md
+++ b/dev-docs/bidders/clickio.md
@@ -4,7 +4,7 @@ title: Clickio
 description: Clickio Bidder Adapter
 biddercode: clickio
 pbjs: true
-pbs: false
+pbs: true
 gvl_id: 1500
 tcfeu_supported: true
 usp_supported: true
@@ -31,6 +31,7 @@ To get started, simply replace the ``said`` with the ID assigned to you.
 
 ## Bid Params
 
+{: .table .table-bordered .table-striped }
 | Name   | Scope    | Description  | Example   | Type     |
 |--------|----------|--------------|-----------|----------|
 | `said` | required | Site Area ID | `'11111'` | `string` |


### PR DESCRIPTION
Updated Clickio bidder documentation:
- changed `pbs` support flag from `false` to `true`
- added table classes (`.table .table-bordered .table-striped`) to the Bid Params table for consistent rendering with other bidder docs

Prebid Server Adaper PR - https://github.com/prebid/prebid-server/pull/4786

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] update bid adapter

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->

