### PR TITLE
CWire: Support Video Media Format - Docs Update

### DIFF
--- a/dev-docs/bidders/cwire.md
+++ b/dev-docs/bidders/cwire.md
@@ -11,7 +11,7 @@ usp_supported: false
 schain_supported: false
 userIds: none
 enable_download: true
-media_types: banner
+media_types: banner, video
 sidebarType: 1
 ---
 ---

--- a/dev-docs/bidders/cwire.md
+++ b/dev-docs/bidders/cwire.md
@@ -16,7 +16,7 @@ sidebarType: 1
 ---
 ---
 
-### Bid Params
+## Bid Params
 
 {: .table .table-bordered .table-striped }
 | Name          |  Scope   |                 Description                  | Example  |   Type    |
@@ -25,7 +25,7 @@ sidebarType: 1
 | `placementId` | optional |             C-WIRE placement id              | `113244` | `integer` |
 | `domainId`    | required |               C-WIRE domain id               |  `2453`  | `integer` |
 
-### URL parameters
+## URL parameters
 
 Additionally, the following parameters can be passed by URL parameters for testing.
 

--- a/dev-docs/bidders/cwire.md
+++ b/dev-docs/bidders/cwire.md
@@ -12,6 +12,7 @@ schain_supported: false
 userIds: none
 enable_download: true
 media_types: banner, video
+multiformat_supported: will-bid-on-any
 sidebarType: 1
 ---
 ---


### PR DESCRIPTION
## Description
The CWire prebid-server adapter doc lists supported only banner media type, but now we want to support video.

## Changes
Added video to the media_types where it matter in cwire.yaml
Had code changes in prebid-server adapter, to accept video media type

## References
We opened PR for this changes: [CWIRE PR](https://github.com/prebid/prebid-server/pull/4831)





