### PR TITLE
Add JJTech bidder adapter documentation

### DIFF
--- a/dev-docs/bidders/jjtech.md
+++ b/dev-docs/bidders/jjtech.md
@@ -21,7 +21,7 @@ pbs: false
 sidebarType: 1
 ---
 
-### Bid Params
+## Bid Params
 
 {: .table .table-bordered .table-striped }
 | Name          | Scope    | Description                                   | Example                | Type     |

--- a/dev-docs/bidders/jjtech.md
+++ b/dev-docs/bidders/jjtech.md
@@ -1,0 +1,29 @@
+---
+layout: bidder
+title: JJTech
+description: JJTech (Jambojar Technologies) Bidder Adapter
+biddercode: jjtech
+media_types: banner
+tcfeu_supported: false
+dsa_supported: false
+gvl_id: none
+gpp_sids: none
+dchain_supported: false
+usp_supported: true
+coppa_supported: true
+schain_supported: true
+deals_supported: true
+floors_supported: true
+fpd_supported: true
+safeframes_ok: true
+pbjs: true
+pbs: false
+sidebarType: 1
+---
+
+### Bid Params
+
+{: .table .table-bordered .table-striped }
+| Name          | Scope    | Description                                   | Example                | Type     |
+|---------------|----------|-----------------------------------------------|------------------------|----------|
+| `placementId` | required | Placement ID assigned by JJTech               | `'test-placement-1'`   | `string` |


### PR DESCRIPTION
Documentation for the new JJTech bid adapter (banner, Prebid.js only).

Code PR: https://github.com/prebid/Prebid.js/pull/15312

Frontmatter declares: `usp_supported: true`, `coppa_supported: true`, `tcfeu_supported: false`, `gvl_id: none`, `pbs: false`, plus floors/deals/schain/fpd support. Single required bid param: `placementId`.

Please hold for merge until the code PR is released, per the standard new-bidder flow.
