### PR TITLE
Adelerate: set pbs to true

### DIFF
--- a/dev-docs/bidders/adelerate.md
+++ b/dev-docs/bidders/adelerate.md
@@ -16,7 +16,7 @@ fpd_supported: true
 multiformat_supported: will-bid-on-any
 userId: all
 pbjs: true
-pbs: false
+pbs: true
 pbs_app_supported: true
 safeframes_ok: true
 sidebarType: 1


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.

⚠️ The documentation is merged after the related code changes are merged and release ⚠️
-->

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Related pull requests in prebid.js or server are linked -> [prebid/prebid-server#4767](https://github.com/prebid/prebid-server/pull/4767)
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)

## Description

Follow-up to the merged Adelerate bidder docs PR (#6557).

During that initial merge, `pbs` was temporarily set to `false` to speed up merging. This PR re-enables `pbs: true` for the Adelerate adapter now that the Prebid Server adapter is in place.