### PR TITLE
Project Agora Bidder: migrate alias to Microsoft

### DIFF
--- a/dev-docs/bidders/projectagora.md
+++ b/dev-docs/bidders/projectagora.md
@@ -5,7 +5,7 @@ description: Prebid Project Agora Bidder Adapter
 biddercode: projectagora
 pbjs: true
 pbs: false
-aliasCode: appnexus
+aliasCode: msft
 tcfeu_supported: true
 media_types: banner, video, native
 gvl_id: 1032
@@ -13,15 +13,15 @@ schain_supported: true
 userId: all
 sidebarType: 1
 ---
-### Bid Params
+## Bid Params
 
 {: .table .table-bordered .table-striped }
-| Name          | Scope    | Description           | Example   | Type      |
-|---------------|----------|-----------------------|-----------|-----------|
-| `placementId` | required | Placement id          | `'11111'` | `integer` |
+| Name           | Scope    | Description  | Example | Type      |
+|----------------|----------|--------------|---------|-----------|
+| `placement_id` | required | Placement id | `11111` | `integer` |
 
-Project Agora is an aliased bidder for AppNexus.
+Project Agora is an aliased bidder for Microsoft.
 
-### Note:
+## Note
 
-The Project Agora bidder adapter requires setup before beginning. Please contact us at pub_growth@projectagora.com.
+The Project Agora bidder adapter requires setup before beginning. Please contact us at [pub_growth@projectagora.com](mailto:pub_growth@projectagora.com).


### PR DESCRIPTION
## 🏷 Type of documentation

- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist

- [x] Related pull request in Prebid.js: https://github.com/prebid/Prebid.js/pull/15441
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)

## Description

Update the Project Agora bidder documentation for the migration from the deprecated AppNexus adapter to the Microsoft adapter:

- Change `aliasCode` from `appnexus` to `msft`.
- Replace the legacy `placementId` parameter with numeric `placement_id`.
- Identify Project Agora as an alias of Microsoft.
- Preserve the existing bidder code, GVL ID, media types, and support contact.

## Validation

`markdownlint --config .markdownlint.json dev-docs/bidders/projectagora.md` passes locally.

The Jekyll site build was not run because Bundler is not installed in the local environment.
