### PR TITLE
OCM: Document Prebid Server support

### DIFF
--- a/dev-docs/bidders/ocm.md
+++ b/dev-docs/bidders/ocm.md
@@ -16,7 +16,8 @@ prebid_member: true
 multiformat_supported: will-bid-on-any
 ortb_blocking_supported: partial
 pbjs: true
-pbs: false
+pbs: true
+pbs_app_supported: true
 deals_supported: true
 floors_supported: true
 gvl_id: 1148
@@ -30,6 +31,12 @@ sidebarType: 1
 |---------------|----------|----------------------------------------|---------------|----------|
 | `publisherId` | required | The publisher id (e.g. "domain.tld")   | `example.com` | `string` |
 | `placementId` | required | Domain-wide placement id               | `1234567890`  | `string` |
+
+### Prebid Server
+
+The Prebid Server adapter takes the same two parameters. `placementId` is sent as the
+impression's stored request id, and `publisherId` is sent as the request-level publisher
+id, so every impression in a single request must use the same `publisherId`.
 
 ### Description
 


### PR DESCRIPTION
Documents Prebid Server support for the existing `ocm` bidder.

The Prebid Server bid adapter is submitted in prebid/prebid-server#4982. It reuses this bidder's existing parameters — `publisherId` and `placementId` — with
the same meaning they already have in the Prebid.js adapter, so the bid params table is
unchanged.

Changes:

- `pbs: false` → `pbs: true`
- `pbs_app_supported: true` — the server adapter declares both `site` and `app` in its
  bidder-info yaml
- A short Prebid Server note recording that `placementId` is sent as the impression's
  stored request id and `publisherId` as the request-level publisher id, which is why all
  impressions in one request must share a `publisherId`

No other front-matter flags change: both platforms talk to the same endpoint through the
same mechanism, so the existing privacy, schain and media-type declarations carry over.
