### PR TITLE
New Bidder: Epom Ad Server

### DIFF
--- a/dev-docs/bidders/epom_as.md
+++ b/dev-docs/bidders/epom_as.md
@@ -62,7 +62,6 @@ The endpoint is reached differently. In Prebid.js the adapter builds the URL its
 
 Two differences are worth knowing rather than discovering. A browser request carries the reader's cookies; a server-side one carries none, so any frequency capping Epom applies per user needs `user.buyeruid` from a cookie sync. And the reader's address reaches Epom in the header the adapter forwards from `device.ip`, since on a server-to-server call the connection itself comes from the Prebid Server host rather than from the reader.
 
-
 ## Example Ad Unit Configuration
 
 ```javascript

--- a/dev-docs/bidders/epom_as.md
+++ b/dev-docs/bidders/epom_as.md
@@ -1,7 +1,7 @@
 ---
 layout: bidder
 title: Epom Ad Server
-description: Prebid Epom Ad Server Bid Adapter
+description: Prebid Epom Ad Server Bidder Adapter
 pbjs: true
 pbs: true
 pbs_app_supported: true
@@ -12,12 +12,11 @@ gvl_id: 849
 tcfeu_supported: true
 usp_supported: true
 coppa_supported: true
-gpp_sids: none
+gpp_sids: tcfeu, usp
 dsa_supported: false
 schain_supported: true
 dchain_supported: false
-userId: none
-userIds:
+userIds: all
 floors_supported: true
 fpd_supported: true
 deals_supported: true
@@ -41,14 +40,25 @@ All ad units on the page are auctioned in a **single request**, one `imp` per ad
 ## Bid Parameters
 
 {: .table .table-bordered .table-striped }
-| Name           | Scope    | Description                                                                                                     | Example             | Type     |
-|----------------|----------|-----------------------------------------------------------------------------------------------------------------|---------------------|----------|
-| `host`         | required | Serving host of the publisher's Epom Ad Server deployment, as a bare hostname.                                   | `'ads.example.com'` | `string` |
-| `placementKey` | required | Placement identifier, copied from the placement's invocation-code tab in the Epom UI. Sent as `imp.tagid`.        | `'a4f21c9e7b'`      | `string` |
-| `channel`      | optional | Epom channel — a publisher traffic-slice label used for channel targeting and reporting. Sent as `imp.ext.epom_as.channel`. | `"sports-uk"` | `string` |
-| `customParams` | optional | Epom custom parameters, for custom targeting and creative macros. Merged into `imp.ext.data`. Scalar values only; at most 32 keys, keys up to 128 and values up to 512 characters. | `{section: 'sport'}` | `object` |
-| `bidFloor`     | optional | CPM floor for this impression. Applied only when the Price Floors module has not already resolved `imp.bidfloor`. | `0.50`              | `number` |
-| `bidFloorCur`  | optional | Currency of `bidFloor`. Defaults to `USD`.                                                                       | `'EUR'`             | `string` |
+| Name           | Scope    | Description                                                                                                                                                                             | Example              | Type     |
+|----------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------|----------|
+| `host`         | required | Serving host of the publisher's Epom Ad Server deployment, as a bare hostname with an optional port — no scheme, path or query. The adapter POSTs to `https://{host}/hb/bid`.           | `'ads.example.com'`  | `string` |
+| `placementKey` | required | Placement identifier, copied from the placement's invocation-code tab in the Epom UI. Must not be empty. Sent as `imp.tagid`.                                                           | `'a4f21c9e7b'`       | `string` |
+| `channel`      | optional | Epom channel — a publisher traffic-slice label used for channel targeting and reporting. Sent as `imp.ext.epom_as.channel`. An empty value is ignored.                                  | `'sports-uk'`        | `string` |
+| `customParams` | optional | Epom custom parameters, for custom targeting and creative macros. Values must be strings, numbers or booleans; they are stringified and merged into `imp.ext.data`.                     | `{section: 'sport'}` | `object` |
+| `bidFloor`     | optional | CPM floor for this impression, applied only when no floor has already been resolved — a value from the Price Floors module always wins. `0` means no floor, and it may not be negative. | `0.50`               | `number` |
+| `bidFloorCur`  | optional | Currency of `bidFloor`, as an ISO-4217 code. Defaults to `USD`.                                                                                                                         | `'EUR'`              | `string` |
+
+Two details the table cannot hold comfortably:
+
+- `host` accepts a single-label hostname such as `'ads-eu'` as well as a dotted one, because an Epom deployment may be reached over an internal name. It never accepts a scheme, a path, a query, a fragment or userinfo, on either transport.
+- `customParams` carries no key-count or length limit at the adapter. Epom Ad Server applies its own ingest limits on top — at most 32 keys, keys to 128 and values to 512 characters — and ignores anything beyond them. When a key in `customParams` collides with one already on the impression, the impression's value wins; see [First Party Data](#first-party-data).
+
+## Prebid.js and Prebid Server
+
+The parameters above are the same on both transports, and both send the same OpenRTB payload, so an ad unit needs no change when it moves between them.
+
+The one difference is where the host comes from. In Prebid.js the adapter builds the URL itself from `params.host`. In Prebid Server the endpoint is host-templated as `https://{% raw %}{{.Host}}{% endraw %}/hb/bid`, resolved per impression from the same `host` parameter — a Prebid Server host operator does not configure a per-publisher endpoint.
 
 ## Example Ad Unit Configuration
 
