### PR TITLE
New bidder: Bid Espresso

### DIFF
--- a/dev-docs/bidders/bidespresso.md
+++ b/dev-docs/bidders/bidespresso.md
@@ -1,0 +1,76 @@
+---
+layout: bidder
+title: Bid Espresso
+description: Prebid Bid Espresso Bidder Adapter
+biddercode: bidespresso
+media_types: banner, video
+tcfeu_supported: false
+dsa_supported: false
+gvl_id: none
+gpp_sids: usnat, usstate_all, usp
+usp_supported: true
+coppa_supported: true
+schain_supported: false
+dchain_supported: false
+deals_supported: false
+floors_supported: true
+fpd_supported: true
+ortb_blocking_supported: true
+multiformat_supported: will-bid-on-any
+userIds: all
+prebid_member: false
+pbjs: true
+pbs: false
+sidebarType: 1
+---
+
+### Note
+
+The Bid Espresso adapter sends a single OpenRTB request per auction to the
+Bid Espresso gateway, which enriches it and fans out to demand server-side.
+Bids are returned net of the Bid Espresso margin. Registration is required —
+contact prebid@bidespresso.com to receive your `publisherId` and `inventoryId`.
+
+Outstream video requires a publisher-supplied renderer. Mixed banner+video
+ad units are fully supported: both media objects are sent on a single imp
+and either media class can bid.
+
+User syncing requires iframe syncs to be enabled for this bidder in the
+publisher's `userSync` configuration; the adapter registers no syncs in
+pixel-only mode. Price floors from the floors module are forwarded only when
+they resolve in USD; floors configured in another currency are converted
+automatically when the currency module is present.
+
+### Bid Params
+
+{: .table .table-bordered .table-striped }
+
+| Name          | Scope    | Description                                                                                    | Example      | Type     |
+|---------------|----------|------------------------------------------------------------------------------------------------|--------------|----------|
+| `publisherId` | required | Publisher ID on the Bid Espresso gateway. Provided by Bid Espresso during onboarding.           | `'k8xw2r4p'` | `string` |
+| `inventoryId` | required | Inventory segment ID. Always assigned by Bid Espresso during onboarding — single-placement integrations receive their default segment ID. | `'n7c3tkqe'` | `string` |
+
+### Example Ad Unit
+
+```javascript
+var adUnits = [
+  {
+    code: 'div-ad-leaderboard',
+    mediaTypes: {
+      banner: {
+        sizes: [
+          [728, 90],
+          [970, 90]
+        ]
+      }
+    },
+    bids: [{
+      bidder: 'bidespresso',
+      params: {
+        publisherId: 'k8xw2r4p', // Required - provided by Bid Espresso during onboarding
+        inventoryId: 'n7c3tkqe'  // Required - assigned by Bid Espresso during onboarding
+      }
+    }]
+  }
+];
+```

--- a/dev-docs/bidders/bidespresso.md
+++ b/dev-docs/bidders/bidespresso.md
@@ -67,4 +67,17 @@ var adUnits = [
     }]
   }
 ];
