### PR TITLE
Missena: remove formats bid param from bidder docs

### DIFF
--- a/dev-docs/bidders/missena.md
+++ b/dev-docs/bidders/missena.md
@@ -24,7 +24,6 @@ The Missena Bidding adapter requires setup before beginning. Please contact us a
 |------------|----------|----------------------------|-----------------|----------|
 | `apiKey`   | required | Missena's publisher token  | `'PA-34745704'` | `string` |
 | `placement`   | optional | Placement Type, default: 'sticky' | `'sticky'` | `string` |
-| `formats`  | optional | An array of formats to request (banner, native, or video) | `['banner', 'video']` | `array` |
 | `settings` | optional | An object containing extra settings for the Missena adapter | `{ settingName: 'value' }` | `object` |
 
 #### Available Placement Values

--- a/dev-docs/bidders/missena.md
+++ b/dev-docs/bidders/missena.md
@@ -13,18 +13,18 @@ pbs_app_supported: true
 prebid_member: true
 ---
 
-### Note
+## Note
 
 The Missena Bidding adapter requires setup before beginning. Please contact us at <jney@missena.com>
 
 ### Bid params
 
 {: .table .table-bordered .table-striped }
-| Name       | Scope    | Description                | Example         | Type     |
-|------------|----------|----------------------------|-----------------|----------|
-| `apiKey`   | required | Missena's publisher token  | `'PA-34745704'` | `string` |
-| `placement`   | optional | Placement Type, default: 'sticky' | `'sticky'` | `string` |
-| `settings` | optional | An object containing extra settings for the Missena adapter | `{ settingName: 'value' }` | `object` |
+| Name        | Scope    | Description                                                 | Example                    | Type     |
+|-------------|----------|-------------------------------------------------------------|----------------------------|----------|
+| `apiKey`    | required | Missena's publisher token                                   | `'PA-34745704'`            | `string` |
+| `placement` | optional | Placement Type, default: 'sticky'                           | `'sticky'`                 | `string` |
+| `settings`  | optional | An object containing extra settings for the Missena adapter | `{ settingName: 'value' }` | `object` |
 
 #### Available Placement Values
 


### PR DESCRIPTION
## 🏷 Type of documentation
- [x] update bid adapter
- [x] text edit only (wording, typos)

## 📋 Checklist
- [x] No code change required — documentation-only fix

## Description

Removes the `formats` param from the Missena bid params table.

Publishers following this page and setting `formats` in their bid params end up with a setup that prevents Missena from bidding. Removing it from the documentation avoids this incorrect configuration; the remaining params (`apiKey`, `placement`, `settings`) are unchanged.