### PR TITLE
New Bidder: Ezoic

### DIFF
--- a/dev-docs/bidders/ezoic.md
+++ b/dev-docs/bidders/ezoic.md
@@ -1,0 +1,41 @@
+---
+layout: bidder
+title: Ezoic
+description: Prebid Ezoic Bidder Adapter
+biddercode: ezoic
+tcfeu_supported: true
+gvl_id: 347
+usp_supported: true
+gpp_sids: tcfeu, usp
+coppa_supported: false
+schain_supported: true
+dchain_supported: false
+media_types: banner
+safeframes_ok: false
+deals_supported: false
+floors_supported: true
+fpd_supported: true
+pbjs: false
+pbs: true
+pbs_app_supported: false
+multiformat_supported: will-bid-on-one
+ortb_blocking_supported: false
+privacy_sandbox: no
+sidebarType: 1
+---
+
+### Registration
+
+The Ezoic bidder adapter requires approval before use. Bids are returned
+only for publisher domains that have been registered and approved by
+Ezoic; requests for unapproved inventory receive no-bid responses.
+Contact <prebid@ezoic.com> to get set up before adding the bidder.
+
+### Bid Params
+
+The Ezoic adapter requires no parameters.
+
+{: .table .table-bordered .table-striped }
+| Name          | Scope    | Description  | Example   | Type     |
+|---------------|----------|--------------|-----------|----------|
+| `placementId` | optional | Placement ID | `'11111'` | `string` |

--- a/dev-docs/bidders/ezoic.md
+++ b/dev-docs/bidders/ezoic.md
@@ -10,14 +10,14 @@ gpp_sids: tcfeu, usp
 coppa_supported: false
 schain_supported: true
 dchain_supported: false
-media_types: banner
+media_types: banner, video, native
 safeframes_ok: false
 deals_supported: false
 floors_supported: true
 fpd_supported: true
 pbjs: false
 pbs: true
-pbs_app_supported: false
+pbs_app_supported: true
 multiformat_supported: will-bid-on-one
 ortb_blocking_supported: false
 privacy_sandbox: no

--- a/dev-docs/bidders/ezoic.md
+++ b/dev-docs/bidders/ezoic.md
@@ -24,14 +24,14 @@ privacy_sandbox: no
 sidebarType: 1
 ---
 
-### Registration
+## Registration
 
 The Ezoic bidder adapter requires approval before use. Bids are returned
 only for publisher domains that have been registered and approved by
 Ezoic; requests for unapproved inventory receive no-bid responses.
 Contact <prebid@ezoic.com> to get set up before adding the bidder.
 
-### Bid Params
+## Bid Params
 
 The Ezoic adapter requires no parameters.
 


### PR DESCRIPTION
<!-- PR is writeable — feel free to fix typos/linting directly. -->

## 🏷 Type of documentation
- [x] new bid adapter

## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked -> prebid/prebid-server#4823 (New Adapter: Ezoic, PBS-Go)

Adds `dev-docs/bidders/ezoic.md` for the new server-side Ezoic bid adapter (`pbs: true`, no client-side adapter). The adapter requires publisher registration/approval before bidding, which is stated in the Registration section. No required bid params (`placementId` optional).