### PR TITLE
Document mobile ad controls

### DIFF
--- a/_includes/mobile/rewarded-server-side-configuration.md
+++ b/_includes/mobile/rewarded-server-side-configuration.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD041 -->
+
 ##### Server-side Rewarded Ad Unit Configuration
 
 The Rewarded Ad Unit assumes special behavior that should be configurable by the platform or publisher according to the application or ad experience guides.  
@@ -7,6 +9,7 @@ Configuration of rewarded ad unit can be done by defining the Prebid Server [pas
 Prebid SDK will search for a particular `rwdd` object in `$.seatbid.bid.ext.prebid.passthrough` of bid response to configure the behavior and rendering of the Rewarded Ad Unit. The following table describes the structure and usage purpose of `rwdd` configuration parameters.  
 
 {: .table .table-bordered .table-striped }
+<!-- markdownlint-disable MD060 -->
 | Attribute | Type | Description | Example |  
 |-----------|------|-------------|---------|
 | `reward`             | object <br> (optional)   | Metadata provided by the publisher to describe the reward.                                                             |<code>{<br>&nbsp;"type": "SuperDollars",<br>&nbsp;"count": 10<br>}</code> | 
@@ -26,7 +29,38 @@ Prebid SDK will search for a particular `rwdd` object in `$.seatbid.bid.ext.preb
 | `close`              | object <br> (optional)   | Describes the ad close behavior after the reward is earned. |<code>{<br>&nbsp;"postrewardtime": 3,<br>&nbsp;"action": "autoclose"<br>}</code> | 
 | `close.postrewardtime` | integer  | Time interval (seconds) after reward event when SDK should close interstitial. | `3` | 
 | `close.action`       | string   | Action SDK should make: `"autoclose"` (close interstitial) or `"closebutton"` (show close button) | `"autoclose"` | 
+<!-- markdownlint-enable MD060 -->
 
+Publishers can also supply the same impression-level configuration from the app with the ad unit's `setImpORTBConfig()` method. This is useful when a bidder does not return `rwdd` and the app needs to replace the default 120-second end-card completion time. Pass the `ext.prebid.passthrough` portion of the impression, for example:
+
+```json
+{
+  "ext": {
+    "prebid": {
+      "passthrough": [
+        {
+          "type": "prebidmobilesdk",
+          "rwdd": {
+            "completion": {
+              "video": {
+                "endcard": {
+                  "time": 15
+                }
+              }
+            },
+            "close": {
+              "postrewardtime": 0,
+              "action": "closebutton"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Serialize this object as JSON and pass it to `RewardedAdUnit.setImpORTBConfig()`. Prebid Server returns the passthrough data with the bid, where the SDK reads the `rwdd` configuration.
 
 An example of an impression-level stored request:
 

--- a/prebid-mobile/modules/rendering/combined-ad-experience-controls.md
+++ b/prebid-mobile/modules/rendering/combined-ad-experience-controls.md
@@ -236,6 +236,32 @@ This setting determines the number of seconds after the start of playback before
 
 {% include code/mobile-sdk.html id="skip-delay" kotlin=android swift=ios %}
 
+### Auto-Close on Video Completion
+
+This setting controls whether a non-rewarded fullscreen video ad without a companion ad closes automatically when video playback completes. Disable it to keep the interstitial open with a **Watch Again** button until the user closes the ad.
+
+Rewarded ads do not use this setting. Configure their post-reward behavior with [`rwdd.close.action`](/prebid-mobile/modules/rendering/combined-ui-ux-policy.html#rewarded-ad), using either `autoclose` or `closebutton`.
+
+{% capture android %}
+  {: .table .table-bordered .table-striped }
+
+  |**API Object**         | *not supported*|
+  |**Ad Unit Property**   | *not supported*|
+  |**Server Property**    | *not supported*|
+{% endcapture %}
+
+{% capture ios %}
+  {: .table .table-bordered .table-striped }
+
+  |**API Object**         |`InterstitialRenderingAdUnit`, `MediationInterstitialAdUnit`|
+  |**Ad Unit Property**   |`adUnit.isAutoCloseOnCompletionEnabled`|
+  |**Server Property**    |`isautocloseoncompletionenabled`|
+  |**Allowed Values**     |`true`, `false`|
+  |**Default Value**      |`true`|
+{% endcapture %}
+
+{% include code/mobile-sdk.html id="auto-close-on-video-completion" kotlin=android swift=ios %}
+
 ### Sound Button
 
 This option switches on or off the visibility of the sound/mute button for users.
@@ -310,6 +336,7 @@ Here is how you can implement all the API's to customize your ad.
   interstitialController?.skipButtonArea = 0.1
   interstitialController?.skipButtonPosition = .topRight
   interstitialController?.closeButtonPosition = .topRight
+  interstitialController?.isAutoCloseOnCompletionEnabled = false
   ```
   
 {% endcapture %}


### PR DESCRIPTION
## Summary

- document the iOS interstitial auto-close API and server property
- clarify that rewarded close behavior is controlled by rwdd.close.action
- show how to supply rewarded fallback configuration with setImpORTBConfig

## Why

This addresses the public documentation feedback on prebid/prebid-mobile-ios#1305 and documents the supported configuration path discussed on prebid/prebid-mobile-ios#1306.

## Validation

- markdownlint passed for both edited files
- bundle exec jekyll build passed