@@ -70,7 +80,7 @@ var adUnits = [{
 
 ## Test Parameters
 
-A live placement that always fills, for checking the integration end to end:
+A live placement on an Epom-operated demo deployment, which always fills, for checking the integration end to end:
 
 ```javascript
 var adUnits = [{
@@ -113,15 +123,33 @@ pbjs.addAdUnits([
 ]);
 ```
 
+## First Party Data
+
+The adapter forwards first party data unchanged; it neither filters nor reshapes it.
+
+Global and bidder-scoped data set through `pbjs.setConfig({ortb2: ...})` or `pbjs.setBidderConfig({bidder: 'epom_as', config: {ortb2: ...}})` is merged into the OpenRTB request as supplied, so `site.*` (including `site.content` and `site.keywords`), `user.*` (including `user.data`) and `app.*` all reach Epom Ad Server. Ad-unit data set as `ortb2Imp` — most usefully `ortb2Imp.ext.data` and `ortb2Imp.ext.gpid` — is merged into that ad unit's `imp` object.
+
+`params.customParams` lands in the same place as ad-unit first party data: `imp.ext.data`. The two are merged, and **first party data wins** — a key already present on the impression, whether it came from `ortb2Imp.ext.data`, from a Real-Time Data module or from `gptPreAuction`, is not overwritten by an entry of the same name in `customParams`. Use `customParams` for values that belong to Epom's own targeting and macros, and `ortb2Imp.ext.data` for values every bidder should see.
+
+User IDs are forwarded the same way. Any ID module enabled on the page writes its EIDs into `user.ext.eids`, which the adapter passes through untouched; the adapter itself resolves no identifiers.
+
 ## Deals
 
 Every bid from Epom Ad Server carries a deal id, surfaced by Prebid as `bid.dealId` and as the `hb_deal_epom_as` targeting key. Publishers who want their own direct campaigns to take precedence over programmatic demand rather than compete with it on price can target an ad server line item on that key.
 
+## Notes
+
+Epom Ad Server does not currently populate `seatbid.bid[].adomain` on its bid responses, so `bid.meta.advertiserDomains` arrives empty. Brand-safety or blocking line items keyed on advertiser domain will not match a bid from this adapter.
+
 ## Privacy
 
-The adapter registers IAB TCF Global Vendor List ID **849** and forwards the standard OpenRTB privacy signals unchanged: `regs.ext.gdpr` and `user.ext.consent` for TCF, `regs.ext.us_privacy` for US Privacy, `regs.gpp` / `regs.gpp_sid` for GPP, and `regs.coppa`.
+The adapter registers IAB TCF Global Vendor List ID **849**.
 
-The adapter sets `withCredentials: true`, so an existing Epom identity on the ad-server domain reaches the auction; the ad server answers with the request origin rather than a wildcard. The adapter performs no user syncs.
+It forwards the standard OpenRTB privacy signals to Epom Ad Server unchanged, and enforces none of them itself — enforcement is the ad server's: `regs.ext.gdpr` and `user.ext.consent` for TCF EU, `regs.ext.us_privacy` for US Privacy, `regs.gpp` with `regs.gpp_sid` for GPP, and `regs.coppa`. The GPP sections the ad server acts on are the TCF EU and US Privacy ones.
+
+The adapter sets `withCredentials: true`, so an existing Epom identity cookie — set by the ad server on its own domain, never by the adapter — reaches the auction; the ad server answers with the request origin rather than a wildcard. The adapter itself uses no storage manager and writes nothing to cookies or local storage.
+
+The Prebid.js adapter performs no user syncs. Server-side, the sync endpoint lives on each publisher's own Epom deployment, so a Prebid Server host must configure it; contact Epom to have it enabled.
 
 ## Support
 

--- a/dev-docs/bidders/epom_as.md
+++ b/dev-docs/bidders/epom_as.md
@@ -6,7 +6,7 @@ pbjs: true
 pbs: true
 pbs_app_supported: true
 biddercode: epom_as
-media_types: banner
+media_types: banner, video, native
 multiformat_supported: will-bid-on-one
 gvl_id: 849
 tcfeu_supported: true
@@ -82,7 +82,7 @@ var adUnits = [{
 
 ## Test Parameters
 
-A live placement on an Epom-operated demo deployment, which always fills, for checking the integration end to end:
+Live placements on an Epom-operated demo deployment, which always fill, one per media type, for checking the integration end to end. Each key names a placement of that type on the same host, because the ad server decides what a placement may answer from the placement's own type.
 
 ```javascript
 var adUnits = [{
@@ -97,8 +97,48 @@ var adUnits = [{
       placementKey: '63bad7a99f270394e7b4b370952cbff2'
     }
   }]
+}, {
+  code: 'test-video',
+  mediaTypes: {
+    video: {
+      context: 'instream',
+      playerSize: [[640, 480]],
+      mimes: ['video/mp4'],
+      protocols: [2, 3, 5, 6]
+    }
+  },
+  bids: [{
+    bidder: 'epom_as',
+    params: {
+      host: 'aj2494.online',
+      placementKey: '7659fd47e17263ba6ae1de3c9e137c74'
+    }
+  }]
+}, {
+  code: 'test-native',
+  mediaTypes: {
+    native: {
+      ortb: {
+        assets: [
+          { id: 1, required: 1, title: { len: 90 } },
+          { id: 2, required: 1, img: { type: 3, w: 1200, h: 627 } },
+          { id: 3, required: 0, img: { type: 1, w: 128, h: 128 } },
+          { id: 4, required: 0, data: { type: 1, len: 50 } }
+        ]
+      }
+    }
+  },
+  bids: [{
+    bidder: 'epom_as',
+    params: {
+      host: 'aj2494.online',
+      placementKey: 'f4dd0f413d5c4f8d8c515f8a999e038f'
+    }
+  }]
 }];
 ```
+
+Instream video needs a cache setting, or Prebid discards the bid before `bidsBackHandler` runs: `pbjs.setConfig({ cache: { allowVastXmlOnly: true } })` for a player that takes VAST as a string, or a Prebid Cache `url` when the ad server is rendered through Google Ad Manager.
 
 ## Multiple Deployments
 

--- a/dev-docs/bidders/epom_as.md
+++ b/dev-docs/bidders/epom_as.md
@@ -56,9 +56,12 @@ Two details the table cannot hold comfortably:
 
 ## Prebid.js and Prebid Server
 
-The parameters above are the same on both transports, and both send the same OpenRTB payload, so an ad unit needs no change when it moves between them.
+The parameters above are the same on both transports, and the OpenRTB payload Epom Ad Server reads is the same, so an ad unit needs no change when it moves between them.
 
-The one difference is where the host comes from. In Prebid.js the adapter builds the URL itself from `params.host`. In Prebid Server the endpoint is host-templated as `https://{% raw %}{{.Host}}{% endraw %}/hb/bid`, resolved per impression from the same `host` parameter — a Prebid Server host operator does not configure a per-publisher endpoint.
+The endpoint is reached differently. In Prebid.js the adapter builds the URL itself from `params.host`. In Prebid Server it is host-templated as `https://{% raw %}{{.Host}}{% endraw %}/hb/bid`, resolved per impression from the same `host` parameter — a Prebid Server host operator does not configure a per-publisher endpoint.
+
+Two differences are worth knowing rather than discovering. A browser request carries the reader's cookies; a server-side one carries none, so any frequency capping Epom applies per user needs `user.buyeruid` from a cookie sync. And the reader's address reaches Epom in the header the adapter forwards from `device.ip`, since on a server-to-server call the connection itself comes from the Prebid Server host rather than from the reader.
+
 
 ## Example Ad Unit Configuration
 

--- a/dev-docs/bidders/epom_as.md
+++ b/dev-docs/bidders/epom_as.md
@@ -3,8 +3,8 @@ layout: bidder
 title: Epom Ad Server
 description: Prebid Epom Ad Server Bid Adapter
 pbjs: true
-pbs: true
-pbs_app_supported: true
+pbs: false
+pbs_app_supported: false
 biddercode: epom_as
 media_types: banner
 multiformat_supported: will-bid-on-one
@@ -45,6 +45,8 @@ All ad units on the page are auctioned in a **single request**, one `imp` per ad
 |----------------|----------|-----------------------------------------------------------------------------------------------------------------|---------------------|----------|
 | `host`         | required | Serving host of the publisher's Epom Ad Server deployment, as a bare hostname.                                   | `'ads.example.com'` | `string` |
 | `placementKey` | required | Placement identifier, copied from the placement's invocation-code tab in the Epom UI. Sent as `imp.tagid`.        | `'a4f21c9e7b'`      | `string` |
+| `channel`      | optional | Epom channel — a publisher traffic-slice label used for channel targeting and reporting. Sent as `imp.ext.epom_as.channel`. | `"sports-uk"` | `string` |
+| `customParams` | optional | Epom custom parameters, for custom targeting and creative macros. Merged into `imp.ext.data`. Scalar values only; at most 32 keys, keys up to 128 and values up to 512 characters. | `{section: 'sport'}` | `object` |
 | `bidFloor`     | optional | CPM floor for this impression. Applied only when the Price Floors module has not already resolved `imp.bidfloor`. | `0.50`              | `number` |
 | `bidFloorCur`  | optional | Currency of `bidFloor`. Defaults to `USD`.                                                                       | `'EUR'`             | `string` |
 
@@ -99,7 +101,7 @@ Every bid from Epom Ad Server carries a deal id, surfaced by Prebid as `bid.deal
 
 The adapter registers IAB TCF Global Vendor List ID **849** and forwards the standard OpenRTB privacy signals unchanged: `regs.ext.gdpr` and `user.ext.consent` for TCF, `regs.ext.us_privacy` for US Privacy, `regs.gpp` / `regs.gpp_sid` for GPP, and `regs.coppa`.
 
-No cookies are sent to the ad server (`withCredentials: false`) and the adapter performs no user syncs.
+The adapter sets `withCredentials: true`, so an existing Epom identity on the ad-server domain reaches the auction; the ad server answers with the request origin rather than a wildcard. The adapter performs no user syncs.
 
 ## Support
 

--- a/dev-docs/bidders/epom_as.md
+++ b/dev-docs/bidders/epom_as.md
@@ -68,6 +68,26 @@ var adUnits = [{
 }];
 ```
 
+## Test Parameters
+
+A live placement that always fills, for checking the integration end to end:
+
+```javascript
+var adUnits = [{
+  code: 'test-div',
+  mediaTypes: {
+    banner: { sizes: [[300, 250]] }
+  },
+  bids: [{
+    bidder: 'epom_as',
+    params: {
+      host: 'aj2494.online',
+      placementKey: '63bad7a99f270394e7b4b370952cbff2'
+    }
+  }]
+}];
+```
+
 ## Multiple Deployments
 
 Inventory sold by two Epom networks can run in the same auction. Each host receives its own request, containing only the impressions addressed to it.

--- a/dev-docs/bidders/epom_as.md
+++ b/dev-docs/bidders/epom_as.md
@@ -1,0 +1,106 @@
+---
+layout: bidder
+title: Epom Ad Server
+description: Prebid Epom Ad Server Bid Adapter
+pbjs: true
+pbs: true
+pbs_app_supported: true
+biddercode: epom_as
+media_types: banner
+multiformat_supported: will-bid-on-one
+gvl_id: 849
+tcfeu_supported: true
+usp_supported: true
+coppa_supported: true
+gpp_sids: none
+dsa_supported: false
+schain_supported: true
+dchain_supported: false
+userId: none
+userIds:
+floors_supported: true
+fpd_supported: true
+deals_supported: true
+ortb_blocking_supported: false
+safeframes_ok: true
+prebid_member: false
+privacy_sandbox: no
+sidebarType: 1
+---
+
+## Overview
+
+The **Epom Ad Server** bid adapter lets a publisher put their own direct-sold campaigns — booked in Epom Ad Server — into the header auction alongside programmatic demand.
+
+This is a different product from the [Epom DSP](/dev-docs/bidders/epomDspBidAdapter.html) adapter. The DSP **buys** impressions on the open market; this adapter **sells** a publisher's own inventory.
+
+Epom Ad Server is white-label: each network runs its own deployment on its own domain, so the serving host is supplied per ad unit through `params.host`. Only the host is configurable — the request path is fixed by the adapter — and a page may mix several deployments, in which case the adapter groups impressions by host and sends one request to each.
+
+All ad units on the page are auctioned in a **single request**, one `imp` per ad unit. Epom Ad Server resolves a page as a unit, so its roadblock and one-campaign-per-page rules require every slot to be decided in the same auction.
+
+## Bid Parameters
+
+{: .table .table-bordered .table-striped }
+| Name           | Scope    | Description                                                                                                     | Example             | Type     |
+|----------------|----------|-----------------------------------------------------------------------------------------------------------------|---------------------|----------|
+| `host`         | required | Serving host of the publisher's Epom Ad Server deployment, as a bare hostname.                                   | `'ads.example.com'` | `string` |
+| `placementKey` | required | Placement identifier, copied from the placement's invocation-code tab in the Epom UI. Sent as `imp.tagid`.        | `'a4f21c9e7b'`      | `string` |
+| `bidFloor`     | optional | CPM floor for this impression. Applied only when the Price Floors module has not already resolved `imp.bidfloor`. | `0.50`              | `number` |
+| `bidFloorCur`  | optional | Currency of `bidFloor`. Defaults to `USD`.                                                                       | `'EUR'`             | `string` |
+
+## Example Ad Unit Configuration
+
+```javascript
+var adUnits = [{
+  code: 'leaderboard',
+  mediaTypes: {
+    banner: { sizes: [[728, 90], [970, 250]] }
+  },
+  bids: [{
+    bidder: 'epom_as',
+    params: {
+      host: 'ads.example.com',
+      placementKey: 'a4f21c9e7b'
+    }
+  }]
+}];
+```
+
+## Multiple Deployments
+
+Inventory sold by two Epom networks can run in the same auction. Each host receives its own request, containing only the impressions addressed to it.
+
+```javascript
+pbjs.addAdUnits([
+  {
+    code: 'slot-a',
+    mediaTypes: { banner: { sizes: [[300, 250]] } },
+    bids: [{
+      bidder: 'epom_as',
+      params: { host: 'ads.network-one.com', placementKey: 'a4f21c9e7b' }
+    }]
+  },
+  {
+    code: 'slot-b',
+    mediaTypes: { banner: { sizes: [[728, 90]] } },
+    bids: [{
+      bidder: 'epom_as',
+      params: { host: 'ads.network-two.com', placementKey: '6d0e83b415' }
+    }]
+  }
+]);
+```
+
+## Deals
+
+Every bid from Epom Ad Server carries a deal id, surfaced by Prebid as `bid.dealId` and as the `hb_deal_epom_as` targeting key. Publishers who want their own direct campaigns to take precedence over programmatic demand rather than compete with it on price can target an ad server line item on that key.
+
+## Privacy
+
+The adapter registers IAB TCF Global Vendor List ID **849** and forwards the standard OpenRTB privacy signals unchanged: `regs.ext.gdpr` and `user.ext.consent` for TCF, `regs.ext.us_privacy` for US Privacy, `regs.gpp` / `regs.gpp_sid` for GPP, and `regs.coppa`.
+
+No cookies are sent to the ad server (`withCredentials: false`) and the adapter performs no user syncs.
+
+## Support
+
+📩 [support@epom.com](mailto:support@epom.com)

--- a/dev-docs/bidders/epom_as.md
+++ b/dev-docs/bidders/epom_as.md
@@ -3,8 +3,8 @@ layout: bidder
 title: Epom Ad Server
 description: Prebid Epom Ad Server Bid Adapter
 pbjs: true
-pbs: false
-pbs_app_supported: false
+pbs: true
+pbs_app_supported: true
 biddercode: epom_as
 media_types: banner
 multiformat_supported: will-bid-on-one

--- a/dev-docs/bidders/epom_as.md
+++ b/dev-docs/bidders/epom_as.md
@@ -58,9 +58,11 @@ Two details the table cannot hold comfortably:
 
 The parameters above are the same on both transports, and the OpenRTB payload Epom Ad Server reads is the same, so an ad unit needs no change when it moves between them.
 
+The server-side adapter is written for **Prebid Server Go**; there is no Prebid Server Java implementation. It is not in a released build yet — it is open as [prebid-server PR #4916](https://github.com/prebid/prebid-server/pull/4916), so a host that wants it today builds from that branch. A build without it refuses the impression by name rather than ignoring it: `request.imp[0].ext.prebid.bidder contains unknown bidder: epom_as`.
+
 The endpoint is reached differently. In Prebid.js the adapter builds the URL itself from `params.host`. In Prebid Server it is host-templated as `https://{% raw %}{{.Host}}{% endraw %}/hb/bid`, resolved per impression from the same `host` parameter — a Prebid Server host operator does not configure a per-publisher endpoint.
 
-Two differences are worth knowing rather than discovering. A browser request carries the reader's cookies; a server-side one carries none, so any frequency capping Epom applies per user needs `user.buyeruid` from a cookie sync. And the reader's address reaches Epom in the header the adapter forwards from `device.ip`, since on a server-to-server call the connection itself comes from the Prebid Server host rather than from the reader.
+One difference is worth knowing rather than discovering. A browser request carries the reader's cookies, and Epom's per-user frequency capping counts against the identity in one of them; a server-side request carries none, and Epom Ad Server reads no `user.buyeruid` on this path, so per-user capping has no identity to count against there. The reader's address does reach Epom: the adapter forwards it from `device.ip`, since on a server-to-server call the connection itself comes from the Prebid Server host rather than from the reader.
 
 ## Example Ad Unit Configuration
 
@@ -79,6 +81,59 @@ var adUnits = [{
   }]
 }];
 ```
+
+### Prebid Server
+
+Through a Prebid Server the same two parameters travel in the impression, under `ext.prebid.bidder`:
+
+```json
+{
+  "id": "some-request-id",
+  "imp": [{
+    "id": "leaderboard",
+    "banner": { "format": [{ "w": 728, "h": 90 }] },
+    "ext": {
+      "prebid": {
+        "bidder": {
+          "epom_as": {
+            "host": "ads.example.com",
+            "placementKey": "a4f21c9e7b"
+          }
+        }
+      }
+    }
+  }]
+}
+```
+
+`host` and `placementKey` are both required and there is no server-side default for either: the endpoint is resolved per impression from `host`, so an entry without one is not bid.
+
+A page already running Prebid.js can route the bidder server-side instead, leaving its ad units and the `bids` entry above unchanged:
+
+```javascript
+pbjs.setConfig({
+  s2sConfig: [{
+    accountId: 'the-id-the-server-issued',
+    bidders: ['epom_as'],
+    enabled: true,
+    endpoint: 'https://prebid-server.example.com/openrtb2/auction'
+  }]
+});
+```
+
+The `accountId` is issued by the Prebid Server host, not by Epom.
+
+## Registration
+
+A publisher needs two values from Epom, and the inventory has to be sold by a header-bidding tag before either is worth anything:
+
+1. Epom creates or confirms the placements and their placement keys.
+2. Epom creates an **active header-bidding tag listing those placements**. This is the step that is easy to skip and impossible to diagnose from outside: Epom Ad Server answers a bid only for a placement an active tag sells, and the placement key alone does not authorise anything — it is public by design, since it travels in every invocation code on the page.
+3. Epom hands over the serving `host` and one `placementKey` per ad unit.
+4. For a server-side integration, the publisher gets the `accountId` from their own Prebid Server host — Epom does not issue it.
+5. For a server-side integration, the host must run a Prebid Server Go build carrying `epom_as` (see above).
+
+📩 [support@epom.com](mailto:support@epom.com)
 
 ## Test Parameters
 
@@ -191,7 +246,7 @@ It forwards the standard OpenRTB privacy signals to Epom Ad Server unchanged, an
 
 The adapter sets `withCredentials: true`, so an existing Epom identity cookie — set by the ad server on its own domain, never by the adapter — reaches the auction; the ad server answers with the request origin rather than a wildcard. The adapter itself uses no storage manager and writes nothing to cookies or local storage.
 
-The Prebid.js adapter performs no user syncs. Server-side, the sync endpoint lives on each publisher's own Epom deployment, so a Prebid Server host must configure it; contact Epom to have it enabled.
+The Prebid.js adapter performs no user syncs. Server-side there is none either, and the reason is structural rather than pending: a Prebid Server syncer is one URL per bidder per host, and the only macros it can carry are the privacy signals and the redirect — `{% raw %}{{.GDPR}}{% endraw %}`, `{% raw %}{{.GDPRConsent}}{% endraw %}`, `{% raw %}{{.USPrivacy}}{% endraw %}`, `{% raw %}{{.GPP}}{% endraw %}`, `{% raw %}{{.GPPSID}}{% endraw %}`, `{% raw %}{{.RedirectURL}}{% endraw %}` and the syncer key. Nothing in it varies per impression, and Epom Ad Server is white-label: the sync endpoint lives on each publisher's own deployment, so one URL cannot serve two publishers. A host serving a single Epom deployment can configure a syncer for it; contact Epom for the URL.
 
 ## Support
 


### PR DESCRIPTION
## 🏷 Type of documentation
- [x] new bid adapter

## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked
- [x] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)

## Description

Documentation for **Epom Ad Server** (`epom_as`), a new sell-side bid adapter submitted for both
Prebid.js and Prebid Server.

Epom Ad Server is white-label: each network runs its own deployment on its own domain, so the
serving host is supplied per ad unit via `params.host` and the adapter posts to `https://{host}/hb/bid`.
Only the host is configurable — the request path is fixed by the adapter, so a page configuration
cannot redirect the auction payload. A page may mix several deployments; impressions are grouped by
host and one request goes to each.

Banner only, GVL vendor 849, TCF EU and USP signals forwarded via `ortbConverter`. Maintainer:
support@epom.com.

Related pull requests:

- Prebid.js adapter: https://github.com/prebid/Prebid.js/pull/15505
- Prebid Server adapter: https://github.com/prebid/prebid-server/pull/4916