### PR TITLE
New bidder: Adferry

### DIFF
--- a/dev-docs/bidders/adferry.md
+++ b/dev-docs/bidders/adferry.md
@@ -1,0 +1,50 @@
+---
+layout: bidder
+title: Adferry
+description: Adferry Bidder Adapter
+biddercode: adferry
+# US-only bidder: no IAB Europe (TCF) registration, so no gvl_id and no
+# tcfeu_supported. Revisit both only if Adferry starts serving EU traffic.
+gvl_id: none
+usp_supported: true
+coppa_supported: true
+# GPP passthrough is verbatim (full string + every applicable section id),
+# so whatever section the CMP sends reaches the endpoint untouched. The
+# documented claim is scoped to the national section we test against.
+gpp_sids: usnat
+schain_supported: true
+fpd_supported: true
+media_types: banner, video, audio
+floors_supported: true
+deals_supported: true
+multiformat_supported: will-bid-on-any
+safeframes_ok: true
+pbjs: true
+pbs: false
+sidebarType: 1
+---
+
+### Registration
+
+The Adferry bid adapter requires setup and approval. The `placementId` is the
+tag id issued in the Adferry portal under Integrations &rarr; Prebid. Please
+reach out to <admin@adferry.co> for an account.
+
+### Bid Params
+
+{: .table .table-bordered .table-striped }
+| Name          | Scope    | Description                                          | Example      | Type     |
+|---------------|----------|------------------------------------------------------|--------------|----------|
+| `placementId` | required | Tag ID from the Adferry portal                       | `'adferryprebidtest1'` | `string` |
+| `bidFloor`    | optional | Floor CPM; ignored when the Floors Module is in use  | `2.50`       | `number` |
+| `currency`    | optional | Floor currency, defaults to `USD`                    | `'USD'`      | `string` |
+
+### First Party Data
+
+The adapter forwards the full `ortb2` object (site, user, regs) to the
+Adferry exchange as-is, and `ortb2Imp` is merged into each impression.
+
+### Notes
+
+Video parameters are read from `AdUnit.mediaTypes.video`. The adapter sends
+one request per placement. User syncs are not used.

--- a/dev-docs/bidders/adferry.md
+++ b/dev-docs/bidders/adferry.md
@@ -9,6 +9,7 @@ coppa_supported: true
 gpp_sids: usnat
 schain_supported: true
 fpd_supported: true
+userIds: all
 media_types: banner, video, audio
 floors_supported: true
 deals_supported: true

--- a/dev-docs/bidders/adferry.md
+++ b/dev-docs/bidders/adferry.md
@@ -3,14 +3,9 @@ layout: bidder
 title: Adferry
 description: Adferry Bidder Adapter
 biddercode: adferry
-# US-only bidder: no IAB Europe (TCF) registration, so no gvl_id and no
-# tcfeu_supported. Revisit both only if Adferry starts serving EU traffic.
 gvl_id: none
 usp_supported: true
 coppa_supported: true
-# GPP passthrough is verbatim (full string + every applicable section id),
-# so whatever section the CMP sends reaches the endpoint untouched. The
-# documented claim is scoped to the national section we test against.
 gpp_sids: usnat
 schain_supported: true
 fpd_supported: true
@@ -24,27 +19,27 @@ pbs: false
 sidebarType: 1
 ---
 
-### Registration
+## Registration
 
 The Adferry bid adapter requires setup and approval. The `placementId` is the
 tag id issued in the Adferry portal under Integrations &rarr; Prebid. Please
 reach out to <admin@adferry.co> for an account.
 
-### Bid Params
+## Bid Params
 
 {: .table .table-bordered .table-striped }
-| Name          | Scope    | Description                                          | Example      | Type     |
-|---------------|----------|------------------------------------------------------|--------------|----------|
-| `placementId` | required | Tag ID from the Adferry portal                       | `'adferryprebidtest1'` | `string` |
-| `bidFloor`    | optional | Floor CPM; ignored when the Floors Module is in use  | `2.50`       | `number` |
-| `currency`    | optional | Floor currency, defaults to `USD`                    | `'USD'`      | `string` |
+| Name          | Scope    | Description                                         | Example                | Type     |
+|---------------|----------|-----------------------------------------------------|------------------------|----------|
+| `placementId` | required | Tag ID from the Adferry portal                      | `'adferryprebidtest1'` | `string` |
+| `bidFloor`    | optional | Floor CPM; ignored when the Floors Module is in use | `2.50`                 | `number` |
+| `currency`    | optional | Floor currency, defaults to `USD`                   | `'USD'`                | `string` |
 
-### First Party Data
+## First Party Data
 
 The adapter forwards the full `ortb2` object (site, user, regs) to the
 Adferry exchange as-is, and `ortb2Imp` is merged into each impression.
 
-### Notes
+## Notes
 
 Video parameters are read from `AdUnit.mediaTypes.video`. The adapter sends
 one request per placement. User syncs are not used.


### PR DESCRIPTION
Bidder docs for the Adferry adapter.

Companion to the code PR: prebid/Prebid.js#15476

- biddercode: `adferry`
- Media types: banner, video, audio
- US-only: `gvl_id: none`; `usp_supported`, `coppa_supported`, `gpp_sids: usnat`
- `schain_supported`, `fpd_supported`
- Maintainer: admin@adferry.co