### PR TITLE
Eskimi: enable Prebid Server adapter (banner + video, app + web)

### DIFF
--- a/dev-docs/bidders/eskimi.md
+++ b/dev-docs/bidders/eskimi.md
@@ -3,7 +3,8 @@ layout: bidder
 title: Eskimi
 description: Prebid Eskimi Bidder Adapter
 pbjs: true
-pbs: false
+pbs: true
+pbs_app_supported: true
 biddercode: eskimi
 media_types: banner, video
 schain_supported: true
@@ -21,7 +22,7 @@ gvl_id: 814
 sidebarType: 1
 ---
 
-### Bid Params
+## Bid Params
 
 {: .table .table-bordered .table-striped }
 
@@ -31,10 +32,10 @@ sidebarType: 1
 | `bcat`            | optional | ORTB blocked categories         | `['IAB-1-1']`          | `string[]`|
 | `badv`            | optional | ORTB blocked advertiser domains | `['example.com']`      | `string[]`|
 | `bapp`            | optional | ORTB blocked applications       | `['com.example.game']` | `string[]`|
-| `bidFloor`        | optional | Minimum CPM                   | `0.3`                | `number` |
-| `bidFloorCur`     | optional | Currency of bid floor         | `'USD'`              | `string` |
-| `coppa`           | optional | Set to `true` to enable COPPA  | `true`               | `boolean` |
-| `test`            | optional | Set to `1` to enable test mode | `1`                  | `integer` |
+| `bidFloor`        | optional | Minimum CPM                     | `0.3`                  | `number`  |
+| `bidFloorCur`     | optional | Currency of bid floor           | `'USD'`                | `string`  |
+| `coppa`           | optional | Set to `true` to enable COPPA   | `true`                 | `boolean` |
+| `test`            | optional | Set to `1` to enable test mode  | `1`                    | `integer` |
 
 Additionally `battr` ORTB blocking param may be set on `BANNER` and `VIDEO` media types to specify blocked creative
 attributes.


### PR DESCRIPTION
## Type of change

Updates the Eskimi bidder page to reflect the new Prebid Server adapter shipping in **prebid-server #4806**:

- `pbs: false` → `pbs: true`
- adds `pbs_app_supported: true` (the PBS adapter supports both site and app)

## Notes

- The `media_types: banner, video` line is **unchanged** — the PBS adapter ships with banner + video parity with the Prebid.js adapter from day one; both formats are declared under `app` and `site` capabilities in `static/bidder-info/eskimi.yaml`.
- GVL ID 814, TCF v2 / USP / GPP / COPPA / SChain support are unchanged.
- Cookie sync (redirect type) is declared in `static/bidder-info/eskimi.yaml` in the prebid-server PR; the auto-generated PBS bidders matrix at <https://docs.prebid.org/dev-docs/pbs-bidders.html> picks it up from there.

## Companion PR

prebid-server: https://github.com/prebid/prebid-server/pull/4806
