### PR TITLE
docs: update LunamediaHB and MyFeature setup contacts

### DIFF
--- a/dev-docs/bidders/lunamediahb.md
+++ b/dev-docs/bidders/lunamediahb.md
@@ -20,7 +20,7 @@ sidebarType: 1
 
 ## Note
 
-The LunamediaHB bidder adapter is maintained by Ferio and requires setup before beginning. Please contact <prebid@ferio.cloud> for more information.
+The LunamediaHB Bidding adapter requires setup before beginning. Please contact us at prebid@lunamedia.io
 
 ### Prebid.js Bid Params
 

--- a/dev-docs/bidders/lunamediahb.md
+++ b/dev-docs/bidders/lunamediahb.md
@@ -20,7 +20,7 @@ sidebarType: 1
 
 ## Note
 
-The LunamediaHB Bidding adapter requires setup before beginning. Please contact us at prebid@lunamedia.io
+The LunamediaHB Bidding adapter requires setup before beginning. Please contact us at <prebid@lunamedia.io>
 
 ### Prebid.js Bid Params
 

--- a/dev-docs/bidders/myfeature.md
+++ b/dev-docs/bidders/myfeature.md
@@ -20,12 +20,7 @@ sidebarType: 1
 
 ## Note
 
-The MyFeature bidder adapter is a client-side alias of the `ferio` adapter and
-requires setup before beginning. Please contact <prebid@ferio.cloud> for more
-information.
-
-User syncs for the alias only run when the publisher enables
-`userSync.aliasSyncEnabled` via `pbjs.setConfig`.
+The MyFeature Bidding adapter requires setup before beginning. Please contact us at prebid-support@myfeature.tv
 
 ## Prebid.js Bid Params
 

--- a/dev-docs/bidders/myfeature.md
+++ b/dev-docs/bidders/myfeature.md
@@ -20,7 +20,7 @@ sidebarType: 1
 
 ## Note
 
-The MyFeature Bidding adapter requires setup before beginning. Please contact us at prebid-support@myfeature.tv
+The MyFeature Bidding adapter requires setup before beginning. Please contact us at <prebid-support@myfeature.tv>
 
 ## Prebid.js Bid Params
 


### PR DESCRIPTION
Updates the LunamediaHB and MyFeature bidder documentation setup notes with the correct brand-specific support contacts.

## 🏷 Type of documentation
- [ x] text edit only (wording, typos)
