### PR TITLE
Floxis: set gvl_id to 1609

### DIFF
--- a/dev-docs/bidders/floxis.md
+++ b/dev-docs/bidders/floxis.md
@@ -10,7 +10,7 @@ safeframes_ok: true
 sidebarType: 1
 tcfeu_supported: true
 dsa_supported: false
-gvl_id: none
+gvl_id: 1609
 usp_supported: true
 coppa_supported: true
 gpp_supported: true

--- a/dev-docs/bidders/floxis.md
+++ b/dev-docs/bidders/floxis.md
@@ -25,29 +25,29 @@ ortb_blocking_supported: true
 privacy_sandbox: no
 ---
 
-### Note
+## Note
 
 The Floxis bidder adapter enables integration with the Floxis programmatic advertising platform via Prebid.js. It supports banner, video, and native formats with OpenRTB 2.x compliance. Please contact Floxis to set up your partner account and obtain the required parameters.
 
-### Bid Params
+## Bid Params
 
 {: .table .table-bordered .table-striped }
 
 | Name | Scope | Description | Example | Type |
-|------|-------|-------------|---------|------|
+| ------ | ------- | ----------- | ------- | ---- |
 | `seat` | required | Seat identifier provided by Floxis | `"testSeat"` | `string` |
 | `region` | required | Region identifier for routing | `"us-e"` | `string` |
 | `partner` | required | Partner identifier provided by Floxis | `"floxis"` | `string` |
 
-### Floors Support
+## Floors Support
 
 The Floxis adapter supports the Prebid.js [Floors Module](https://docs.prebid.org/dev-docs/modules/floors.html). Floor values are automatically included in the OpenRTB request as `imp.bidfloor` and `imp.bidfloorcur`.
 
-### Privacy Support
+## Privacy Support
 
 Privacy fields (GDPR, USP, GPP, COPPA) are handled by Prebid.js core and automatically included in the OpenRTB request.
 
-### AdUnit Configuration for Banner
+## AdUnit Configuration for Banner
 
 ```javascript
 var adUnits = [{
@@ -68,7 +68,7 @@ var adUnits = [{
 }];
 ```
 
-### AdUnit Configuration for Video
+## AdUnit Configuration for Video
 
 ```javascript
 var adUnits = [{
@@ -94,7 +94,7 @@ var adUnits = [{
 }];
 ```
 
-### AdUnit Configuration for Native
+## AdUnit Configuration for Native
 
 ```javascript
 var adUnits = [{
@@ -128,7 +128,7 @@ var adUnits = [{
 }];
 ```
 
-### Example
+## Example
 
 ```javascript
 var pbjs = pbjs || {};


### PR DESCRIPTION
One-line correction: this page reads `gvl_id: none`, but the Floxis adapter has declared `gvlid: 1609` since it merged (`modules/floxisBidAdapter.js` on master, lines 7 and 171), and IAB GVL vendor **1609** is registered to Ad Tech Company OÜ (GVL v171).

Raising it separately because publishers evaluating the adapter read this page as "no registered TCF vendor ID", which is a blocker for them.

The same line is corrected in #6596, but that PR also flips `pbs: true` and is held under *Pending PBS Release* while prebid/prebid-server#4811 is in review — so the fix is currently gated on something unrelated to it. This PR carries only the `gvl_id` line so it can land independently; I'll rebase #6596 on top once it merges.
