### PR TITLE
Geoedge RTD Provider: document outstream video monitoring

### DIFF
--- a/dev-docs/modules/geoedgeRtdProvider.md
+++ b/dev-docs/modules/geoedgeRtdProvider.md
@@ -66,6 +66,39 @@ Parameters details:
 |params.key | String | Customer key |Required, contact Geoedge to get your key |
 |params.bidders | Object | Bidders to monitor |Optional, list of bidder to include / exclude from monitoring. Omitting this will monitor bids from all bidders. |
 |params.wap |Boolean |Wrap after preload |Optional, defaults to `false`. Set to `true` if you want to monitor only after the module has preloaded the monitoring client. |
+|params.outstream |Boolean |Monitor outstream video |Optional, defaults to `false`. Set to `true` to extend monitoring to outstream video bids. See [Outstream video](#outstream-video) below. |
+
+## Outstream video
+
+Video creatives are VAST rather than HTML, so they cannot be wrapped the way display creatives are.
+With `outstream: true` the module instead wraps the bid's own `renderer.render` and asks the
+monitoring client whether the creative may run:
+
+```javascript
+pbjs.setConfig({
+    realTimeData: {
+        dataProviders: [{
+            name: 'geoedge',
+            params: {
+                key: '123123',
+                outstream: true
+            }
+        }]
+    }
+});
+```
+
+Behavior worth knowing before enabling it:
+
+* **Render timing.** The monitoring client is preloaded when the module initializes, so by the time a
+  bid renders it has normally already answered and rendering proceeds immediately. Only a render that
+  happens before the client is ready waits for the answer, and that wait is capped by a short
+  deadline.
+* **It fails open.** If the client does not load within that deadline, or loads without a verdict for
+  the bid, the creative renders unmonitored. An ad is never lost because monitoring was unavailable.
+* **It only affects bids Prebid renders through the bid's renderer.** Bids carrying a `safeRenderer`,
+  and bids whose VAST reaches a player straight from targeting or Prebid Cache, are left untouched.
+* **Display monitoring is unchanged.** A bid handled by the outstream path is not also HTML-wrapped.
 
 ## Example
 

--- a/dev-docs/modules/geoedgeRtdProvider.md
+++ b/dev-docs/modules/geoedgeRtdProvider.md
@@ -59,14 +59,14 @@ pbjs.setConfig({
 Parameters details:
 
 {: .table .table-bordered .table-striped }
-|Name |Type |Description |Notes |
-| :------------ | :------------ | :------------ |:------------ |
-|name | String | Real time data module name |Required, always 'geoedge' |
-|params | Object | | |
-|params.key | String | Customer key |Required, contact Geoedge to get your key |
-|params.bidders | Object | Bidders to monitor |Optional, list of bidder to include / exclude from monitoring. Omitting this will monitor bids from all bidders. |
-|params.wap |Boolean |Wrap after preload |Optional, defaults to `false`. Set to `true` if you want to monitor only after the module has preloaded the monitoring client. |
-|params.outstream |Boolean |Monitor outstream video |Optional, defaults to `false`. Set to `true` to extend monitoring to outstream video bids. See [Outstream video](#outstream-video) below. |
+| Name | Type | Description | Notes |
+| :------------ | :------------ | :------------ | :------------ |
+| name | String | Real time data module name | Required, always 'geoedge' |
+| params | Object | | |
+| params.key | String | Customer key | Required, contact Geoedge to get your key |
+| params.bidders | Object | Bidders to monitor | Optional, list of bidder to include / exclude from monitoring. Omitting this will monitor bids from all bidders. |
+| params.wap | Boolean | Wrap after preload | Optional, defaults to `false`. Set to `true` if you want to monitor only after the module has preloaded the monitoring client. |
+| params.outstream | Boolean | Monitor outstream video | Optional, defaults to `false`. Set to `true` to extend monitoring to outstream video bids. See [Outstream video](#outstream-video) below. |
 
 ## Outstream video
 

--- a/dev-docs/modules/geoedgeRtdProvider.md
+++ b/dev-docs/modules/geoedgeRtdProvider.md
@@ -65,7 +65,7 @@ Parameters details:
 | params | Object | | |
 | params.key | String | Customer key | Required, contact Geoedge to get your key |
 | params.bidders | Object | Bidders to monitor | Optional, list of bidder to include / exclude from monitoring. Omitting this will monitor bids from all bidders. |
-| params.wap | Boolean | Wrap after preload | Optional, defaults to `false`. Set to `true` if you want to monitor only after the module has preloaded the monitoring client. |
+| params.wap | Boolean | Wrap after client load | Optional, defaults to `false`. Set to `true` if you want to monitor only after the module has loaded the monitoring client. |
 | params.outstream | Boolean | Monitor outstream video | Optional, defaults to `false`. Set to `true` to extend monitoring to outstream video bids. See [Outstream video](#outstream-video) below. |
 
 ## Outstream video
@@ -90,7 +90,7 @@ pbjs.setConfig({
 
 Behavior worth knowing before enabling it:
 
-* **Render timing.** The monitoring client is preloaded when the module initializes, so by the time a
+* **Render timing.** The monitoring client is loaded when the module initializes, so by the time a
   bid renders it has normally already answered and rendering proceeds immediately. Only a render that
   happens before the client is ready waits for the answer, and that wait is capped by a short
   deadline.


### PR DESCRIPTION
## 🏷 Type of documentation

- [x] New feature

## 📋 Checklist

- [x] Related pull requests in prebid.js or server are linked

Documents the new `outstream` param for the Geoedge RTD module: adds the params
table row and an "Outstream video" section covering render timing, fail-open
behavior, and which bids it applies to.

Prebid.js PR: https://github.com/prebid/Prebid.js/pull/15416