+
+// Enable iframe user syncing so Bid Espresso can match users to demand.
+// Required — without it no syncs fire and match rates drop.
+pbjs.setConfig({
+  userSync: {
+    filterSettings: {
+      iframe: {
+        bidders: ['bidespresso'],
+        filter: 'include'
+      }
+    }
+  }
+});
 ```

--- a/dev-docs/bidders/bidespresso.md
+++ b/dev-docs/bidders/bidespresso.md
@@ -24,17 +24,6 @@ pbs: false
 sidebarType: 1
 ---
 
-## Note
-
-The Bid Espresso adapter sends a single OpenRTB request per auction to the
-Bid Espresso gateway, which enriches it and fans out to demand server-side.
-Your `publisherId` and `inventoryId` are provided by Bid Espresso during
-onboarding.
-
-User syncing requires iframe syncs to be enabled for this bidder in the
-publisher's `userSync` configuration; the adapter registers no syncs in
-pixel-only mode.
-
 ## Bid Params
 
 {: .table .table-bordered .table-striped }

--- a/dev-docs/bidders/bidespresso.md
+++ b/dev-docs/bidders/bidespresso.md
@@ -24,12 +24,12 @@ pbs: false
 sidebarType: 1
 ---
 
-### Note
+## Note
 
 The Bid Espresso adapter sends a single OpenRTB request per auction to the
 Bid Espresso gateway, which enriches it and fans out to demand server-side.
 Bids are returned net of the Bid Espresso margin. Registration is required —
-contact prebid@bidespresso.com to receive your `publisherId` and `inventoryId`.
+contact <prebid@bidespresso.com> to receive your `publisherId` and `inventoryId`.
 
 Outstream video requires a publisher-supplied renderer. Mixed banner+video
 ad units are fully supported: both media objects are sent on a single imp
@@ -41,16 +41,16 @@ pixel-only mode. Price floors from the floors module are forwarded only when
 they resolve in USD; floors configured in another currency are converted
 automatically when the currency module is present.
 
-### Bid Params
+## Bid Params
 
 {: .table .table-bordered .table-striped }
 
-| Name          | Scope    | Description                                                                                    | Example      | Type     |
-|---------------|----------|------------------------------------------------------------------------------------------------|--------------|----------|
-| `publisherId` | required | Publisher ID on the Bid Espresso gateway. Provided by Bid Espresso during onboarding.           | `'k8xw2r4p'` | `string` |
-| `inventoryId` | required | Inventory segment ID. Always assigned by Bid Espresso during onboarding — single-placement integrations receive their default segment ID. | `'n7c3tkqe'` | `string` |
+| Name | Scope | Description | Example | Type |
+| --- | --- | --- | --- | --- |
+| `publisherId` | required | Publisher ID on the Bid Espresso gateway. Provided by Bid Espresso during onboarding. | `'k8xw2r4p'` | `string` |
+| `inventoryId` | required | Inventory segment ID, assigned by Bid Espresso during onboarding. Single-placement integrations receive a default segment ID. | `'n7c3tkqe'` | `string` |
 
-### Example Ad Unit
+## Example Ad Unit
 
 ```javascript
 var adUnits = [

--- a/dev-docs/bidders/bidespresso.md
+++ b/dev-docs/bidders/bidespresso.md
@@ -5,14 +5,14 @@ description: Prebid Bid Espresso Bidder Adapter
 biddercode: bidespresso
 media_types: banner, video
 tcfeu_supported: false
-dsa_supported: false
+dsa_supported: true
 gvl_id: none
 gpp_sids: usnat, usstate_all, usp
 usp_supported: true
 coppa_supported: true
-schain_supported: false
+schain_supported: true
 dchain_supported: false
-deals_supported: false
+deals_supported: true
 floors_supported: true
 fpd_supported: true
 ortb_blocking_supported: true
@@ -28,18 +28,12 @@ sidebarType: 1
 
 The Bid Espresso adapter sends a single OpenRTB request per auction to the
 Bid Espresso gateway, which enriches it and fans out to demand server-side.
-Bids are returned net of the Bid Espresso margin. Registration is required —
-contact <prebid@bidespresso.com> to receive your `publisherId` and `inventoryId`.
-
-Outstream video requires a publisher-supplied renderer. Mixed banner+video
-ad units are fully supported: both media objects are sent on a single imp
-and either media class can bid.
+Your `publisherId` and `inventoryId` are provided by Bid Espresso during
+onboarding.
 
 User syncing requires iframe syncs to be enabled for this bidder in the
 publisher's `userSync` configuration; the adapter registers no syncs in
-pixel-only mode. Price floors from the floors module are forwarded only when
-they resolve in USD; floors configured in another currency are converted
-automatically when the currency module is present.
+pixel-only mode.
 
 ## Bid Params
 
@@ -68,7 +62,7 @@ var adUnits = [
       bidder: 'bidespresso',
       params: {
         publisherId: 'k8xw2r4p', // Required - provided by Bid Espresso during onboarding
-        inventoryId: 'n7c3tkqe'  // Required - assigned by Bid Espresso during onboarding
+        inventoryId: 'n7c3tkqe'  // Required - provided by Bid Espresso during onboarding
       }
     }]
   }

--- a/dev-docs/bidders/bidespresso.md
+++ b/dev-docs/bidders/bidespresso.md
@@ -57,8 +57,7 @@ var adUnits = [
   }
 ];
 
-// Enable iframe user syncing so Bid Espresso can match users to demand.
-// Required — without it no syncs fire and match rates drop.
+// Required - enables Bid Espresso user syncing
 pbjs.setConfig({
   userSync: {
     filterSettings: {


### PR DESCRIPTION
Adds the bidder documentation page for the new Bid Espresso adapter.

Adapter PR: prebid/Prebid.js#15466

Front-matter flags match the shipped adapter: banner+video with
`multiformat_supported: will-bid-on-any` (mixed ad units send both media
objects; the gateway answers per media class), `floors_supported: true`
(USD-resolved via the floors module), `usp`/`coppa` supported, no GVL ID
(vendorless posture documented in the module .md), `pbjs` only.
