### PR TITLE
Recommend dynamic creatives for Prebid.js native templates

### DIFF
--- a/adops/gam-native.md
+++ b/adops/gam-native.md
@@ -19,9 +19,9 @@ This page walks you through the steps required to set up native ads in GAM for t
 - Create a native ad template within the Google Ad Manager (GAM) native design tool.
 - Prebid Mobile In-App native
 
-You don't necessarily need to use GAM's native design tool - if you're using Prebid.js and have chosen to use
-in-adunit or external native templates, then you can just follow the
-instructions for [banner creatives with the PUC](/adops/gam-creative-banner-sbs.html).
+You don't necessarily need to use GAM's native design tool. If you're using Prebid.js and have chosen to use
+in-adunit or external native templates, the recommended ad ops workflow is to use a
+[Prebid.js dynamic creative](/adops/js-dynamic-creative.html) rather than Prebid Universal Creative (PUC).
 
 {: .alert.alert-success :}
 For complete instructions on setting up Prebid line items in Google Ad Manager, see [Google Ad Manager with Prebid Step by Step](/adops/step-by-step.html).
@@ -71,8 +71,8 @@ If this creative is served, it will fire impression trackers on load. Clicking t
 The creative template HTML will depend on which of the three scenarios you're implementing. You can choose to manage the native template in one of these ways:
 
 - in GAM ([Managing the Native Template in GAM](#managing-the-native-template-in-gam) below)
-- in the Prebid.js AdUnit - this is handled as a 3rd party HTML creative using the Prebid Universal Creative.
-- in a separate JavaScript file - this is handled as a 3rd party HTML creative using the Prebid Universal Creative.
+- in the Prebid.js AdUnit, handled as a third-party HTML creative using the [Prebid.js dynamic creative workflow](#managing-the-native-template-outside-of-gam)
+- in a separate JavaScript file, handled as a third-party HTML creative using the [Prebid.js dynamic creative workflow](#managing-the-native-template-outside-of-gam)
 
 {: .alert.alert-info :}
 For engineering instructions, see [Native Implementation Guide](/prebid/native-implementation.html).
@@ -81,6 +81,29 @@ For engineering instructions, see [Native Implementation Guide](/prebid/native-i
 2. After entering your HTML and CSS per the approriate instructions below, click **Continue**.
 3. Add any targeting you want to apply and click **Save and activate** (or **Save** if you're not yet ready to activate your template.)
 4. Provide a **Name** for your native style and click **Save**.
+
+#### Managing the Native Template Outside of GAM
+
+If your native template is defined in the Prebid.js AdUnit or in a separate JavaScript renderer,
+set up the ad server creative with the [Prebid.js dynamic creative](/adops/js-dynamic-creative.html).
+This is the recommended browser workflow for Prebid.js native ads because the creative asks
+Prebid.js to render the winning bid directly instead of loading PUC.
+
+Use this workflow when all of the following are true:
+
+- the line item targets browser inventory where Prebid.js is present on the page;
+- your Prebid.js bundle includes the [nativeRendering](/dev-docs/modules/nativeRendering.html) module;
+- you are using Prebid.js 8.36 or later.
+
+For GAM, create a third-party HTML creative and paste the dynamic creative from the
+[Prebid.js dynamic creatives](/adops/js-dynamic-creative.html) guide. Keep the GAM macros in the
+second `script` block. In Send All Bids setups, replace `%%PATTERN:hb_adid%%` with the bidder-specific
+`%%PATTERN:hb_adid_BIDDERCODE%%` value for each bidder creative, truncating the key name as required
+by GAM.
+
+{: .alert.alert-info :}
+Dynamic creatives are for Prebid.js browser line items. Continue to use the GAM native design-tool
+workflow below when GAM owns the native template, and use the mobile in-app workflow for Prebid Mobile.
 
 #### Managing the Native Template in GAM
 
@@ -235,6 +258,6 @@ Follow the instructions in [Google Ad Manager with Prebid Step by Step](/adops/s
 - [Google Ad Manager with Prebid Step by Step](/adops/step-by-step.html)
 - [Prebid Native Implementation Guide](/prebid/native-implementation.html)
 - [Send All Bids vs Top Price](/adops/send-all-vs-top-price.html)
-- [Prebid Universal Creative](/overview/prebid-universal-creative.html)
+- [Prebid.js dynamic creatives](/adops/js-dynamic-creative.html)
 - [Creative Considerations](/adops/creative-considerations.html)
 - [Ad Ops Planning Guide](/adops/adops-planning-guide.html)

--- a/prebid/native-implementation.md
+++ b/prebid/native-implementation.md
@@ -64,11 +64,11 @@ This table summarizes how the 3 approaches work:
 {: .table .table-bordered .table-striped }
 
 | Component | AdServer-Defined Creative Scenario | AdUnit-Defined Creative Scenario | Custom Renderer Scenario |
-| --- | --- |--- | --- |
+| --- | --- | --- | --- |
 | Prebid.js | mediaTypes. native.ortb | mediaTypes. native.ortb and mediaTypes.native.adTemplate contains ##macros## | mediaTypes. native.ortb and mediaTypes.native.rendererUrl |
 | Ad Server Key Value Pairs | hb_adid | hb_adid | hb_adid |
-| Ad Server | Native template loads native.js and calls renderNativeAd(). Uses Prebid ##macro## format. | Native creative loads native.js and calls renderNativeAd() with requestAllAssets: true | Native creative loads native.js and calls renderNativeAd(), with requestAllAssets:true |
-| Prebid Universal Creative | renderNativeAd resolves macros in the creative body and CSS. | renderNativeAd resolves ##macros## in adTemplate and CSS, appending the adTemplate to the creative body | renderNativeAd loads javascript from renderUrl, calls the renderAd function, appending the results to the creative body. |
+| Ad Server | Native template loads native.js and calls renderNativeAd(). Uses Prebid ##macro## format. | Dynamic creative calls Prebid.js with the winning hb_adid. | Dynamic creative calls Prebid.js with the winning hb_adid. |
+| Rendering code | renderNativeAd resolves macros in the creative body and CSS. | Prebid.js uses the nativeRendering module to resolve ##macros## in adTemplate and append the adTemplate to the creative body. | Prebid.js uses the nativeRendering module to load JavaScript from renderUrl, call the renderAd function, and append the results to the creative body. |
 | Javascript rendering function | n/a | n/a | Receives the ortb response into `bid.ortb`, and the renderer is responsible for resolving any macro format and returning an HTML block. |
 
 ## 3. Prebid.js Native AdUnit Overview
@@ -425,32 +425,20 @@ var adUnits = [{
 
 #### 4.2.2. Define the AdServer Creative
 
-Even though the body of the native creative is defined in the AdUnit, an AdServer creative is still needed. There are two key aspects of the native creative in this scenario:
+Even though the body of the native creative is defined in the AdUnit, an AdServer creative is still needed.
+For Prebid.js browser inventory, the recommended ad server creative is the
+[Prebid.js dynamic creative](/adops/js-dynamic-creative.html) rather than PUC.
+The dynamic creative calls back to Prebid.js with the winning `hb_adid`, and Prebid.js uses the
+[nativeRendering](/dev-docs/modules/nativeRendering.html) module to render the AdUnit-defined template.
 
-1. Load the Prebid.js native rendering code. You may utilize the jsdelivr version of native.js or host your own copy. If you use the version hosted on jsdelivr, make sure any necessary ad server permissions are established.
-2. Invoke the Prebid.js native rendering function with an object containing the following attributes:
-   1. adid - used to identify which Prebid.js creative holds the appropriate native assets
-   2. pubUrl - the URL of the page, which is needed for the HTML postmessage call
-   3. requestAllAssets - tells the renderer to get all the native assets from Prebid.js. The rendering function cannot currently scan a template defined in the AdUnit.
-
-Example Creative HTML
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/prebid-universal-creative@%%PATTERN:hb_ver%%/dist//%%PATTERN:hb_format%%.js"></script>
-<script>
-    var pbNativeTagData = {};
-    pbNativeTagData.pubUrl = "%%PATTERN:url%%";     // GAM specific
-    pbNativeTagData.adId = "%%PATTERN:hb_adid%%";   // GAM specific
-    // if you're using 'Send All Bids' mode, you should use %%PATTERN:hb_adid_BIDDER%%
-    pbNativeTagData.requestAllAssets = true;
-    // if you want to track clicks in GAM, add the following variable
-    pbNativeTagData.clickUrlUnesc = "%%CLICK_URL_UNESC%%";
-    window.pbNativeTag.renderNativeAd(pbNativeTagData);
-</script>
-```
+Dynamic creatives require Prebid.js 8.36 or later and require Prebid.js to be present on the page.
+Set up the creative following the [dynamic creative example](/adops/js-dynamic-creative.html#how-to-use).
+For GAM, keep the `%%PATTERN:hb_adid%%`, `%%PATTERN:url%%`, and `%%CLICK_URL_UNESC%%` macros in the
+second `script` block.
 
 {: .alert.alert-warning :}
-When using 'Send All Bids' mode you should update `pbNativeTagData.adId = "%%PATTERN:hb_adid_BIDDERCODE%%";` for each bidder’s creative.
+When using 'Send All Bids' mode, replace `%%PATTERN:hb_adid%%` with
+`%%PATTERN:hb_adid_BIDDERCODE%%` for each bidder's creative, truncating the key name as required by GAM.
 
 {: .alert.alert-info :}
 See [Managing the Native Template Outside of GAM](/adops/gam-native.html#managing-the-native-template-outside-of-gam) for ad server instructions.
@@ -515,32 +503,21 @@ var adUnits = [{
 
 #### 4.3.2. Define the AdServer Creative
 
-Even though the body of the native creative is defined in the external JavaScript, an AdServer creative is still needed. There are two key aspects of the native creative in this scenario:
+Even though the body of the native creative is defined in the external JavaScript,
+an AdServer creative is still needed. For Prebid.js browser inventory, use the
+[Prebid.js dynamic creative](/adops/js-dynamic-creative.html) rather than PUC.
+The dynamic creative calls back to Prebid.js with the winning `hb_adid`, and Prebid.js uses the
+[nativeRendering](/dev-docs/modules/nativeRendering.html) module to load the `rendererUrl` and call
+`window.renderAd()`.
 
-1. Load the Prebid.js native rendering code. You may utilize the jsdelivr version of native.js or host your own copy. If you use the version hosted on jsdelivr, make sure any necessary ad server permissions are established.
-2. Invoke the Prebid.js native rendering function with an object containing the following attributes:
-   1. adid - used to identify which Prebid.js creative holds the appropriate native assets
-   2. pubUrl - the URL of the page, which is needed for the HTML postmessage call
-   3. requestAllAssets - tells the renderer to get all the native assets from Prebid.js so they can be passed to the render function.
-
-Example creative HTML:
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/prebid-universal-creative@%%PATTERN:hb_ver%%/dist//%%PATTERN:hb_format%%.js"></script>
-<script>
-    var pbNativeTagData = {};
-    pbNativeTagData.pubUrl = "%%PATTERN:url%%";    // GAM specific
-    pbNativeTagData.adId = "%%PATTERN:hb_adid%%";  // GAM specific
-    // if you're using 'Send All Bids' mode, you should use %%PATTERN:hb_adid_BIDDER%%
-    pbNativeTagData.requestAllAssets = true;
-    // if you want to track clicks in GAM, add the following variable
-    pbNativeTagData.clickUrlUnesc = "%%CLICK_URL_UNESC%%";
-    window.pbNativeTag.renderNativeAd(pbNativeTagData);
-</script>
-```
+Dynamic creatives require Prebid.js 8.36 or later and require Prebid.js to be present on the page.
+Set up the creative following the [dynamic creative example](/adops/js-dynamic-creative.html#how-to-use).
+For GAM, keep the `%%PATTERN:hb_adid%%`, `%%PATTERN:url%%`, and `%%CLICK_URL_UNESC%%` macros in the
+second `script` block.
 
 {: .alert.alert-warning :}
-When using `Send All Bids` you should update `pbNativeTagData.adId = "%%PATTERN:hb_adid_biddercode%%";` for each bidder’s creative
+When using `Send All Bids`, replace `%%PATTERN:hb_adid%%` with
+`%%PATTERN:hb_adid_BIDDERCODE%%` for each bidder's creative, truncating the key name as required by GAM.
 
 {: .alert.alert-info :}
 See [Managing the Native Template Outside of GAM](/adops/gam-native.html#managing-the-native-template-outside-of-gam) for ad server instructions.
@@ -549,7 +526,7 @@ See [Managing the Native Template Outside of GAM](/adops/gam-native.html#managin
 
 Requirements for a native rendering function:
 
-- It must define a `window.renderAd()` function that will be called by the Prebid Universal Creative
+- It must define a `window.renderAd()` function that will be called by the Prebid.js native rendering module
 - The `renderAd()` function is passed an object containing an `ortb` property that contains the response in OpenRTB format, and must return a fully resolved and ready-to-display block of HTML that will be appended to the body.
 - The renderer can optionally expose a `window.postRenderAd()` function that can be useful to trigger javascript functions.
 


### PR DESCRIPTION
Fixes #6401 

### Motivation

- The Prebid Universal Creative (PUC) is no longer the recommended default for Prebid.js-managed native templates and a clearer, modern workflow is needed. 
- Publishers who define native templates in Prebid.js (AdUnit or external renderer) should use a browser-native rendering path that avoids the extra PUC fetch and improves performance. 
- Update documentation to point ad ops to the Prebid.js dynamic creative workflow and to describe required Prebid.js features for native rendering.

### Description

- Update `adops/gam-native.md` to add a **Managing the Native Template Outside of GAM** section that recommends the Prebid.js dynamic creative workflow for Prebid.js-managed native templates and lists requirements (browser inventory with Prebid.js present, `nativeRendering` module, Prebid.js >= 8.36). 
- Modify `adops/gam-native.md` to explain GAM setup for dynamic creatives (use the dynamic creative example, keep GAM macros in the second script block, and explain Send All Bids handling). 
- Update `prebid/native-implementation.md` to change the implementation table and the AdUnit-defined / Custom Renderer ad server creative guidance to reference dynamic creatives and the `nativeRendering` module instead of relying on PUC, and to update wording around `window.renderAd()` usage. 
- Minor markdown/table formatting fixes to satisfy lint rules and replace the PUC further-reading link with the dynamic creatives guide.

### Testing

- Ran `npx --yes markdownlint-cli --config .markdownlint.json adops/gam-native.md prebid/native-implementation.md` and addressed the lint issues reported; the lint check completed successfully. 
- Ran `bundle exec jekyll build` to verify the site builds and the build completed without errors. 
- Confirmed the edited pages render in the generated site output during the `jekyll build` step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a29275e7c60832b9cea171ac0663081)