### PR TITLE
Docs(prebid-mobile-ios): document Video Progress Indicator control

### DIFF
--- a/prebid-mobile/modules/rendering/combined-ad-experience-controls.md
+++ b/prebid-mobile/modules/rendering/combined-ad-experience-controls.md
@@ -274,6 +274,34 @@ This option switches on or off the visibility of the sound/mute button for users
 
 {% include code/mobile-sdk.html id="sound-button" kotlin=android swift=ios %}
 
+### Video Progress Indicator
+
+This option switches the remaining-time countdown indicator on or off during full-screen video playback. Setting this property explicitly overrides the platform's default for that ad type; leaving it untouched preserves existing behavior.
+
+{% capture android %}
+  {: .table .table-bordered .table-striped }
+
+  |**API Object**         | *not yet available* |
+  |**Ad Unit Property**   | *not yet available* |
+  |**Server Property**    | `isvideoprogressindicatorvisible` |
+  |**Default Value**      | *not yet available* |
+
+  Not yet available on Android. Tracked in [prebid/prebid-mobile-ios#1298](https://github.com/prebid/prebid-mobile-ios/issues/1298){:target="_blank"}.
+{% endcapture %}
+
+{% capture ios %}
+  {: .table .table-bordered .table-striped }
+
+  |**API Object**         |`InterstitialRenderingAdUnit`, `RewardedAdUnit`, <br />`MediationInterstitialAdUnit`, `MediationRewardedAdUnit` |
+  |**Ad Unit Property**   | `adUnit.isVideoProgressIndicatorVisible`|
+  |**Server Property**    | `isvideoprogressindicatorvisible` |
+  |**Default Value**      | `true` for rewarded ads, `false` for interstitials|
+
+  Implemented in [prebid/prebid-mobile-ios#1307](https://github.com/prebid/prebid-mobile-ios/pull/1307){:target="_blank"}, resolving [prebid/prebid-mobile-ios#1298](https://github.com/prebid/prebid-mobile-ios/issues/1298){:target="_blank"}.
+{% endcapture %}
+
+{% include code/mobile-sdk.html id="video-progress-indicator" kotlin=android swift=ios %}
+
 ### Code Example
 
 Here is how you can implement all the API's to customize your ad.


### PR DESCRIPTION
## Summary
Adds the **Video Progress Indicator** property to the [Ad Experience Controls](https://docs.prebid.org/prebid-mobile/modules/rendering/combined-ad-experience-controls.html) page, documenting iOS's new `isVideoProgressIndicatorVisible` toggle (shows/hides the remaining-time countdown during full-screen video playback).

- Default: `true` for rewarded ads, `false` for interstitials (preserves existing behavior unless explicitly overridden)
- Server property: `isvideoprogressindicatorvisible`
- Not yet available on Android

## Context
Requested by [@YuriyVelichkoPI](https://github.com/YuriyVelichkoPI) in review on [prebid/prebid-mobile-ios#1307](https://github.com/prebid/prebid-mobile-ios/pull/1307), which implements [prebid/prebid-mobile-ios#1298](https://github.com/prebid/prebid-mobile-ios/issues/1298).

🤖 Generated with [Claude Code](https://claude.com/claude-code)