### PR TITLE
Fix SharedId documentation typo

### DIFF
--- a/identity/sharedid.md
+++ b/identity/sharedid.md
@@ -181,7 +181,7 @@ Publishers that decide to build a first-party opt-out workflow might follow a pr
 
 ## Alternative Implementations
 
-For those not using Prebid's header bidding solution, SharedId can deployed via in inline script reference or from a web server.
+For those not using Prebid's header bidding solution, SharedId can be deployed via in inline script reference or from a web server.
 
 ### SharedId Script
 


### PR DESCRIPTION
## Summary
- Fix a small grammar typo in the SharedId documentation.

## Testing
- Not run; documentation-only change.