### PR TITLE
Ad Generation: enable Prebid Server (banner, native)

### DIFF
--- a/dev-docs/bidders/adgeneration.md
+++ b/dev-docs/bidders/adgeneration.md
@@ -4,12 +4,12 @@ title: Ad Generation
 description: Prebid Ad Generation Bidder Adaptor
 schain_supported: true
 pbjs: true
-pbs: no
-pbs_app_supported: no
+pbs: true
+pbs_app_supported: true
 fpd_supported: true
 biddercode: adgeneration
 userIds: all
-media_types: native
+media_types: banner, native
 sidebarType: 1
 ---
 


### PR DESCRIPTION
Companion docs update for prebid/prebid-server#4858, which brings the Adgeneration server-side adapter into parity with our Prebid.js adapter (v1.6.6).

| front matter | before | after |
|---|---|---|
| `pbs` | no | true |
| `pbs_app_supported` | no | true |
| `media_types` | native | banner, native |

We (Supership Inc.) are the maintainer of this bidder.