### PR TITLE
51Degrees RTD Module: per-type 51Did eids and on-page integration

### DIFF
--- a/dev-docs/modules/51DegreesRtdProvider.md
+++ b/dev-docs/modules/51DegreesRtdProvider.md
@@ -25,7 +25,7 @@ The Cloud API is **free** to integrate and use. To increase limits please check 
 
 ## Description
 
-51Degrees module enriches an OpenRTB request with [51Degrees Device Data](https://51degrees.com/documentation/index.html) and (optionally) IP-derived geo plus a 51Did (51Degrees identifier) entry in `user.eids`.
+51Degrees module enriches an OpenRTB request with [51Degrees Device Data](https://51degrees.com/documentation/index.html) and (optionally) IP-derived geo plus 51Did (51Degrees identifier) entries in `user.eids`.
 
 51Degrees module sets the following fields of the device object: `devicetype`, `make`, `model`, `hwv`, `os`, `osv`, `h`, `w`, `ppi`, `pxratio`. Interested bidder adapters may use these fields as needed. 
 
@@ -37,9 +37,20 @@ When 51Degrees IPI is available in the cloud response, the module sets `device.i
 
 [51Did](https://51degrees.com/documentation/4.5/_identifiers_51_did.html) is a 51Degrees privacy-safe identifier derived from device signals. Its production requires a marketing usage preference (`id.usage`). The recommended way to collect and store that preference is the [51Degrees Preference Management Platform (PMP)](https://51degrees.com/documentation/4.5/_identifiers__p_m_p.html) — a lightweight consent widget that writes the user's choice to `localStorage`. When PMP is present on the page the module picks up that preference automatically. When PMP is absent the module falls back to inferring the preference from the publisher's existing TCF or GPP consent string (see below).
 
-When 51Did is available, the module appends an entry to `user.eids` with `source = "51d.es"`, `inserter = "51degrees.com"`, `mm = 5` (inference), and `uids` carrying `idproblic` and `idprobglobal`. The `ext.tdl` URL inside the entry comes from the `params.tdlUrl` module config.
+When 51Did is available, the module appends one `user.eids` entry per identifier type returned by the cloud, each with `source = "51d.es"` and `inserter = "51degrees.com"`. The match method (`mm`) is an eid-level field, so a type cannot share an entry with another type:
+
+{: .table .table-bordered .table-striped }
+| Type | `mm` | `atype` |
+| :--- | :--- | :--- |
+| Probabilistic | 5 (inference) | 1 (browser or device tied) |
+| Random | 0 (unknown) | 1 (browser or device tied) |
+| Hashed Email | 3 (authenticated) | 3 (person based) |
+
+A type's license and global values share its entry as `uids`, license value first. The `ext.tdl` URL comes from the `params.tdlUrl` module config and is added to every entry. Random and Hashed Email appear only when the resource key includes those properties, and Hashed Email additionally requires evidence supplied to the 51Degrees integration itself (see [On-page integration](#on-page-integration)).
 
 The module forwards the publisher's consent strings to the cloud as evidence when present. The TCF consent string (from Prebid's GDPR consent) is sent as `tcstring` and the GPP string (from Prebid's GPP consent) is sent as `gppstring`; the cloud can infer the marketing usage preference from either when PMP is not present, so 51Did works for publishers running any TCF or GPP CMP. These come from Prebid's consent data, not module params.
+
+When the consent evidence changes mid-session, the module reloads its script so the new strings reach the cloud, and removes the `fod` entry the 51Degrees script keeps in session storage. That entry is the script's cached cloud response and is keyed on nothing but the script's object name, so leaving it in place would let the reloaded script replay the response the previous consent produced. The module writes nothing to session storage and removes only that one key, only on a consent change; where session storage is not permitted the removal is skipped.
 
 The module supports on premise and cloud device detection services with free options for both. 
 
@@ -148,6 +159,37 @@ pbjs.setConfig({
 });
 ```
 
+### On-page integration
+
+When the page already runs its own 51Degrees integration, the module detects it automatically (the integration's `window.fod` object) and consumes its result instead of loading a second copy of the script. No module params are needed in this mode:
+
+```javascript
+pbjs.setConfig({
+    realTimeData: {
+        auctionDelay: 250,
+        dataProviders: [
+            {
+                name: '51Degrees',
+                waitForIt: true,
+            },
+        ],
+    },
+});
+```
+
+The module converts the integration's payload and enriches the ORTB2 request exactly as it does with its own script, and `tdlUrl` is still honoured. It sends nothing to the cloud itself, so the integration's script URL must carry the same parameters the module would send: `id.usage` (or the `tcstring` / `gppstring` consent strings) and any client-hint parameters. When an integration is present on the page the module uses it even if `resourceKey` is configured.
+
+Publisher requirements:
+
+* Load the 51Degrees script **synchronously**, before Prebid runs the auction. Do not use `async` or `defer` on the script tag, and do not inject it from a later-running script. Detection is a point-in-time check for `window.fod` at auction time: if the integration has not executed by then, the module does not see it and falls back to its configured behaviour, which with `resourceKey` set means loading a second copy of the script.
+* Keep the default object name (`fod`); the module reads `window.fod`, so an integration publishing under a different object name is not detected.
+* Identifiers that require additional evidence, such as Hashed Email, are configured on the 51Degrees integration itself. See the [51Degrees documentation](https://51degrees.com/documentation/index.html).
+
+Two limitations follow from consuming the page integration directly:
+
+* A consent change during the session does not re-run the page integration. Its payload reflects the consent state it was loaded under, and the new preference takes effect from the next page load.
+* If the integration never completes, the module never calls back and the auction proceeds only after the configured `auctionDelay`. The module does not fall back to loading its own script while `window.fod` is present, because two integrations on one page would conflict.
+
 ### Parameters 
 
 > Note that `resourceKey` and `onPremiseJSUrl` are mutually exclusive parameters.  Use strictly one of them: either a `resourceKey` for cloud integration and `onPremiseJSUrl` for the on-premise self-hosted integration. 
@@ -176,6 +218,9 @@ run the following command:
 and then open the following URL in your browser:
 
 `http://localhost:9999/integrationExamples/gpt/51DegreesRtdProvider_example.html`
+
+A second example shows the on-page integration mode:\
+`http://localhost:9999/integrationExamples/gpt/51DegreesRtdProvider_pageIntegration_example.html`
 
 Open the browser console to see the logs.
 


### PR DESCRIPTION
## 🏷 Type of documentation
- [x] text edit only (wording, typos)
- [x] new examples

## 📋 Checklist
- [x] Related pull requests in prebid.js: https://github.com/prebid/Prebid.js/pull/15490

## Details
Document the one user.eids entry per identifier type, with the match method and agent type each type carries, and the on-page integration mode: what it needs from the publisher, what it does not re-run, and the session storage entry the module removes on a consent change.

cc: @jwrosewell 