### PR TITLE
Nexx360 aliases: fix scoremedia GVL ID, mark two pages pbs, drop duplicate key

### DIFF
--- a/dev-docs/bidders/bidstailamedia.md
+++ b/dev-docs/bidders/bidstailamedia.md
@@ -23,13 +23,13 @@ multiformat_supported: will-bid-on-any
 
 ---
 
-### Bid Params
+## Bid Params
 
 | Name          | Scope    | Description                | Example                                   | Type      |
 |---------------|----------|----------------------------|--------------------------------------     |-----------|
-| `tagId`       | required | tag ID                     | `"hk15z9sy"`                             | `string`  |
+| `tagId`       | required | tag ID                     | `"hk15z9sy"`                              | `string`  |
 
-### First Party Data
+## First Party Data
 
 Publishers should use the `ortb2` method of setting [First Party Data](/features/firstPartyData.html).
 The following fields are supported:
@@ -39,7 +39,7 @@ The following fields are supported:
 * ortb2.user.ext.data.*
 * ortb2.user.data[]
 
-### Test Parameters
+## Test Parameters
 
 ```javascript
 var adUnits = [

--- a/dev-docs/bidders/bidstailamedia.md
+++ b/dev-docs/bidders/bidstailamedia.md
@@ -3,6 +3,7 @@ layout: bidder
 title: stailamedia Bidder
 description: Prebid bidstailamedia Bidder Adapter
 pbjs: true
+pbs: true
 biddercode: bidstailamedia
 aliasCode: nexx360
 gvl_id: 965 (nexx360)
@@ -13,7 +14,6 @@ schain_supported: true
 dchain_supported: false
 floors_supported: true
 userIds: all
-tcfeu_supported: true
 media_types: banner, video, native
 safeframes_ok: true
 deals_supported: true

--- a/dev-docs/bidders/glomexbidder.md
+++ b/dev-docs/bidders/glomexbidder.md
@@ -23,7 +23,7 @@ multiformat_supported: will-bid-on-any
 
 ---
 
-### Bid Params
+## Bid Params
 
 {: .table .table-bordered .table-striped }
 | Name          | Scope    | Description                | Example                                   | Type      |
@@ -33,7 +33,7 @@ multiformat_supported: will-bid-on-any
 
 For the prebid.js you only need to use one parameter: either tagId or placement
 
-### First Party Data
+## First Party Data
 
 Publishers should use the `ortb2` method of setting [First Party Data](/features/firstPartyData.html).
 The following fields are supported:
@@ -43,7 +43,7 @@ The following fields are supported:
 * ortb2.user.ext.data.*
 * ortb2.user.data[]
 
-### Test Parameters
+## Test Parameters
 
 ```javascript
 var adUnits = [

--- a/dev-docs/bidders/glomexbidder.md
+++ b/dev-docs/bidders/glomexbidder.md
@@ -14,7 +14,6 @@ schain_supported: true
 dchain_supported: true
 floors_supported: true
 userIds: all
-tcfeu_supported: true
 media_types: banner, video, native
 safeframes_ok: true
 deals_supported: true

--- a/dev-docs/bidders/revnew.md
+++ b/dev-docs/bidders/revnew.md
@@ -22,7 +22,7 @@ multiformat_supported: will-bid-on-any
 
 ---
 
-### Bid Params
+## Bid Params
 
 {: .table .table-bordered .table-striped }
 | Name          | Scope    | Description                | Example                                   | Type      |
@@ -33,7 +33,7 @@ multiformat_supported: will-bid-on-any
 *You*must* only include one ID field - either `tagId` or `placement`, not both. If you have questions on which parameter to use, please reach out to your Account Manager.
 The `tagId` and `placement` are **mutually exclusive** but at least one is required. If you pass both, `tagId` takes precedence.
 
-### Bidder Config
+## Bidder Config
 
 You can allow writing in localStorage `pbjs.bidderSettings` for the bidder `revnew`
 
@@ -47,11 +47,11 @@ pbjs.bidderSettings = {
 }
 ```
 
-### First Party Data
+## First Party Data
 
 Publishers should use the `ortb2` method of setting [First Party Data](https://docs.prebid.org/features/firstPartyData.html).
 
-### Test Parameters
+## Test Parameters
 
 ```javascript
 var adUnits = [

--- a/dev-docs/bidders/revnew.md
+++ b/dev-docs/bidders/revnew.md
@@ -13,7 +13,6 @@ schain_supported: true
 dchain_supported: false
 floors_supported: true
 userIds: all
-tcfeu_supported: true
 media_types: banner, video, native
 safeframes_ok: true
 deals_supported: true

--- a/dev-docs/bidders/scoremedia.md
+++ b/dev-docs/bidders/scoremedia.md
@@ -3,9 +3,10 @@ layout: bidder
 title: scoremedia
 description: Prebid scoremedia Bidder Adapter
 pbjs: true
+pbs: true
 biddercode: scoremedia
 aliasCode: nexx360
-gvl_id: 965
+gvl_id: 1090
 tcfeu_supported: true
 usp_supported: true
 gpp_supported: true
@@ -13,7 +14,6 @@ schain_supported: true
 dchain_supported: false
 floors_supported: true
 userIds: all
-tcfeu_supported: true
 media_types: banner, video, native
 safeframes_ok: true
 deals_supported: true

--- a/dev-docs/bidders/scoremedia.md
+++ b/dev-docs/bidders/scoremedia.md
@@ -23,14 +23,14 @@ multiformat_supported: will-bid-on-any
 
 ---
 
-### Bid Params
+## Bid Params
 
 {: .table .table-bordered .table-striped }
 | Name          | Scope    | Description                | Example                                   | Type      |
 |---------------|----------|----------------------------|--------------------------------------     |-----------|
-| `tagId`       | required | tag ID                     | `"795dtj21"`                             | `string`  |
+| `tagId`       | required | tag ID                     | `"795dtj21"`                              | `string`  |
 
-### First Party Data
+## First Party Data
 
 Publishers should use the `ortb2` method of setting [First Party Data](/features/firstPartyData.html).
 The following fields are supported:
@@ -40,7 +40,7 @@ The following fields are supported:
 * ortb2.user.ext.data.*
 * ortb2.user.data[]
 
-### Test Parameters
+## Test Parameters
 
 ```javascript
 var adUnits = [


### PR DESCRIPTION
Docs follow-up to prebid/prebid-server#4738, where @postindustria-code flagged that these pages were out of step with the yaml.

**`scoremedia`: `gvl_id` 965 → 1090.** 965 is Nexx360's own registration. Score Media Group GmbH & Co. KG holds its own GVL entry, **1090**, which is what Prebid.js declares (`modules/nexx360BidAdapter.ts`: `{ code: 'scoremedia', gvlid: 1090 }`). The 965 here was simply wrong, and prebid-server#4738 now sets `gvlVendorID: 1090` for the alias to match.

**`scoremedia`, `bidstailamedia`: add `pbs: true`.** Both become server-side bidders in prebid-server#4738, so the pages should list them as available in Prebid Server. (`bidstailamedia`'s `gvl_id: 965 (nexx360)` is deliberately left as-is — it is a Nexx360-operated white label with no separate registration, which is the form [add-new-bidder-go](https://docs.prebid.org/prebid-server/developers/add-new-bidder-go.html) prescribes.)

**`scoremedia`, `bidstailamedia`, `glomexbidder`, `revnew`: drop the duplicate `tcfeu_supported: true`.** Each declared the key twice in its front matter. Kept the occurrence grouped with the other TCF fields after `gvl_id` and removed the later one after `userIds`; no behaviour change, the values were identical.

+3 / −5 across four files, front matter only.