### PR TITLE
AdOcean Bid Adapter: support for optional, extra emitter parameters

### DIFF
--- a/dev-docs/bidders/adocean.md
+++ b/dev-docs/bidders/adocean.md
@@ -27,11 +27,11 @@ privacy_sandbox: no
 sidebarType: 1
 ---
 
-### Note
+## Note
 
 If you have any issues with setting up the AdOcean bidder, please contact with your local Technical Support team or by visiting [AdOcean website](https://adocean-global.com/en/contact/).
 
-### Prebid.JS Bid Params
+## Prebid.JS Bid Params
 
 {: .table .table-bordered .table-striped }
 | Name                  | Scope    | Description                | Example                                            | Type     |

--- a/dev-docs/bidders/adocean.md
+++ b/dev-docs/bidders/adocean.md
@@ -34,8 +34,9 @@ If you have any issues with setting up the AdOcean bidder, please contact with y
 ### Prebid.JS Bid Params
 
 {: .table .table-bordered .table-striped }
-| Name     | Scope    | Description       | Example                                            | Type     |
-|----------|----------|-------------------|----------------------------------------------------|----------|
-| slaveId  | required | slave ID          | `'adoceanmyaotcpiltmmnj'`                          | `string` |
-| masterId | required | master ID         | `'ek1AWtSWh3BOa_x2P1vlMQ_uXXJpJcbhsHAY5PFQjWD.D7'` | `string` |
-| emitter  | required | traffic source id | `'myao.adocean.pl'`                                | `string` |
+| Name                  | Scope    | Description                | Example                                            | Type     |
+|-----------------------|----------|----------------------------|----------------------------------------------------|----------|
+| slaveId               | required | slave ID                   | `'adoceanmyaotcpiltmmnj'`                          | `string` |
+| masterId              | required | master ID                  | `'ek1AWtSWh3BOa_x2P1vlMQ_uXXJpJcbhsHAY5PFQjWD.D7'` | `string` |
+| emitter               | required | traffic source id          | `'myao.adocean.pl'`                                | `string` |
+| emitterRequestParams  | optional | extra targeting parameters | `{key: 'value'}`                                   | `object` |


### PR DESCRIPTION
## 🏷 Type of documentation
- [x] update bid adapter


- [x] Related pull requests in prebid.js: https://github.com/prebid/Prebid.js/pull/14959

